### PR TITLE
v1.2.1: Add personal platform config and fix shared repo UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,31 @@ All notable changes to skillfile are documented here.
 
 ---
 
-## v1.2.0
+## v1.2.1 - 14-03-2026
+
+### Added
+
+- **Personal platform config** - platform preferences can now be stored in a user-global TOML config file (`~/.config/skillfile/config.toml`) instead of the committed Skillfile. Useful in shared repos where each developer uses different AI tools.
+  - `skillfile init` now asks where to store platform config: personal (recommended for shared repos) or Skillfile (shared with team)
+  - Existing config from both sources shown during `init` with labels ("Skillfile" / "personal config")
+  - Precedence rule: Skillfile install targets always override personal config
+  - All commands (`status`, `diff`, `pin`, `unpin`, `resolve`) fall back to personal config when Skillfile has no install lines
+  - `install` prints "Using platform targets from personal config" when falling back
+- **Smarter init outro** - when the Skillfile already has entries (e.g. after cloning), the wizard now tells you how many and suggests `skillfile install` as the next step.
+
+### Changed
+
+- **Binary size reduced** - release profile now uses `opt-level = "s"` (optimize for size), bringing the binary from ~4.2 MB to ~3.4 MB.
+- **Personal config is the default init choice** - the destination picker now lists personal config first with a tip about avoiding merge conflicts in shared repos.
+- **Status formatting extracted** - `format_entry_status` is now a standalone function, no behavior change.
+
+### Fixed
+
+- **"No install targets" in shared repos** - if a Skillfile had entries but no `install` lines (common when teams don't want to commit platform preferences), every command failed. Now falls back to personal config so each developer can set their own platforms without touching the shared Skillfile.
+
+---
+
+## v1.2.0 - 13-03-2026
 
 ### Added
 
@@ -28,7 +52,7 @@ All notable changes to skillfile are documented here.
 
 ---
 
-## v1.1.0
+## v1.1.0 - 12-03-2026
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,7 +1415,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skillfile"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1424,12 +1433,13 @@ dependencies = [
  "skillfile-deploy",
  "skillfile-sources",
  "tempfile",
+ "toml",
  "ureq",
 ]
 
 [[package]]
 name = "skillfile-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1440,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-deploy"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "dirs",
  "skillfile-core",
@@ -1462,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-sources"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1650,6 +1660,47 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -2018,6 +2069,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "tests"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
@@ -27,6 +27,7 @@ ureq = { version = "3", features = ["json"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 # Error handling
 thiserror = "2"
@@ -66,6 +67,7 @@ many_single_char_names = "warn"
 fn_params_excessive_bools = "warn"
 
 [profile.release]
+opt-level = "s"
 lto = true
 strip = true
 codegen-units = 1

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 semver = { workspace = true }
 ureq = { workspace = true }
 dirs = { workspace = true }

--- a/crates/cli/src/commands/diff.rs
+++ b/crates/cli/src/commands/diff.rs
@@ -14,7 +14,7 @@ use skillfile_sources::sync::vendor_dir_for;
 use crate::patch::walkdir;
 
 fn diff_local_single(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), SkillfileError> {
-    let result = parse_manifest(&repo_root.join(MANIFEST_NAME))?;
+    let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
     let vdir = vendor_dir_for(entry, repo_root);
     let cf = content_file(entry);
     if cf.is_empty() {
@@ -31,7 +31,7 @@ fn diff_local_single(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), S
         )));
     }
 
-    let dest = installed_path(entry, &result.manifest, repo_root)?;
+    let dest = installed_path(entry, &manifest, repo_root)?;
     if !dest.exists() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed — run `skillfile install` first",
@@ -63,7 +63,7 @@ fn diff_local_single(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), S
 }
 
 fn diff_local_dir(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), SkillfileError> {
-    let result = parse_manifest(&repo_root.join(MANIFEST_NAME))?;
+    let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
     let vdir = vendor_dir_for(entry, repo_root);
     if !vdir.is_dir() {
         return Err(SkillfileError::Manifest(format!(
@@ -72,7 +72,7 @@ fn diff_local_dir(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), Skil
         )));
     }
 
-    let installed = installed_dir_files(entry, &result.manifest, repo_root)?;
+    let installed = installed_dir_files(entry, &manifest, repo_root)?;
     if installed.is_empty() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed — run `skillfile install` first",

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -114,6 +114,97 @@ fn supported_types_hint(adapter_name: &str) -> &'static str {
     }
 }
 
