### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,33 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FUNCTIONAL_TESTS_GITHUB_TOKEN }}
         run: cargo test --workspace
 
+  test-windows:
+    name: Tests (Windows)
+    needs: [check]
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build binary for functional tests
+        run: cargo build -p skillfile
+
+      - name: Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.FUNCTIONAL_TESTS_GITHUB_TOKEN }}
+        run: cargo test --workspace
+
   fuzz:
     name: Fuzz parse_manifest
     needs: [check]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,9 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: skillfile-aarch64-macos
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: skillfile-x86_64-windows.exe
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to skillfile are documented here.
 
 - **One-line installer** - `curl -fsSL .../install.sh | sh` detects OS and architecture, downloads the right binary to `~/.local/bin/`, and prints a PATH hint if needed. Supports `SKILLFILE_VERSION` and `SKILLFILE_INSTALL_DIR` overrides. Served as a release asset so it never reflects in-progress work on master.
 - **`cargo-binstall` support** - `cargo binstall skillfile` now downloads the pre-built binary in seconds instead of compiling from source. Zero config needed, piggybacks on existing release assets.
+- **Windows support** - pre-built `x86_64-pc-windows-msvc` binary in releases. Path separators normalized to forward slashes in deploy keys. CRLF line endings handled in patch application. Windows CI test job added.
 
 ### Fixed
 

--- a/crates/core/src/patch.rs
+++ b/crates/core/src/patch.rs
@@ -283,7 +283,7 @@ fn try_hunk_at(lines: &[String], start: usize, ctx_lines: &[&str]) -> bool {
         return false;
     }
     for (i, expected) in ctx_lines.iter().enumerate() {
-        if lines[start + i].trim_end_matches('\n') != *expected {
+        if lines[start + i].trim_end_matches(['\n', '\r']) != *expected {
             return false;
         }
     }
@@ -390,6 +390,10 @@ pub fn apply_patch_pure(original: &str, patch_text: &str) -> Result<String, Skil
     if patch_text.is_empty() {
         return Ok(original.to_string());
     }
+
+    // Normalize CRLF to LF so patches apply cleanly on Windows.
+    let original = &original.replace("\r\n", "\n");
+    let patch_text = &patch_text.replace("\r\n", "\n");
 
     // Split into lines preserving newlines (like Python's splitlines(keepends=True))
     let lines: Vec<String> = original
@@ -892,6 +896,32 @@ mod tests {
             v
         };
         assert_eq!(files, sorted, "walkdir results must be sorted");
+    }
+
+    // --- apply_patch_pure: CRLF handling ---
+
+    #[test]
+    fn apply_patch_pure_handles_crlf_original() {
+        let orig_lf = "line1\nline2\nline3\n";
+        let modified = "line1\nchanged\nline3\n";
+        let patch = generate_patch(orig_lf, modified, "test.md");
+
+        // Apply the LF-generated patch to a CRLF original
+        let orig_crlf = "line1\r\nline2\r\nline3\r\n";
+        let result = apply_patch_pure(orig_crlf, &patch).unwrap();
+        assert_eq!(result, modified);
+    }
+
+    #[test]
+    fn apply_patch_pure_handles_crlf_patch() {
+        let orig = "line1\nline2\nline3\n";
+        let modified = "line1\nchanged\nline3\n";
+        let patch_lf = generate_patch(orig, modified, "test.md");
+
+        // Convert patch itself to CRLF
+        let patch_crlf = patch_lf.replace('\n', "\r\n");
+        let result = apply_patch_pure(orig, &patch_crlf).unwrap();
+        assert_eq!(result, modified);
     }
 
     // --- apply_patch_pure: fuzzy hunk matching ---

