### PR TITLE
Add nix flake

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,191 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to bump to (e.g., 1.4.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bump:
+    name: Bump version and create RC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update Cargo.toml with new version
+        run: |
+          VERSION="${{ inputs.version }}"
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+
+          # Update Cargo.lock
+          cargo update --workspace
+
+      - name: Commit version bump
+        id: commit
+        run: |
+          VERSION="${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add Cargo.toml Cargo.lock
+          git commit -m "Bump version to v${VERSION}"
+          git push origin master
+
+          # Get the commit SHA
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    needs: [bump]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: skillfile-x86_64-linux
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: skillfile-aarch64-linux
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: skillfile-x86_64-macos
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: skillfile-aarch64-macos
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: skillfile-x86_64-windows.exe
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux aarch64)
+        if: matrix.cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build release binary
+        shell: bash
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/skillfile${{ runner.os == 'Windows' && '.exe' || '' }} dist/${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}
+
+  create-rc:
+    name: Create RC Pre-release
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create checksums
+        working-directory: dist
+        run: sha256sum skillfile-* > checksums-sha256.txt
+
+      - name: Update flake.nix with new version and hashes
+        run: |
+          VERSION="${{ inputs.version }}"
+
+          # Read hashes from checksums file
+          X86_64_LINUX=$(grep "skillfile-x86_64-linux$" dist/checksums-sha256.txt | awk '{print $1}')
+          AARCH64_LINUX=$(grep "skillfile-aarch64-linux$" dist/checksums-sha256.txt | awk '{print $1}')
+          X86_64_DARWIN=$(grep "skillfile-x86_64-macos$" dist/checksums-sha256.txt | awk '{print $1}')
+          AARCH64_DARWIN=$(grep "skillfile-aarch64-macos$" dist/checksums-sha256.txt | awk '{print $1}')
+
+          # Update flake.nix with new version and hashes
+          sed -i \
+            -e "s/version = \"[^\"]*\";/version = \"$VERSION\";/" \
+            -e "s/x86_64-linux = \"[^\"]*\";/x86_64-linux = \"$X86_64_LINUX\";/" \
+            -e "s/aarch64-linux = \"[^\"]*\";/aarch64-linux = \"$AARCH64_LINUX\";/" \
+            -e "s/x86_64-darwin = \"[^\"]*\";/x86_64-darwin = \"$X86_64_DARWIN\";/" \
+            -e "s/aarch64-darwin = \"[^\"]*\";/aarch64-darwin = \"$AARCH64_DARWIN\";/" \
+            flake.nix
+
+      - name: Commit flake.nix update and create RC tag
+        run: |
+          VERSION="${{ inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Pull latest master
+          git pull origin master
+
+          # Commit flake.nix if there are changes
+          if ! git diff --quiet flake.nix; then
+            git add flake.nix
+            git commit -m "Update flake.nix to v${VERSION}"
+            git push origin master
+          fi
+
+          # Now create and push the RC tag (points to the flake.nix update commit)
+          git tag "v${VERSION}-rc"
+          git push origin "v${VERSION}-rc"
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${{ inputs.version }}"
+          # Extract the section between the first ## and the next ## (or EOF)
+          if [ -f CHANGELOG.md ]; then
+            awk '/^## v'"$VERSION"'/{found=1; next} found && /^## /{exit} found{print}' CHANGELOG.md > release-notes.md
+          else
+            echo "Release candidate for version ${VERSION}" > release-notes.md
+          fi
+
+      - name: Create RC pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}-rc
+          name: v${{ inputs.version }}-rc
+          body_path: release-notes.md
+          prerelease: true
+          files: |
+            dist/skillfile-*
+            dist/checksums-sha256.txt
+            install.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["v*-rc"]
 
 permissions:
   contents: write