+/// Write targets to the user-global personal config file.
+fn write_personal_config(new_targets: &[(String, String)]) -> Result<(), SkillfileError> {
+    use skillfile_core::models::{InstallTarget, Scope};
+    let targets: Vec<InstallTarget> = new_targets
+        .iter()
+        .map(|(a, s)| InstallTarget {
+            adapter: a.clone(),
+            scope: Scope::parse(s).unwrap_or(Scope::Local),
+        })
+        .collect();
+    crate::config::write_user_targets(&targets)?;
+    Ok(())
+}
+
+/// Interactive platform + scope selection. Returns (adapter, scope) pairs.
+fn select_platforms_and_scope(
+    existing_set: &std::collections::HashSet<&str>,
+) -> Result<Option<Vec<(String, String)>>, SkillfileError> {
+    let adapter_names = known_adapters();
+    let mut multi =
+        cliclack::multiselect("Select platforms to install to (space to toggle, enter to confirm)");
+    for name in &adapter_names {
+        multi = multi.item(*name, *name, supported_types_hint(name));
+    }
+
+    let initial: Vec<&str> = adapter_names
+        .iter()
+        .copied()
+        .filter(|n| existing_set.contains(n))
+        .collect();
+    if !initial.is_empty() {
+        multi = multi.initial_values(initial);
+    }
+
+    let selected: Vec<&str> = multi.interact()?;
+
+    if selected.is_empty() {
+        return Ok(None);
+    }
+
+    let scope: &str = cliclack::select("Default scope for selected platforms?")
+        .item("local", "local", "project-specific")
+        .item("global", "global", "user-wide (~/.tool/)")
+        .item("both", "both", "add global and local for each platform")
+        .interact()?;
+
+    let targets = if scope == "both" {
+        selected
+            .iter()
+            .flat_map(|p| {
+                [
+                    (p.to_string(), "global".to_string()),
+                    (p.to_string(), "local".to_string()),
+                ]
+            })
+            .collect()
+    } else {
+        selected
+            .iter()
+            .map(|p| (p.to_string(), scope.to_string()))
+            .collect()
+    };
+
+    Ok(Some(targets))
+}
+
+/// Interactive destination choice: Skillfile or personal config.
+fn select_destination() -> Result<&'static str, SkillfileError> {
+    let config_location = crate::config::config_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "~/.config/skillfile/config.toml".into());
+    let destination: &str = cliclack::select(
+        "Where should platform config be stored?\n\
+         Tip: In shared repos, personal config avoids merge conflicts when\n\
+         teammates use different AI tools.\n\
+         Precedence: Skillfile targets always override personal config.",
+    )
+    .item(
+        "personal",
+        "Personal config (recommended for shared repos)",
+        format!("saved to {config_location} — each developer picks their own platforms"),
+    )
+    .item(
+        "skillfile",
+        "Skillfile (shared with team)",
+        "committed to git, visible to all collaborators",
+    )
+    .interact()?;
+    Ok(destination)
+}
+
 // ---------------------------------------------------------------------------
 // Public entry point — interactive cliclack flow
 // ---------------------------------------------------------------------------