--- a/crates/deploy/src/adapter.rs
+++ b/crates/deploy/src/adapter.rs
@@ -226,6 +226,14 @@ impl PlatformAdapter for FileSystemAdapter {
 // Deployment helpers (used by FileSystemAdapter)
 // ---------------------------------------------------------------------------
 
+/// Convert a [`Path`] to a forward-slash string for use as patch/deploy keys.
+///
+/// On Unix this is a no-op. On Windows, `\` separators become `/` so that
+/// patch keys are portable across platforms.
+fn forward_slash(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
 /// Build `{relative_path: absolute_path}` for all non-.meta files in a deployed directory.
 fn collect_dir_deploy_result(source: &Path, dest: &Path) -> DeployResult {
     let mut result = HashMap::new();
@@ -236,7 +244,7 @@ fn collect_dir_deploy_result(source: &Path, dest: &Path) -> DeployResult {
         let Ok(rel) = file.strip_prefix(source) else {
             continue;
         };
-        result.insert(rel.to_string_lossy().to_string(), dest.join(rel));
+        result.insert(forward_slash(rel), dest.join(rel));
     }
     result
 }
@@ -267,7 +275,7 @@ fn collect_walkdir_relative(base: &Path) -> HashMap<String, PathBuf> {
         let Ok(rel) = file.strip_prefix(base) else {
             continue;
         };
-        result.insert(rel.to_string_lossy().to_string(), file);
+        result.insert(forward_slash(rel), file);
     }
     result
 }
@@ -288,7 +296,7 @@ fn collect_flat_installed(vdir: &Path, target_dir: &Path) -> HashMap<String, Pat
         };
         let dest = target_dir.join(file.file_name().unwrap_or_default());
         if dest.exists() {
-            result.insert(rel.to_string_lossy().to_string(), dest);
+            result.insert(forward_slash(rel), dest);
         }
     }
     result
@@ -332,7 +340,7 @@ fn deploy_flat(source_dir: &Path, target_dir: &Path, opts: &InstallOptions) -> D
         }
         progress!("  {} -> {}", name.to_string_lossy(), dest.display());
         if let Ok(rel) = src.strip_prefix(source_dir) {
-            result.insert(rel.to_string_lossy().to_string(), dest);
+            result.insert(forward_slash(rel), dest);
         }
     }
     result
@@ -1403,6 +1411,18 @@ mod tests {
         let files = a.installed_dir_files(&entry, &local(dir.path()));
         assert!(files.contains_key("backend.md"));
         assert!(!files.contains_key("frontend.md"));
+    }
+
+    #[test]
+    fn forward_slash_converts_backslashes() {
+        assert_eq!(forward_slash(Path::new("a/b/c")), "a/b/c");
+        assert_eq!(forward_slash(Path::new("simple.md")), "simple.md");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn forward_slash_converts_windows_separators() {
+        assert_eq!(forward_slash(Path::new(r"a\b\c.md")), "a/b/c.md");
     }
 
     #[test]


### PR DESCRIPTION
**SUMMARY**
Addresses #14 

Path separator normalization, CRLF handling in patch application, Windows CI test job, and Windows release binary.

**RATIONALE**
~15 lines of code blocked an entire platform. On Windows, `Path::strip_prefix` preserves backslash separators, breaking patch key lookups. Files checked out with CRLF line endings caused patch context mismatches. Both are fixed at the boundary where paths and text enter the system.

**CHANGES**
- `crates/deploy/src/adapter.rs`: `forward_slash()` helper normalizes `\` to `/` in all deploy/patch key construction sites (`collect_dir_deploy_result`, `collect_walkdir_relative`, `collect_flat_installed`, `deploy_flat`)
- `crates/core/src/patch.rs`: `apply_patch_pure()` normalizes CRLF to LF in both original and patch text before processing; `try_hunk_at()` trims `\r` alongside `\n` during context matching
- `.github/workflows/ci.yml`: `test-windows` job on `windows-latest`
- `.github/workflows/release.yml`: `x86_64-pc-windows-msvc` build target producing `skillfile-x86_64-windows.exe`