@@ -19,6 +19,7 @@ jobs:
   verify-install:
     name: Verify install script (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: [ci]
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -38,67 +39,10 @@ jobs:
           "${{ runner.temp }}/skillfile-test/skillfile" --version
           "${{ runner.temp }}/skillfile-test/skillfile" --help
 
-  build:
-    name: Build (${{ matrix.target }})
-    runs-on: ${{ matrix.os }}
-    needs: [ci, verify-install]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            artifact: skillfile-x86_64-linux
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            artifact: skillfile-aarch64-linux
-            cross: true
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            artifact: skillfile-x86_64-macos
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            artifact: skillfile-aarch64-macos
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            artifact: skillfile-x86_64-windows.exe
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Install cross (Linux aarch64)
-        if: matrix.cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
-
-      - name: Build release binary
-        shell: bash
-        run: |
-          if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --release --target ${{ matrix.target }}
-          else
-            cargo build --release --target ${{ matrix.target }}
-          fi
-
-      - name: Package artifact
-        shell: bash
-        run: |
-          mkdir -p dist
-          cp target/${{ matrix.target }}/release/skillfile${{ runner.os == 'Windows' && '.exe' || '' }} dist/${{ matrix.artifact }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: dist/${{ matrix.artifact }}
-
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [ci, verify-install]
     steps:
       - uses: actions/checkout@v4
 
@@ -118,34 +62,60 @@ jobs:
           cargo publish -p skillfile
 
   release:
-    name: Create GitHub Release
+    name: Promote RC to Release
     runs-on: ubuntu-latest
-    needs: [build, publish]
+    needs: [publish]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
         with:
-          path: dist
-          merge-multiple: true
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create checksums
-        working-directory: dist
-        run: sha256sum skillfile-* > checksums-sha256.txt
+      - name: Download binaries from RC pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RC_TAG="${GITHUB_REF_NAME}"
+
+          # Download all assets from the RC pre-release
+          mkdir -p dist
+          gh release download "$RC_TAG" -D dist
 
       - name: Extract changelog for this version
         id: changelog
         run: |
-          # Extract the section between the first ## and the next ## (or EOF)
+          # Remove -rc suffix to get the actual version
           VERSION="${GITHUB_REF_NAME#v}"
-          awk '/^## v'"$VERSION"'/{found=1; next} found && /^## /{exit} found{print}' CHANGELOG.md > release-notes.md
+          VERSION="${VERSION%-rc}"
 
-      - name: Create release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release-notes.md
-          files: |
-            dist/skillfile-*
-            dist/checksums-sha256.txt
-            install.sh
+          if [ -f CHANGELOG.md ]; then
+            awk '/^## v'"$VERSION"'/{found=1; next} found && /^## /{exit} found{print}' CHANGELOG.md > release-notes.md
+          else
+            echo "Release version ${VERSION}" > release-notes.md
+          fi
+
+      - name: Create release tag and promote to full release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RC_TAG="${GITHUB_REF_NAME}"
+          VERSION="${RC_TAG#v}"
+          VERSION="${VERSION%-rc}"
+          RELEASE_TAG="v${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create the release tag pointing to the same commit as the RC tag
+          git tag "$RELEASE_TAG"
+          git push origin "$RELEASE_TAG"
+
+          # Create a new full release with the same assets
+          gh release create "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" \
+            --notes-file release-notes.md \
+            dist/*
+
+          # Delete the RC pre-release and tag
+          gh release delete "$RC_TAG" --yes
+          git push --delete origin "$RC_TAG"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "A declarative package manager for AI agent skills and configurations";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = false;
+        };
+      in
+      {
+        packages.default =
+          let
+            version = "1.4.1";
+
+            # SHA256 hashes from checksums-sha256.txt in GitHub releases
+            hashes = {
+              x86_64-linux = "04f1e553ba41d3d9f0c17dd6aac8d200c7c5aac636c3bb2e1c4f6fd88a106b8a";
+              aarch64-linux = "a554792dbadef07fd0786edcea9ce7d79c6616af50cfb607228a16f70f7467e1";
+              x86_64-darwin = "d86a373428750bd0fff065fafaa53df4dc30bcbd69dce9353d4ed71e30828183";
+              aarch64-darwin = "6f3c932276108317caa900961a44696806d50b7cda61fa0ec2e8037842b29f1e";
+            };
+
+            # Map Nix system names to release artifact names
+            platform = {
+              x86_64-linux = "x86_64-linux";
+              aarch64-linux = "aarch64-linux";
+              x86_64-darwin = "x86_64-macos";
+              aarch64-darwin = "aarch64-macos";
+            }.${system};
+          in
+          pkgs.stdenv.mkDerivation {
+            pname = "skillfile";
+            inherit version;
+
+            src = pkgs.fetchurl {
+              url = "https://github.com/eljulians/skillfile/releases/download/v${version}/skillfile-${platform}";
+              sha256 = hashes.${system};
+            };
+
+            dontUnpack = true;
+            dontBuild = true;
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p $out/bin
+              cp $src $out/bin/skillfile
+              chmod +x $out/bin/skillfile
+
+              runHook postInstall
+            '';
+
+            meta = with pkgs.lib; {
+              description = "A declarative package manager for AI agent skills and configurations";
+              homepage = "https://github.com/eljulians/skillfile";
+              license = licenses.asl20;
+              maintainers = [ ];
+              mainProgram = "skillfile";
+            };
+          };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.rustc
+            pkgs.cargo
+            pkgs.rustfmt
+            pkgs.clippy
+            pkgs.git
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
This fixes #21.

Once the PR is merged:

```
# Direct installation via nix profile
nix profile install github:eljulians/skillfile

# Via home-manager
home.packages = [ inputs.skillfile.packages.${system}.default ];

# Or run directly
nix run github:eljulians/skillfile -- --help
```

For now you can test with: `nix run github:r0hitsharma/skillfile/r0hitsharma/nix-flake -- --version`.

For making sure the version and sha's are updated in a consistent manner, the CI process has been updated to have a separate bump, and release step:

```mermaid
flowchart TD                                                                                                                                                                    
      Start[("Last functional commit<br/>on master")] --> Trigger{{"User triggers<br/>bump workflow<br/>(version: 1.4.2)"}}                                                       
                                                                                                                                                                                  
      Trigger --> Bump["<b>Bump Job</b><br/>• Update Cargo.toml<br/>• Update Cargo.lock<br/>• Commit: 'Bump version to v1.4.2'<br/>• Push to master"]                             
                                                                                                                                                                                  
      Bump --> Commit1[("Commit 1:<br/>Version bump")]                                                                                                                            
                                                            
      Commit1 --> Build["<b>Build Job</b><br/>(parallel matrix)<br/>• Build x86_64-linux<br/>• Build aarch64-linux<br/>• Build x86_64-macos<br/>• Build aarch64-macos<br/>• Build 
  x86_64-windows<br/>• Upload artifacts"]                   
                                                                                                                                                                                  
      Build --> CreateRC["<b>Create-RC Job</b><br/>• Download artifacts<br/>• Compute SHA256 hashes<br/>• Update flake.nix<br/>• Commit: 'Update flake.nix to v1.4.2'<br/>• Push  
  to master<br/>• Create v1.4.2-rc tag<br/>• Create pre-release with binaries"]
                                                                                                                                                                                  
      CreateRC --> Commit2[("Commit 2:<br/>flake.nix with hashes<br/><br/><b>Tagged: v1.4.2-rc</b>")]                                                                             
  
      Commit2 -.->|"RC tag triggers<br/>release workflow"| ReleaseStart["<b>Release Workflow Triggered</b>"]                                                                      
                                                            
      ReleaseStart --> CI["<b>CI Job</b><br/>• Run tests<br/>• Run lints"]                                                                                                        
                                                            
      CI -->|"Pass"| Verify["<b>Verify-Install Job</b><br/>• Test install.sh<br/>• Verify binary works"]                                                                          
                                                            
      CI -->|"Fail"| Failed[("❌ Release Aborted<br/>RC remains as pre-release")]                                                                                                 
                                                            
      Verify --> Publish["<b>Publish Job</b><br/>• Publish skillfile-core<br/>• Publish skillfile-sources<br/>• Publish skillfile-deploy<br/>• Publish skillfile"]                
                                                            
      Publish --> Release["<b>Release Job</b><br/>• Download binaries from RC<br/>• Create v1.4.2 tag<br/>• Create full release<br/>• Delete v1.4.2-rc tag<br/>• Delete RC        
  pre-release"]                                             
                                                                                                                                                                                  
      Release --> FinalTag[("Commit 2:<br/>flake.nix with hashes<br/><br/><b>Tagged: v1.4.2</b><br/>(RC tag removed)")]                                                           
  
      FinalTag --> Complete[("✅ Release Complete<br/>• GitHub Release published<br/>• crates.io published<br/>• Nix flake ready")]                                               
                                                            
      style Start fill:#e1f5ff                                                                                                                                                    
      style Commit1 fill:#fff4e1                            
      style Commit2 fill:#e8f5e1                                                                                                                                                  
      style FinalTag fill:#e1ffe8                                                                                                                                                 
      style Complete fill:#d4edda                                                                                                                                                 
      style Failed fill:#f8d7da                                                                                                                                                   
      style Trigger fill:#f0e6ff                                                                                                                                                  
      style ReleaseStart fill:#f0e6ff
```                                                                                                                                             
                                                                                                                                                                                  
  Key Points:                                                                                                                                                                     
  - 2 commits total: One for Cargo.toml/Cargo.lock, one for flake.nix with correct hashes                                                                                         
  - RC tag is created on the second commit (which has the correct hashes)                                                                                                         
  - CI runs on the RC tag before any publishing happens                  
  - If CI fails: Process stops, RC pre-release remains for debugging                                                                                                              
  - If CI passes: Publishes to crates.io, then promotes RC to full release                                                                                                        
  - Final state: v1.4.2 tag points to commit with correct hashes, RC is cleaned up    