@@ -143,81 +234,74 @@ pub fn cmd_init(repo_root: &Path) -> Result<(), SkillfileError> {
     // Parse existing manifest
     let result = parse_manifest(&manifest_path)?;
     let existing = &result.manifest.install_targets;
+    let user_targets = crate::config::read_user_targets();
 
     // Show existing config
-    let existing_set: std::collections::HashSet<&str> =
-        existing.iter().map(|t| t.adapter.as_str()).collect();
+    let existing_set: std::collections::HashSet<&str> = existing
+        .iter()
+        .chain(user_targets.iter())
+        .map(|t| t.adapter.as_str())
+        .collect();
 
-    if !existing.is_empty() {
-        let lines: Vec<String> = existing
+    if !existing.is_empty() || !user_targets.is_empty() {
+        let mut lines: Vec<String> = existing
             .iter()
-            .map(|t| format!("install  {}  {}", t.adapter, t.scope))
+            .map(|t| format!("install  {}  {}  (Skillfile)", t.adapter, t.scope))
             .collect();
+        for t in &user_targets {
+            lines.push(format!(
+                "install  {}  {}  (personal config)",
+                t.adapter, t.scope
+            ));
+        }
         cliclack::note("Existing config", lines.join("\n"))?;
     }
 
-    // Platform multi-select
-    let adapter_names = known_adapters();
-    let mut multi =
-        cliclack::multiselect("Select platforms to install to (space to toggle, enter to confirm)");
-    for name in &adapter_names {
-        multi = multi.item(*name, *name, supported_types_hint(name));
-    }
-
-    // Pre-select platforms that already have install lines
-    let initial: Vec<&str> = adapter_names
-        .iter()
-        .copied()
-        .filter(|n| existing_set.contains(n))
-        .collect();
-    if !initial.is_empty() {
-        multi = multi.initial_values(initial);
-    }
-
-    let selected: Vec<&str> = multi.interact()?;
-
-    if selected.is_empty() {
-        cliclack::outro_cancel("No platforms selected.")?;
-        return Ok(());
-    }
-
-    // Scope selection
-    let scope: &str = cliclack::select("Default scope for selected platforms?")
-        .item("local", "local", "project-specific")
-        .item("global", "global", "user-wide (~/.tool/)")
-        .item("both", "both", "add global and local for each platform")
-        .interact()?;
-
-    // Build install targets
-    let new_targets: Vec<(String, String)> = if scope == "both" {
-        selected
-            .iter()
-            .flat_map(|p| {
-                [
-                    (p.to_string(), "global".to_string()),
-                    (p.to_string(), "local".to_string()),
-                ]
-            })
-            .collect()
-    } else {
-        selected
-            .iter()
-            .map(|p| (p.to_string(), scope.to_string()))
-            .collect()
+    // Platform + scope selection
+    let new_targets = match select_platforms_and_scope(&existing_set)? {
+        Some(t) => t,
+        None => {
+            cliclack::outro_cancel("No platforms selected.")?;
+            return Ok(());
+        }
     };
 
-    rewrite_install_lines(&manifest_path, &new_targets)?;
-    update_gitignore(repo_root)?;
+    // Destination choice
+    let destination = select_destination()?;
 
     let summary: Vec<String> = new_targets
         .iter()
         .map(|(a, s)| format!("install  {a}  {s}"))
         .collect();
-    cliclack::note("Install config written to Skillfile", summary.join("\n"))?;
 
-    cliclack::outro(
-        "You're all set! Next up:\n  \u{2795} `skillfile add` to add a skill or agent\n  \u{1f50d} `skillfile search` to discover community skills"
-    )?;
+    if destination == "personal" {
+        write_personal_config(&new_targets)?;
+        cliclack::note(
+            "Install config written to personal config",
+            summary.join("\n"),
+        )?;
+    } else {
+        rewrite_install_lines(&manifest_path, &new_targets)?;
+        cliclack::note("Install config written to Skillfile", summary.join("\n"))?;
+    }
+
+    update_gitignore(repo_root)?;
+
+    let outro = if result.manifest.entries.is_empty() {
+        "You're all set! Next up:".to_string()
+    } else {
+        let n = result.manifest.entries.len();
+        let word = if n == 1 { "entry" } else { "entries" };
+        format!(
+            "Platforms configured! This Skillfile already has {n} {word}.\n  \
+                 \u{1f680} Run `skillfile install` to fetch and deploy them."
+        )
+    };
+    cliclack::outro(format!(
+        "{outro}\n  \
+         \u{2795} `skillfile add` to add a skill or agent\n  \
+         \u{1f50d} `skillfile search` to discover community skills"
+    ))?;
 
     Ok(())
 }

--- a/crates/cli/src/commands/pin.rs
+++ b/crates/cli/src/commands/pin.rs
@@ -23,8 +23,8 @@ fn pin_dir_entry(entry: &Entry, repo_root: &Path, dry_run: bool) -> Result<Strin
         )));
     }
 
-    let result = parse_manifest(&repo_root.join(MANIFEST_NAME))?;
-    let installed = installed_dir_files(entry, &result.manifest, repo_root)?;
+    let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
+    let installed = installed_dir_files(entry, &manifest, repo_root)?;
     if installed.is_empty() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed — run `skillfile install` first",
@@ -116,8 +116,8 @@ fn pin_entry(entry: &Entry, repo_root: &Path, dry_run: bool) -> Result<String, S
         )));
     }
 
-    let result = parse_manifest(&repo_root.join(MANIFEST_NAME))?;
-    let dest = installed_path(entry, &result.manifest, repo_root)?;
+    let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
+    let dest = installed_path(entry, &manifest, repo_root)?;
     if !dest.exists() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed — run `skillfile install` first",
@@ -163,9 +163,8 @@ pub fn cmd_pin(name: &str, repo_root: &Path, dry_run: bool) -> Result<(), Skillf
 }
 
 pub fn cmd_unpin(name: &str, repo_root: &Path) -> Result<(), SkillfileError> {
-    let manifest_path = repo_root.join(MANIFEST_NAME);
-    let result = parse_manifest(&manifest_path)?;
-    let entry = find_entry_in(name, &result.manifest)?;
+    let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
+    let entry = find_entry_in(name, &manifest)?;
 
     let single = has_patch(entry, repo_root);
     let directory = has_dir_patch(entry, repo_root);
@@ -183,7 +182,7 @@ pub fn cmd_unpin(name: &str, repo_root: &Path) -> Result<(), SkillfileError> {
     }
 
     // Restore pristine upstream from vendor cache immediately.
-    for target in &result.manifest.install_targets {
+    for target in &manifest.install_targets {
         install_entry(entry, target, repo_root, None)?;
     }
 

--- a/crates/cli/src/commands/resolve.rs
+++ b/crates/cli/src/commands/resolve.rs
@@ -119,8 +119,8 @@ fn resolve_single_file(
     let theirs = fetch_file_at_sha(&client, entry, &conflict.new_sha)?;
     progress!("done");
 
-    let result = parse_manifest(&repo_root.join(MANIFEST_NAME))?;
-    let installed = installed_path(entry, &result.manifest, repo_root)?;
+    let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
+    let installed = installed_path(entry, &manifest, repo_root)?;
 
     // Reconstruct "yours" from stored patch applied to base upstream
     let yours = if has_patch(entry, repo_root) {
@@ -290,8 +290,8 @@ fn resolve_dir_entry(
     let theirs_files = fetch_dir_at_sha(&client, entry, &conflict.new_sha)?;
     progress!("done");
 
-    let result = parse_manifest(&repo_root.join(MANIFEST_NAME))?;
-    let installed = installed_dir_files(entry, &result.manifest, repo_root)?;
+    let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
+    let installed = installed_dir_files(entry, &manifest, repo_root)?;
     if installed.is_empty() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed",

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 
 use skillfile_core::error::SkillfileError;
 use skillfile_core::lock::{lock_key, read_lock};
-use skillfile_core::models::{short_sha, Entry, Manifest, SourceFields};
-use skillfile_core::parser::{parse_manifest, MANIFEST_NAME};
+use skillfile_core::models::{short_sha, Entry, LockEntry, Manifest, SourceFields};
+use skillfile_core::parser::MANIFEST_NAME;
 use skillfile_core::patch::{has_dir_patch, has_patch, walkdir};
 use skillfile_deploy::paths::{installed_dir_files, installed_path};
 use skillfile_sources::strategy::{content_file, is_dir_entry, meta_sha};
@@ -93,6 +93,85 @@ fn is_dir_modified_local(entry: &Entry, manifest: &Manifest, repo_root: &Path) -
     result.unwrap_or(false)
 }
 
+/// Per-run context shared across all entry status computations.
+struct StatusContext<'a> {
+    manifest: &'a Manifest,
+    repo_root: &'a Path,
+    locked: &'a std::collections::BTreeMap<String, LockEntry>,
+    check_upstream: bool,
+    sha_cache: &'a mut HashMap<(String, String), String>,
+    col_w: usize,
+}
+
+fn format_entry_status(
+    entry: &Entry,
+    ctx: &mut StatusContext<'_>,
+) -> Result<String, SkillfileError> {
+    let key = lock_key(entry);
+    let name = &entry.name;
+    let col_w = ctx.col_w;
+
+    if matches!(entry.source, SourceFields::Local { .. }) {
+        return Ok(format!("{name:<col_w$} local"));
+    }
+
+    let locked_info = match ctx.locked.get(&key) {
+        Some(li) => li,
+        None => return Ok(format!("{name:<col_w$} unlocked")),
+    };
+
+    let sha = &locked_info.sha;
+    let vdir = vendor_dir_for(entry, ctx.repo_root);
+    let meta = meta_sha(&vdir);
+
+    let mut annotations = Vec::new();
+    if has_patch(entry, ctx.repo_root) || has_dir_patch(entry, ctx.repo_root) {
+        annotations.push("[pinned]");
+    }
+    if is_modified_local(entry, ctx.manifest, ctx.repo_root) {
+        annotations.push("[modified]");
+    }
+    let annotation = if annotations.is_empty() {
+        String::new()
+    } else {
+        format!("  {}", annotations.join("  "))
+    };
+
+    let sha_short = short_sha(sha);
+
+    let status = if meta.as_deref() != Some(sha.as_str()) {
+        format!("locked    sha={sha_short}  (missing or stale){annotation}")
+    } else if ctx.check_upstream {
+        if let SourceFields::Github {
+            owner_repo, ref_, ..
+        } = &entry.source
+        {
+            let cache_key = (owner_repo.clone(), ref_.clone());
+            let upstream_sha = if let Some(cached) = ctx.sha_cache.get(&cache_key) {
+                cached.clone()
+            } else {
+                let client = skillfile_sources::http::UreqClient::new();
+                let resolved =
+                    skillfile_sources::resolver::resolve_github_sha(&client, owner_repo, ref_)?;
+                ctx.sha_cache.insert(cache_key, resolved.clone());
+                resolved
+            };
+            if upstream_sha == *sha {
+                format!("up to date  sha={sha_short}{annotation}")
+            } else {
+                let upstream_short = short_sha(&upstream_sha);
+                format!("outdated    locked={sha_short}  upstream={upstream_short}{annotation}")
+            }
+        } else {
+            format!("locked    sha={sha_short}{annotation}")
+        }
+    } else {
+        format!("locked    sha={sha_short}{annotation}")
+    };
+
+    Ok(format!("{name:<col_w$} {status}"))
+}
+
 pub fn cmd_status(repo_root: &Path, check_upstream: bool) -> Result<(), SkillfileError> {
     let manifest_path = repo_root.join(MANIFEST_NAME);
     if !manifest_path.exists() {
@@ -102,10 +181,8 @@ pub fn cmd_status(repo_root: &Path, check_upstream: bool) -> Result<(), Skillfil
         )));
     }
 
-    let result = parse_manifest(&manifest_path)?;
-    let manifest = result.manifest;
+    let manifest = crate::config::parse_and_resolve(&manifest_path)?;
     let locked = read_lock(repo_root)?;
-    let mut sha_cache: HashMap<(String, String), String> = HashMap::new();
 
     let col_w = manifest
         .entries
@@ -115,73 +192,18 @@ pub fn cmd_status(repo_root: &Path, check_upstream: bool) -> Result<(), Skillfil
         .unwrap_or(10)
         + 2;
 
+    let mut ctx = StatusContext {
+        manifest: &manifest,
+        repo_root,
+        locked: &locked,
+        check_upstream,
+        sha_cache: &mut HashMap::new(),
+        col_w,
+    };
+
     for entry in &manifest.entries {
-        let key = lock_key(entry);
-        let name = &entry.name;
-
-        if matches!(entry.source, SourceFields::Local { .. }) {
-            println!("{name:<col_w$} local");
-            continue;
-        }
-
-        let locked_info = match locked.get(&key) {
-            Some(li) => li,
-            None => {
-                println!("{name:<col_w$} unlocked");
-                continue;
-            }
-        };
-
-        let sha = &locked_info.sha;
-        let vdir = vendor_dir_for(entry, repo_root);
-        let meta = meta_sha(&vdir);
-
-        let mut annotations = Vec::new();
-        if has_patch(entry, repo_root) || has_dir_patch(entry, repo_root) {
-            annotations.push("[pinned]");
-        }
-        if is_modified_local(entry, &manifest, repo_root) {
-            annotations.push("[modified]");
-        }
-        let annotation = if annotations.is_empty() {
-            String::new()
-        } else {
-            format!("  {}", annotations.join("  "))
-        };
-
-        let sha_short = short_sha(sha);
-
-        let status = if meta.as_deref() != Some(sha.as_str()) {
-            format!("locked    sha={sha_short}  (missing or stale){annotation}")
-        } else if check_upstream {
-            if let SourceFields::Github {
-                owner_repo, ref_, ..
-            } = &entry.source
-            {
-                let cache_key = (owner_repo.clone(), ref_.clone());
-                let upstream_sha = if let Some(cached) = sha_cache.get(&cache_key) {
-                    cached.clone()
-                } else {
-                    let client = skillfile_sources::http::UreqClient::new();
-                    let resolved =
-                        skillfile_sources::resolver::resolve_github_sha(&client, owner_repo, ref_)?;
-                    sha_cache.insert(cache_key, resolved.clone());
-                    resolved
-                };
-                if upstream_sha == *sha {
-                    format!("up to date  sha={sha_short}{annotation}")
-                } else {
-                    let upstream_short = short_sha(&upstream_sha);
-                    format!("outdated    locked={sha_short}  upstream={upstream_short}{annotation}")
-                }
-            } else {
-                format!("locked    sha={sha_short}{annotation}")
-            }
-        } else {
-            format!("locked    sha={sha_short}{annotation}")
-        };
-
-        println!("{name:<col_w$} {status}");
+        let line = format_entry_status(entry, &mut ctx)?;
+        println!("{line}");
     }
 
     Ok(())
@@ -190,6 +212,7 @@ pub fn cmd_status(repo_root: &Path, check_upstream: bool) -> Result<(), Skillfil
 #[cfg(test)]
 mod tests {
     use super::*;
+    use skillfile_core::parser::parse_manifest;
 
     fn write_manifest(dir: &Path, content: &str) {
         std::fs::write(dir.join(MANIFEST_NAME), content).unwrap();

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1,0 +1,340 @@
+//! User-global config for personal platform preferences.
+//!
+//! Stores install targets (platform + scope) in a TOML config file
+//! so collaborative repos don't need `install` lines in the committed Skillfile.
+//!
+//! Config file location (via `dirs::config_dir()`):
+//! - Linux: `~/.config/skillfile/config.toml`
+//! - macOS: `~/Library/Application Support/skillfile/config.toml`
+//!
+//! Precedence: Skillfile install targets (if present) > user config > error.
+//!
+//! # Format
+//!
+//! ```toml
+//! [[install]]
+//! platform = "claude-code"
+//! scope = "global"
+//!
+//! [[install]]
+//! platform = "cursor"
+//! scope = "local"
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use skillfile_core::error::SkillfileError;
+use skillfile_core::models::{InstallTarget, Manifest, Scope};
+use skillfile_core::parser::parse_manifest;
+
+// ---------------------------------------------------------------------------
+// TOML schema
+// ---------------------------------------------------------------------------
+
+/// Root structure of `config.toml`.
+/// Unknown fields are ignored for forward compatibility.
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+struct Config {
+    /// Platform install targets.
+    #[serde(default)]
+    install: Vec<InstallEntry>,
+}
+
+/// A single `[[install]]` entry in the config file.
+#[derive(Debug, Serialize, Deserialize)]
+struct InstallEntry {
+    platform: String,
+    scope: String,
+}
+
+// ---------------------------------------------------------------------------
+// Conversions
+// ---------------------------------------------------------------------------
+
+impl From<&InstallTarget> for InstallEntry {
+    fn from(target: &InstallTarget) -> Self {
+        Self {
+            platform: target.adapter.clone(),
+            scope: target.scope.as_str().to_string(),
+        }
+    }
+}
+
+impl InstallEntry {
+    fn to_install_target(&self) -> Option<InstallTarget> {
+        let scope = Scope::parse(&self.scope)?;
+        Some(InstallTarget {
+            adapter: self.platform.clone(),
+            scope,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Returns the path to the user config file.
+///
+/// Uses `dirs::config_dir()` for a platform-appropriate location:
+/// - Linux: `~/.config/skillfile/config.toml`
+/// - macOS: `~/Library/Application Support/skillfile/config.toml`
+/// - Windows: `{FOLDERID_RoamingAppData}/skillfile/config.toml`
+///
+/// Returns `None` if the platform has no config directory.
+pub fn config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("skillfile").join("config.toml"))
+}
+
+/// Read install targets from a TOML config file at the given path.
+///
+/// Returns an empty `Vec` if the file doesn't exist, can't be parsed,
+/// or contains no valid `[[install]]` entries.
+pub fn read_user_targets_from(path: &Path) -> Vec<InstallTarget> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let config: Config = match toml::from_str(&content) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    config
+        .install
+        .iter()
+        .filter_map(|e| e.to_install_target())
+        .collect()
+}
+
+/// Read install targets from the user-global config file.
+///
+/// Returns an empty `Vec` if no config directory exists, the file is missing,
+/// or it contains no valid entries.
+pub fn read_user_targets() -> Vec<InstallTarget> {
+    match config_path() {
+        Some(path) => read_user_targets_from(&path),
+        None => Vec::new(),
+    }
+}
+
+/// Write install targets to the given TOML config file path.
+///
+/// Creates parent directories if needed. Overwrites any existing content.
+pub fn write_user_targets_to(targets: &[InstallTarget], path: &Path) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let config = Config {
+        install: targets.iter().map(InstallEntry::from).collect(),
+    };
+    let content = toml::to_string_pretty(&config).map_err(std::io::Error::other)?;
+    std::fs::write(path, content)
+}
+
+/// Write install targets to the user-global config file.
+///
+/// Returns `Ok(())` if successful, or an error if the config directory
+/// cannot be determined or the file cannot be written.
+pub fn write_user_targets(targets: &[InstallTarget]) -> Result<(), std::io::Error> {
+    match config_path() {
+        Some(path) => write_user_targets_to(targets, &path),
+        None => Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "could not determine config directory",
+        )),
+    }
+}
+
+/// If the manifest has no install targets, fill them from the user config.
+///
+/// This is the central target resolution point for CLI commands. Call after
+/// `parse_manifest()` in any command that needs install targets.
+pub fn resolve_targets_into(manifest: &mut Manifest) {
+    if manifest.install_targets.is_empty() {
+        manifest.install_targets = read_user_targets();
+    }
+}
+
+/// Parse the manifest and resolve install targets from user config.
+///
+/// Convenience wrapper that combines [`parse_manifest()`] with user-config
+/// target fallback. Use in any CLI command that needs a manifest with
+/// resolved install targets.
+pub fn parse_and_resolve(manifest_path: &Path) -> Result<Manifest, SkillfileError> {
+    let result = parse_manifest(manifest_path)?;
+    let mut manifest = result.manifest;
+    resolve_targets_into(&mut manifest);
+    Ok(manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_path_ends_with_expected_components() {
+        if let Some(path) = config_path() {
+            assert!(path.ends_with("skillfile/config.toml"));
+        }
+        // On platforms without config_dir, returns None — that's fine.
+    }
+
+    #[test]
+    fn read_user_targets_from_missing_file_returns_empty() {
+        let targets = read_user_targets_from(Path::new("/nonexistent/config.toml"));
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn read_user_targets_from_parses_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[[install]]\nplatform = \"claude-code\"\nscope = \"global\"\n\n\
+             [[install]]\nplatform = \"cursor\"\nscope = \"local\"\n",
+        )
+        .unwrap();
+
+        let targets = read_user_targets_from(&path);
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].adapter, "claude-code");
+        assert_eq!(targets[0].scope, Scope::Global);
+        assert_eq!(targets[1].adapter, "cursor");
+        assert_eq!(targets[1].scope, Scope::Local);
+    }
+
+    #[test]
+    fn read_user_targets_from_ignores_invalid_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[[install]]\nplatform = \"claude-code\"\nscope = \"global\"\n\n\
+             [[install]]\nplatform = \"cursor\"\nscope = \"invalid\"\n",
+        )
+        .unwrap();
+
+        let targets = read_user_targets_from(&path);
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].adapter, "claude-code");
+    }
+
+    #[test]
+    fn read_user_targets_from_empty_file_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "# empty config\n").unwrap();
+
+        let targets = read_user_targets_from(&path);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn read_user_targets_from_invalid_toml_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "this is not valid toml {{{").unwrap();
+
+        let targets = read_user_targets_from(&path);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn write_user_targets_to_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("dir").join("config.toml");
+
+        let targets = vec![InstallTarget {
+            adapter: "claude-code".to_string(),
+            scope: Scope::Global,
+        }];
+        write_user_targets_to(&targets, &path).unwrap();
+
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("[[install]]"));
+        assert!(content.contains("platform = \"claude-code\""));
+        assert!(content.contains("scope = \"global\""));
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let targets = vec![
+            InstallTarget {
+                adapter: "claude-code".to_string(),
+                scope: Scope::Global,
+            },
+            InstallTarget {
+                adapter: "gemini-cli".to_string(),
+                scope: Scope::Local,
+            },
+        ];
+        write_user_targets_to(&targets, &path).unwrap();
+
+        let read_back = read_user_targets_from(&path);
+        assert_eq!(read_back.len(), 2);
+        assert_eq!(read_back[0].adapter, "claude-code");
+        assert_eq!(read_back[0].scope, Scope::Global);
+        assert_eq!(read_back[1].adapter, "gemini-cli");
+        assert_eq!(read_back[1].scope, Scope::Local);
+    }
+
+    #[test]
+    fn write_produces_valid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let targets = vec![InstallTarget {
+            adapter: "claude-code".to_string(),
+            scope: Scope::Global,
+        }];
+        write_user_targets_to(&targets, &path).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        // Verify it's valid TOML by parsing it back
+        let parsed: Config = toml::from_str(&content).unwrap();
+        assert_eq!(parsed.install.len(), 1);
+        assert_eq!(parsed.install[0].platform, "claude-code");
+        assert_eq!(parsed.install[0].scope, "global");
+    }
+
+    #[test]
+    fn resolve_targets_into_prefers_manifest_targets() {
+        let mut manifest = Manifest {
+            entries: vec![],
+            install_targets: vec![InstallTarget {
+                adapter: "from-skillfile".to_string(),
+                scope: Scope::Global,
+            }],
+        };
+
+        // Even if user config has targets, manifest targets should win.
+        // resolve_targets_into only fills when manifest is empty.
+        resolve_targets_into(&mut manifest);
+        assert_eq!(manifest.install_targets.len(), 1);
+        assert_eq!(manifest.install_targets[0].adapter, "from-skillfile");
+    }
+
+    #[test]
+    fn read_user_targets_from_with_extra_fields_is_forward_compatible() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        // Future config might have extra sections — current parser should ignore them.
+        std::fs::write(
+            &path,
+            "[[install]]\nplatform = \"claude-code\"\nscope = \"global\"\n\n\
+             [resolve]\ntool = \"vimdiff\"\n",
+        )
+        .unwrap();
+
+        let targets = read_user_targets_from(&path);
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].adapter, "claude-code");
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod commands;
+pub mod config;
 pub mod patch;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod update_check;
 
 use skillfile::commands;
+use skillfile::config;
 
 use std::path::PathBuf;
 use std::process;
@@ -397,7 +398,13 @@ fn run() -> Result<(), SkillfileError> {
             commands::init::cmd_init(&repo_root)?;
         }
         Command::Install { dry_run, update } => {
-            skillfile_deploy::install::cmd_install(&repo_root, dry_run, update)?;
+            let user_targets = config::read_user_targets();
+            let extra = if user_targets.is_empty() {
+                None
+            } else {
+                Some(user_targets.as_slice())
+            };
+            skillfile_deploy::install::cmd_install(&repo_root, dry_run, update, extra)?;
         }
         Command::Add { source } => {
             handle_add(source, &repo_root)?;

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -413,7 +413,12 @@ fn deploy_all(
 // cmd_install
 // ---------------------------------------------------------------------------
 
-pub fn cmd_install(repo_root: &Path, dry_run: bool, update: bool) -> Result<(), SkillfileError> {
+pub fn cmd_install(
+    repo_root: &Path,
+    dry_run: bool,
+    update: bool,
+    extra_targets: Option<&[InstallTarget]>,
+) -> Result<(), SkillfileError> {
     let manifest_path = repo_root.join(MANIFEST_NAME);
     if !manifest_path.exists() {
         return Err(SkillfileError::Manifest(format!(
@@ -426,7 +431,20 @@ pub fn cmd_install(repo_root: &Path, dry_run: bool, update: bool) -> Result<(), 
     for w in &result.warnings {
         eprintln!("{w}");
     }
-    let manifest = result.manifest;
+    let mut manifest = result.manifest;
+
+    // If the Skillfile has no install targets, fall back to caller-provided targets
+    // (e.g. from user-global config).
+    if manifest.install_targets.is_empty() {
+        if let Some(targets) = extra_targets {
+            if !targets.is_empty() {
+                progress!(
+                    "Using platform targets from personal config (Skillfile has no install lines)."
+                );
+            }
+            manifest.install_targets = targets.to_vec();
+        }
+    }
 
     check_preconditions(&manifest, repo_root)?;
 
@@ -867,7 +885,7 @@ mod tests {
     #[test]
     fn cmd_install_no_manifest() {
         let dir = tempfile::tempdir().unwrap();
-        let result = cmd_install(dir.path(), false, false);
+        let result = cmd_install(dir.path(), false, false, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -881,12 +899,60 @@ mod tests {
         )
         .unwrap();
 
-        let result = cmd_install(dir.path(), false, false);
+        let result = cmd_install(dir.path(), false, false, None);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
             .to_string()
             .contains("No install targets"));
+    }
+
+    #[test]
+    fn cmd_install_extra_targets_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        // Skillfile with entries but NO install lines.
+        std::fs::write(
+            dir.path().join("Skillfile"),
+            "local  skill  foo  skills/foo.md\n",
+        )
+        .unwrap();
+        let source_file = dir.path().join("skills/foo.md");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::write(&source_file, "# Foo").unwrap();
+
+        // Pass extra targets — should be used as fallback.
+        let targets = vec![make_target("claude-code", Scope::Local)];
+        cmd_install(dir.path(), false, false, Some(&targets)).unwrap();
+
+        let dest = dir.path().join(".claude/skills/foo.md");
+        assert!(
+            dest.exists(),
+            "extra_targets must be used when Skillfile has none"
+        );
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "# Foo");
+    }
+
+    #[test]
+    fn cmd_install_skillfile_targets_win_over_extra() {
+        let dir = tempfile::tempdir().unwrap();
+        // Skillfile WITH install lines.
+        std::fs::write(
+            dir.path().join("Skillfile"),
+            "install  claude-code  local\nlocal  skill  foo  skills/foo.md\n",
+        )
+        .unwrap();
+        let source_file = dir.path().join("skills/foo.md");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::write(&source_file, "# Foo").unwrap();
+
+        // Pass extra targets for gemini-cli — should be IGNORED (Skillfile wins).
+        let targets = vec![make_target("gemini-cli", Scope::Local)];
+        cmd_install(dir.path(), false, false, Some(&targets)).unwrap();
+
+        // claude-code (from Skillfile) should be deployed.
+        assert!(dir.path().join(".claude/skills/foo.md").exists());
+        // gemini-cli (from extra_targets) should NOT be deployed.
+        assert!(!dir.path().join(".gemini").exists());
     }
 
     #[test]
@@ -901,7 +967,7 @@ mod tests {
         std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
         std::fs::write(&source_file, "# Foo").unwrap();
 
-        cmd_install(dir.path(), true, false).unwrap();
+        cmd_install(dir.path(), true, false, None).unwrap();
 
         assert!(!dir.path().join(".claude").exists());
     }
@@ -923,7 +989,7 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("agents")).unwrap();
         std::fs::write(dir.path().join("agents/bar.md"), "# Bar").unwrap();
 
-        cmd_install(dir.path(), false, false).unwrap();
+        cmd_install(dir.path(), false, false, None).unwrap();
 
         // skill deployed to all three adapters
         assert!(dir.path().join(".claude/skills/foo.md").exists());
@@ -959,7 +1025,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = cmd_install(dir.path(), false, false);
+        let result = cmd_install(dir.path(), false, false, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("pending conflict"));
     }


### PR DESCRIPTION
**SUMMARY**

Adds a user-global TOML config file at
`~/.config/skillfile/config.toml` for personal platform preferences. In shared repos where the Skillfile has entries but no `install` lines, commands now fall back to this config instead of failing with "No install targets configured."

**RATIONALE**

In collaborative repos, each developer uses different AI tools. Having everyone edit the shared Skillfile to add their `install` lines causes merge conflicts. The personal config lets each developer pick their own platforms once, and it applies across all repos. The Skillfile still wins when it has `install` lines, so teams that want explicit shared config keep that behavior.

**CHANGES**

- New `crates/cli/src/config.rs`: TOML-based config with `read_user_targets()`, `write_user_targets()`, and `resolve_targets_into()`. 12 unit tests. Forward-compatible (unknown TOML sections silently ignored).
- `crates/deploy/src/install.rs`: `cmd_install` takes an `extra_targets` param for fallback. Prints "Using platform targets from personal config" when active. 2 new tests.
- `crates/cli/src/main.rs`: wires `config::read_user_targets()` into the `install` command path.
- `crates/cli/src/commands/init.rs`: new destination choice (personal vs Skillfile), personal config recommended first with shared-repo tip. Shows existing config from both sources. Smarter outro that detects existing entries and suggests `skillfile install`.
- `crates/cli/src/commands/{status,diff,pin,resolve}.rs`: call `resolve_targets_into()` after `parse_manifest()` so all commands fall back to personal config when Skillfile has no install lines.
- `Cargo.toml`: `opt-level = "s"` in release profile (~4.2 MB to ~3.4 MB). Added `toml = "0.8"` workspace dependency.