### PR TITLE
Add untracked local file detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skillfile"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-core"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-deploy"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "dirs",
  "serde_json",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-sources"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "html-escape",
  "serde",

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -254,7 +254,7 @@ fn print_untracked(manifest: &Manifest, repo_root: &Path) -> Result<(), Skillfil
     println!();
     println!("Untracked:");
     for f in &untracked {
-        let suffix = if f.is_dir { "/" } else { "" };
+        let suffix = f.kind.suffix();
         println!("  {}  {}{suffix}", f.entity_type, f.path.display());
     }
     Ok(())

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -201,7 +201,11 @@ fn format_entry_status(
     Ok(format!("{name:<col_w$} {base_status}{annotation}"))
 }
 
-pub fn cmd_status(repo_root: &Path, check_upstream: bool) -> Result<(), SkillfileError> {
+pub fn cmd_status(
+    repo_root: &Path,
+    check_upstream: bool,
+    show_untracked: bool,
+) -> Result<(), SkillfileError> {
     let manifest_path = repo_root.join(MANIFEST_NAME);
     if !manifest_path.exists() {
         return Err(SkillfileError::Manifest(format!(
@@ -235,6 +239,24 @@ pub fn cmd_status(repo_root: &Path, check_upstream: bool) -> Result<(), Skillfil
         println!("{line}");
     }
 
+    if show_untracked {
+        print_untracked(&manifest, repo_root)?;
+    }
+
+    Ok(())
+}
+
+fn print_untracked(manifest: &Manifest, repo_root: &Path) -> Result<(), SkillfileError> {
+    let untracked = skillfile_deploy::paths::find_untracked(manifest, repo_root)?;
+    if untracked.is_empty() {
+        return Ok(());
+    }
+    println!();
+    println!("Untracked:");
+    for f in &untracked {
+        let suffix = if f.is_dir { "/" } else { "" };
+        println!("  {}  {}{suffix}", f.entity_type, f.path.display());
+    }
     Ok(())
 }
 
@@ -343,7 +365,7 @@ mod tests {
     #[test]
     fn no_manifest() {
         let dir = tempfile::tempdir().unwrap();
-        let result = cmd_status(dir.path(), false);
+        let result = cmd_status(dir.path(), false, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -355,7 +377,7 @@ mod tests {
         std::fs::create_dir_all(source.parent().unwrap()).unwrap();
         std::fs::write(&source, "# Foo").unwrap();
         write_manifest(dir.path(), "local  skill  foo  skills/foo.md\n");
-        cmd_status(dir.path(), false).unwrap();
+        cmd_status(dir.path(), false, false).unwrap();
     }
 
     #[test]
@@ -363,7 +385,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "local  skill  foo  skills/foo.md\n");
         // Missing path should not cause an error — status reports it inline
-        cmd_status(dir.path(), false).unwrap();
+        cmd_status(dir.path(), false, false).unwrap();
     }
 
     #[test]
@@ -373,7 +395,7 @@ mod tests {
             dir.path(),
             "github  agent  my-agent  owner/repo  agents/agent.md  main\n",
         );
-        cmd_status(dir.path(), false).unwrap();
+        cmd_status(dir.path(), false, false).unwrap();
     }
 
     #[test]
@@ -389,7 +411,7 @@ mod tests {
             &serde_json::json!({"github/agent/my-agent": {"sha": sha, "raw_url": "https://example.com"}}),
         );
         write_meta(dir.path(), &VE_AGENT, sha);
-        cmd_status(dir.path(), false).unwrap();
+        cmd_status(dir.path(), false, false).unwrap();
     }
 
     #[test]
@@ -405,7 +427,7 @@ mod tests {
             &serde_json::json!({"github/agent/my-agent": {"sha": sha, "raw_url": "https://example.com"}}),
         );
         // No .meta written
-        cmd_status(dir.path(), false).unwrap();
+        cmd_status(dir.path(), false, false).unwrap();
     }
 
     #[test]

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -6,6 +6,7 @@ use skillfile_core::lock::{lock_key, read_lock};
 use skillfile_core::models::{Manifest, Scope, SourceFields};
 use skillfile_core::parser::{parse_manifest, MANIFEST_NAME};
 use skillfile_deploy::adapter::adapters;
+use skillfile_deploy::paths::find_untracked;
 
 fn check_duplicate_names(manifest: &Manifest, errors: &mut Vec<String>) {
     let mut seen: HashMap<String, String> = HashMap::new();
@@ -79,7 +80,23 @@ fn check_orphaned_locks(
     Ok(())
 }
 
-pub fn cmd_validate(repo_root: &Path) -> Result<(), SkillfileError> {
+fn check_untracked(
+    manifest: &Manifest,
+    repo_root: &Path,
+    warnings: &mut Vec<String>,
+) -> Result<(), SkillfileError> {
+    for f in find_untracked(manifest, repo_root)? {
+        let entity = f.entity_type;
+        let path = f.path.display();
+        let suffix = if f.is_dir { "/" } else { "" };
+        warnings.push(format!(
+            "{entity}  {path}{suffix}  (add: skillfile add local {entity} {path})"
+        ));
+    }
+    Ok(())
+}
+
+pub fn cmd_validate(repo_root: &Path, strict: bool) -> Result<(), SkillfileError> {
     let manifest_path = repo_root.join(MANIFEST_NAME);
     if !manifest_path.exists() {
         return Err(SkillfileError::Manifest(format!(
@@ -101,6 +118,9 @@ pub fn cmd_validate(repo_root: &Path) -> Result<(), SkillfileError> {
     check_duplicate_targets(&manifest, &mut errors);
     check_orphaned_locks(&manifest, repo_root, &mut errors)?;
 
+    let mut warnings: Vec<String> = Vec::new();
+    check_untracked(&manifest, repo_root, &mut warnings)?;
+
     if !errors.is_empty() {
         for msg in &errors {
             eprintln!("error: {msg}");
@@ -108,11 +128,31 @@ pub fn cmd_validate(repo_root: &Path) -> Result<(), SkillfileError> {
         return Err(SkillfileError::Manifest(String::new()));
     }
 
+    if !warnings.is_empty() {
+        let prefix = if strict { "error" } else { "warning" };
+        eprintln!("{prefix}: untracked files in install targets:");
+        for w in &warnings {
+            eprintln!("  {w}");
+        }
+        if strict {
+            eprintln!(
+                "\n{} untracked file(s). Add to Skillfile or remove from disk.",
+                warnings.len()
+            );
+            return Err(SkillfileError::Manifest(String::new()));
+        }
+    }
+
     let n = manifest.entries.len();
     let t = manifest.install_targets.len();
     let entry_word = if n == 1 { "entry" } else { "entries" };
     let target_word = if t == 1 { "target" } else { "targets" };
-    println!("Skillfile OK — {n} {entry_word}, {t} install {target_word}");
+    let untracked_suffix = if warnings.is_empty() {
+        String::new()
+    } else {
+        format!(" ({} untracked)", warnings.len())
+    };
+    println!("Skillfile OK — {n} {entry_word}, {t} install {target_word}{untracked_suffix}");
 
     Ok(())
 }
@@ -128,7 +168,7 @@ mod tests {
     #[test]
     fn no_manifest() {
         let dir = tempfile::tempdir().unwrap();
-        let result = cmd_validate(dir.path());
+        let result = cmd_validate(dir.path(), false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -137,14 +177,14 @@ mod tests {
     fn valid_empty_manifest() {
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "");
-        cmd_validate(dir.path()).unwrap();
+        cmd_validate(dir.path(), false).unwrap();
     }
 
     #[test]
     fn valid_github_entry() {
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "github  agent  owner/repo  agents/agent.md\n");
-        cmd_validate(dir.path()).unwrap();
+        cmd_validate(dir.path(), false).unwrap();
     }
 
     #[test]
@@ -154,14 +194,14 @@ mod tests {
         std::fs::create_dir_all(source.parent().unwrap()).unwrap();
         std::fs::write(&source, "# Foo").unwrap();
         write_manifest(dir.path(), "local  skill  skills/foo.md\n");
-        cmd_validate(dir.path()).unwrap();
+        cmd_validate(dir.path(), false).unwrap();
     }
 
     #[test]
     fn valid_with_known_install_target() {
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "install  claude-code  global\n");
-        cmd_validate(dir.path()).unwrap();
+        cmd_validate(dir.path(), false).unwrap();
     }
 
     #[test]
@@ -171,7 +211,7 @@ mod tests {
             dir.path(),
             "local  skill  skills/foo.md\ngithub  agent  owner/repo  skills/foo.md\n",
         );
-        let result = cmd_validate(dir.path());
+        let result = cmd_validate(dir.path(), false);
         assert!(result.is_err());
     }
 
@@ -179,7 +219,7 @@ mod tests {
     fn missing_local_path_errors() {
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "local  skill  skills/nonexistent.md\n");
-        let result = cmd_validate(dir.path());
+        let result = cmd_validate(dir.path(), false);
         assert!(result.is_err());
     }
 
@@ -187,7 +227,7 @@ mod tests {
     fn unknown_platform_errors() {
         let dir = tempfile::tempdir().unwrap();
         write_manifest(dir.path(), "install  unknown-platform  global\n");
-        let result = cmd_validate(dir.path());
+        let result = cmd_validate(dir.path(), false);
         assert!(result.is_err());
     }
 
@@ -198,7 +238,7 @@ mod tests {
             dir.path(),
             "install  unknown-platform  global\nlocal  skill  skills/missing.md\n",
         );
-        let result = cmd_validate(dir.path());
+        let result = cmd_validate(dir.path(), false);
         assert!(result.is_err());
     }
 
@@ -209,7 +249,7 @@ mod tests {
             dir.path(),
             "install  claude-code  global\ninstall  claude-code  global\n",
         );
-        let result = cmd_validate(dir.path());
+        let result = cmd_validate(dir.path(), false);
         assert!(result.is_err());
     }
 
@@ -220,7 +260,7 @@ mod tests {
             dir.path(),
             "install  claude-code  global\ninstall  claude-code  local\n",
         );
-        cmd_validate(dir.path()).unwrap();
+        cmd_validate(dir.path(), false).unwrap();
     }
 
     #[test]
@@ -238,7 +278,7 @@ mod tests {
             serde_json::to_string_pretty(&lock_data).unwrap(),
         )
         .unwrap();
-        let result = cmd_validate(dir.path());
+        let result = cmd_validate(dir.path(), false);
         assert!(result.is_err());
     }
 
@@ -254,6 +294,45 @@ mod tests {
             serde_json::to_string_pretty(&lock_data).unwrap(),
         )
         .unwrap();
-        cmd_validate(dir.path()).unwrap();
+        cmd_validate(dir.path(), false).unwrap();
+    }
+
+    #[test]
+    fn untracked_files_warn_but_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "install  claude-code  local\n");
+        let agents = dir.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("rogue.md"), "# rogue").unwrap();
+
+        // Without strict, untracked files are warnings only → Ok
+        cmd_validate(dir.path(), false).unwrap();
+    }
+
+    #[test]
+    fn untracked_files_strict_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "install  claude-code  local\n");
+        let agents = dir.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("rogue.md"), "# rogue").unwrap();
+
+        let result = cmd_validate(dir.path(), true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn no_untracked_no_warnings() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "github  agent  owner/repo  agents/helper.md\ninstall  claude-code  local\n",
+        );
+        let agents = dir.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("helper.md"), "# tracked").unwrap();
+
+        // Validate should pass cleanly
+        cmd_validate(dir.path(), false).unwrap();
     }
 }

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -6,7 +6,7 @@ use skillfile_core::lock::{lock_key, read_lock};
 use skillfile_core::models::{Manifest, Scope, SourceFields};
 use skillfile_core::parser::{parse_manifest, MANIFEST_NAME};
 use skillfile_deploy::adapter::adapters;
-use skillfile_deploy::paths::find_untracked;
+use skillfile_deploy::paths::{find_untracked, UntrackedFile};
 
 fn check_duplicate_names(manifest: &Manifest, errors: &mut Vec<String>) {
     let mut seen: HashMap<String, String> = HashMap::new();
@@ -80,18 +80,27 @@ fn check_orphaned_locks(
     Ok(())
 }
 
-fn check_untracked(
-    manifest: &Manifest,
-    repo_root: &Path,
-    warnings: &mut Vec<String>,
+fn print_untracked_warnings(
+    untracked: &[UntrackedFile],
+    strict: bool,
 ) -> Result<(), SkillfileError> {
-    for f in find_untracked(manifest, repo_root)? {
+    if untracked.is_empty() {
+        return Ok(());
+    }
+    let prefix = if strict { "error" } else { "warning" };
+    eprintln!("{prefix}: untracked files in install targets:");
+    for f in untracked {
         let entity = f.entity_type;
         let path = f.path.display();
-        let suffix = if f.is_dir { "/" } else { "" };
-        warnings.push(format!(
-            "{entity}  {path}{suffix}  (add: skillfile add local {entity} {path})"
-        ));
+        let suffix = f.kind.suffix();
+        eprintln!("  {entity}  {path}{suffix}  (add: skillfile add local {entity} {path})");
+    }
+    if strict {
+        eprintln!(
+            "\n{} untracked file(s). Add to Skillfile or remove from disk.",
+            untracked.len()
+        );
+        return Err(SkillfileError::Manifest(String::new()));
     }
     Ok(())
 }
@@ -118,8 +127,7 @@ pub fn cmd_validate(repo_root: &Path, strict: bool) -> Result<(), SkillfileError
     check_duplicate_targets(&manifest, &mut errors);
     check_orphaned_locks(&manifest, repo_root, &mut errors)?;
 
-    let mut warnings: Vec<String> = Vec::new();
-    check_untracked(&manifest, repo_root, &mut warnings)?;
+    let untracked = find_untracked(&manifest, repo_root)?;
 
     if !errors.is_empty() {
         for msg in &errors {
@@ -128,29 +136,16 @@ pub fn cmd_validate(repo_root: &Path, strict: bool) -> Result<(), SkillfileError
         return Err(SkillfileError::Manifest(String::new()));
     }
 
-    if !warnings.is_empty() {
-        let prefix = if strict { "error" } else { "warning" };
-        eprintln!("{prefix}: untracked files in install targets:");
-        for w in &warnings {
-            eprintln!("  {w}");
-        }
-        if strict {
-            eprintln!(
-                "\n{} untracked file(s). Add to Skillfile or remove from disk.",
-                warnings.len()
-            );
-            return Err(SkillfileError::Manifest(String::new()));
-        }
-    }
+    print_untracked_warnings(&untracked, strict)?;
 
     let n = manifest.entries.len();
     let t = manifest.install_targets.len();
     let entry_word = if n == 1 { "entry" } else { "entries" };
     let target_word = if t == 1 { "target" } else { "targets" };
-    let untracked_suffix = if warnings.is_empty() {
+    let untracked_suffix = if untracked.is_empty() {
         String::new()
     } else {
-        format!(" ({} untracked)", warnings.len())
+        format!(" ({} untracked)", untracked.len())
     };
     println!("Skillfile OK — {n} {entry_word}, {t} install {target_word}{untracked_suffix}");
 

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -127,8 +127,6 @@ pub fn cmd_validate(repo_root: &Path, strict: bool) -> Result<(), SkillfileError
     check_duplicate_targets(&manifest, &mut errors);
     check_orphaned_locks(&manifest, repo_root, &mut errors)?;
 
-    let untracked = find_untracked(&manifest, repo_root)?;
-
     if !errors.is_empty() {
         for msg in &errors {
             eprintln!("error: {msg}");
@@ -136,6 +134,7 @@ pub fn cmd_validate(repo_root: &Path, strict: bool) -> Result<(), SkillfileError
         return Err(SkillfileError::Manifest(String::new()));
     }
 
+    let untracked = find_untracked(&manifest, repo_root)?;
     print_untracked_warnings(&untracked, strict)?;
 
     let n = manifest.entries.len();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -175,6 +175,9 @@ Examples:
         /// Check current upstream SHA (makes API calls)
         #[arg(long)]
         check_upstream: bool,
+        /// Show files in install directories not tracked by the Skillfile
+        #[arg(long)]
+        untracked: bool,
     },
 
     // -- Discovery (display_order 25-29) ----------------------------------------
@@ -235,7 +238,11 @@ duplicate entry names, orphaned lock entries, and duplicate install targets.
 
 Examples:
   skillfile validate")]
-    Validate,
+    Validate {
+        /// Fail if untracked files exist in install target directories
+        #[arg(long)]
+        strict: bool,
+    },
 
     /// Format and sort entries in the Skillfile into a standard order
     #[command(display_order = 31)]
@@ -467,7 +474,7 @@ fn run_content_commands(repo_root: &Path, cmd: Command) -> Result<(), SkillfileE
             );
             Ok(())
         }
-        Command::Validate => commands::validate::cmd_validate(repo_root),
+        Command::Validate { strict } => commands::validate::cmd_validate(repo_root, strict),
         Command::Format { dry_run } => commands::format::cmd_format(repo_root, dry_run),
         Command::Pin { name, dry_run } => commands::pin::cmd_pin(&name, repo_root, dry_run),
         Command::Unpin { name } => commands::pin::cmd_unpin(&name, repo_root),
@@ -491,9 +498,10 @@ fn run_source_commands(repo_root: &Path, cmd: Command) -> Result<(), SkillfileEr
             entry_filter: entry.as_deref(),
             update,
         }),
-        Command::Status { check_upstream } => {
-            commands::status::cmd_status(repo_root, check_upstream)
-        }
+        Command::Status {
+            check_upstream,
+            untracked,
+        } => commands::status::cmd_status(repo_root, check_upstream, untracked),
         Command::Init => commands::init::cmd_init(repo_root),
         Command::Install { dry_run, update } => run_install(repo_root, dry_run, update),
         Command::Add {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -168,9 +168,13 @@ Show the state of every entry: locked, unlocked, pinned, or missing.
 With --check-upstream, resolves the current upstream SHA for each entry
 and shows whether an update is available.
 
+With --untracked, lists files in install directories that are not tracked
+by any Skillfile entry.
+
 Examples:
   skillfile status
-  skillfile status --check-upstream")]
+  skillfile status --check-upstream
+  skillfile status --untracked")]
     Status {
         /// Check current upstream SHA (makes API calls)
         #[arg(long)]
@@ -230,14 +234,19 @@ Examples:
     },
 
     // -- Validation (display_order 30-39) -------------------------------------
-    /// Check the Skillfile for errors
+    /// Check the Skillfile for errors and warn about untracked files
     #[command(display_order = 30)]
     #[command(long_about = "\
 Parse the Skillfile and report any errors: syntax issues, unknown platforms,
 duplicate entry names, orphaned lock entries, and duplicate install targets.
 
+Also detects files in install directories (e.g. .claude/skills/) that are not
+tracked by any Skillfile entry. By default these are warnings on stderr.
+Use --strict to promote them to errors (useful as a CI gate).
+
 Examples:
-  skillfile validate")]
+  skillfile validate
+  skillfile validate --strict     # CI: fail on untracked files")]
     Validate {
         /// Fail if untracked files exist in install target directories
         #[arg(long)]

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -1,12 +1,12 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use skillfile_core::error::SkillfileError;
-use skillfile_core::models::{EntityType, Entry, Manifest, SourceFields};
+use skillfile_core::models::{EntityType, Entry, Manifest, Scope, SourceFields};
 use skillfile_sources::strategy::{content_file, is_dir_entry};
 use skillfile_sources::sync::vendor_dir_for;
 
-use crate::adapter::{adapters, AdapterScope, PlatformAdapter};
+use crate::adapter::{adapters, AdapterScope, DirInstallMode, PlatformAdapter};
 
 pub fn resolve_target_dir(
     adapter_name: &str,
@@ -65,6 +65,165 @@ fn source_path_remote(entry: &Entry, repo_root: &Path) -> Option<PathBuf> {
         let filename = content_file(entry);
         (!filename.is_empty()).then(|| vdir.join(filename))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Untracked file detection
+// ---------------------------------------------------------------------------
+
+pub struct UntrackedFile {
+    pub entity_type: EntityType,
+    pub path: PathBuf,
+    pub is_dir: bool,
+}
+
+pub fn covered_paths(manifest: &Manifest, repo_root: &Path) -> HashSet<PathBuf> {
+    let mut covered = HashSet::new();
+    for_each_local_adapter(manifest, repo_root, |adapter, ctx| {
+        for entry in manifest
+            .entries
+            .iter()
+            .filter(|e| adapter.supports(e.entity_type))
+        {
+            covered.extend(entry_covered_paths(adapter, ctx, entry));
+        }
+    });
+    covered
+}
+
+fn entry_covered_paths(
+    adapter: &dyn PlatformAdapter,
+    ctx: &AdapterScope<'_>,
+    entry: &Entry,
+) -> Vec<PathBuf> {
+    let installed = if is_dir_entry(entry) {
+        adapter.target_dir(entry.entity_type, ctx).join(&entry.name)
+    } else {
+        adapter.installed_path(entry, ctx)
+    };
+    let mut paths = vec![installed];
+    if let SourceFields::Local { path } = &entry.source {
+        paths.push(ctx.repo_root.join(path));
+    }
+    paths
+}
+
+pub fn find_untracked(
+    manifest: &Manifest,
+    repo_root: &Path,
+) -> Result<Vec<UntrackedFile>, SkillfileError> {
+    let covered = covered_paths(manifest, repo_root);
+    let mut scanner = DirScanner::new(&covered, repo_root);
+    for_each_local_adapter(manifest, repo_root, |adapter, ctx| {
+        scanner.scan_adapter(adapter, ctx);
+    });
+    Ok(scanner.into_sorted())
+}
+
+fn for_each_local_adapter(
+    manifest: &Manifest,
+    repo_root: &Path,
+    mut f: impl FnMut(&dyn PlatformAdapter, &AdapterScope<'_>),
+) {
+    let registry = adapters();
+    for target in manifest
+        .install_targets
+        .iter()
+        .filter(|t| t.scope == Scope::Local)
+    {
+        let Some(adapter) = registry.get(&target.adapter) else {
+            continue;
+        };
+        let ctx = AdapterScope {
+            scope: target.scope,
+            repo_root,
+        };
+        f(adapter, &ctx);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ScanSpec {
+    entity_type: EntityType,
+    mode: DirInstallMode,
+}
+
+struct DirScanner<'a> {
+    covered: &'a HashSet<PathBuf>,
+    repo_root: &'a Path,
+    seen: HashSet<PathBuf>,
+    items: Vec<UntrackedFile>,
+}
+
+impl<'a> DirScanner<'a> {
+    fn new(covered: &'a HashSet<PathBuf>, repo_root: &'a Path) -> Self {
+        Self {
+            covered,
+            repo_root,
+            seen: HashSet::new(),
+            items: Vec::new(),
+        }
+    }
+
+    fn scan_adapter(&mut self, adapter: &dyn PlatformAdapter, ctx: &AdapterScope<'_>) {
+        let specs: Vec<_> = EntityType::ALL
+            .iter()
+            .filter(|&&et| adapter.supports(et))
+            .map(|&et| {
+                let dir = adapter.target_dir(et, ctx);
+                let mode = adapter.dir_mode(et).unwrap_or(DirInstallMode::Nested);
+                (
+                    dir,
+                    ScanSpec {
+                        entity_type: et,
+                        mode,
+                    },
+                )
+            })
+            .filter(|(dir, _)| dir.is_dir())
+            .collect();
+
+        for (dir, spec) in &specs {
+            scan_target_dir(dir, *spec, self);
+        }
+    }
+
+    fn into_sorted(mut self) -> Vec<UntrackedFile> {
+        self.items.sort_by(|a, b| a.path.cmp(&b.path));
+        self.items
+    }
+}
+
+fn scan_target_dir(target_dir: &Path, spec: ScanSpec, scanner: &mut DirScanner<'_>) {
+    let Ok(entries) = std::fs::read_dir(target_dir) else {
+        return;
+    };
+    for dir_entry in entries.flatten() {
+        let is_dir = dir_entry.file_type().is_ok_and(|ft| ft.is_dir());
+        let path = dir_entry.path();
+        let is_nested_dir = is_dir && spec.mode == DirInstallMode::Nested;
+        if !is_nested_dir && !is_md_file(&path) {
+            continue;
+        }
+        if scanner.covered.contains(&path) || !scanner.seen.insert(path.clone()) {
+            continue;
+        }
+        scanner.items.push(UntrackedFile {
+            entity_type: spec.entity_type,
+            path: relative_to(scanner.repo_root, &path),
+            is_dir: is_nested_dir,
+        });
+    }
+}
+
+fn is_md_file(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("md"))
+}
+
+fn relative_to(base: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(base)
+        .map_or_else(|_| path.to_path_buf(), Path::to_path_buf)
 }
 
 fn first_target(manifest: &Manifest) -> Result<&'static dyn PlatformAdapter, SkillfileError> {
@@ -298,5 +457,296 @@ mod tests {
             repo_root: Path::new("/tmp"),
         };
         assert!(resolve_target_dir("claude-code", EntityType::Skill, &ctx).is_ok());
+    }
+
+    // -- covered_paths / find_untracked tests --------------------------------
+
+    fn local_target() -> InstallTarget {
+        InstallTarget {
+            adapter: "claude-code".into(),
+            scope: Scope::Local,
+        }
+    }
+
+    fn global_target() -> InstallTarget {
+        InstallTarget {
+            adapter: "claude-code".into(),
+            scope: Scope::Global,
+        }
+    }
+
+    fn github_skill(name: &str) -> Entry {
+        Entry {
+            entity_type: EntityType::Skill,
+            name: name.into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: format!("skills/{name}.md"),
+                ref_: "main".into(),
+            },
+        }
+    }
+
+    fn github_skill_dir(name: &str) -> Entry {
+        Entry {
+            entity_type: EntityType::Skill,
+            name: name.into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: format!("skills/{name}"),
+                ref_: "main".into(),
+            },
+        }
+    }
+
+    fn github_agent(name: &str) -> Entry {
+        Entry {
+            entity_type: EntityType::Agent,
+            name: name.into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: format!("agents/{name}.md"),
+                ref_: "main".into(),
+            },
+        }
+    }
+
+    fn local_skill(name: &str, path: &str) -> Entry {
+        Entry {
+            entity_type: EntityType::Skill,
+            name: name.into(),
+            source: SourceFields::Local { path: path.into() },
+        }
+    }
+
+    #[test]
+    fn covered_single_file_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_skill("browser")],
+            install_targets: vec![local_target()],
+        };
+        let paths = covered_paths(&manifest, tmp.path());
+        assert!(paths.contains(&tmp.path().join(".claude/skills/browser.md")));
+    }
+
+    #[test]
+    fn covered_dir_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_skill_dir("python-pro")],
+            install_targets: vec![local_target()],
+        };
+        let paths = covered_paths(&manifest, tmp.path());
+        assert!(paths.contains(&tmp.path().join(".claude/skills/python-pro")));
+    }
+
+    #[test]
+    fn covered_local_entry_includes_source_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![local_skill("docker", ".claude/skills/docker")],
+            install_targets: vec![local_target()],
+        };
+        let paths = covered_paths(&manifest, tmp.path());
+        assert!(paths.contains(&tmp.path().join(".claude/skills/docker")));
+    }
+
+    #[test]
+    fn covered_multiple_local_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_skill("browser")],
+            install_targets: vec![
+                local_target(),
+                InstallTarget {
+                    adapter: "cursor".into(),
+                    scope: Scope::Local,
+                },
+            ],
+        };
+        let paths = covered_paths(&manifest, tmp.path());
+        assert!(paths.contains(&tmp.path().join(".claude/skills/browser.md")));
+        assert!(paths.contains(&tmp.path().join(".cursor/skills/browser.md")));
+    }
+
+    #[test]
+    fn covered_skips_unsupported_entity() {
+        let tmp = tempfile::tempdir().unwrap();
+        // codex doesn't support agents
+        let manifest = Manifest {
+            entries: vec![github_agent("helper")],
+            install_targets: vec![InstallTarget {
+                adapter: "codex".into(),
+                scope: Scope::Local,
+            }],
+        };
+        let paths = covered_paths(&manifest, tmp.path());
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn covered_skips_global_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_skill("browser")],
+            install_targets: vec![global_target()],
+        };
+        let paths = covered_paths(&manifest, tmp.path());
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn untracked_empty_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![],
+            install_targets: vec![local_target()],
+        };
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn untracked_all_tracked() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_agent("helper")],
+            install_targets: vec![local_target()],
+        };
+        // Create the installed file that IS tracked
+        let agents = tmp.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("helper.md"), "# Helper").unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn untracked_agent_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_agent("helper")],
+            install_targets: vec![local_target()],
+        };
+        let agents = tmp.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("helper.md"), "# tracked").unwrap();
+        std::fs::write(agents.join("rogue.md"), "# rogue").unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].path.ends_with("rogue.md"));
+        assert_eq!(result[0].entity_type, EntityType::Agent);
+        assert!(!result[0].is_dir);
+    }
+
+    #[test]
+    fn untracked_skill_dir_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_skill_dir("python-pro")],
+            install_targets: vec![local_target()],
+        };
+        let skills = tmp.path().join(".claude/skills");
+        std::fs::create_dir_all(skills.join("python-pro")).unwrap();
+        std::fs::create_dir_all(skills.join("docker")).unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].path.ends_with("docker"));
+        assert!(result[0].is_dir);
+    }
+
+    #[test]
+    fn untracked_extra_file_in_managed_dir_not_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_skill_dir("python-pro")],
+            install_targets: vec![local_target()],
+        };
+        let skill_dir = tmp.path().join(".claude/skills/python-pro");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Skill").unwrap();
+        std::fs::write(skill_dir.join("my-notes.md"), "# Notes").unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert!(
+            result.is_empty(),
+            "lenient: extra files in managed dir not flagged"
+        );
+    }
+
+    #[test]
+    fn untracked_non_md_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![],
+            install_targets: vec![local_target()],
+        };
+        let agents = tmp.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("notes.txt"), "not a skill").unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn untracked_missing_target_dir_no_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![],
+            install_targets: vec![local_target()],
+        };
+        // Don't create .claude/ at all
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn untracked_global_target_not_scanned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![],
+            install_targets: vec![global_target()],
+        };
+        // Even with files in global dirs, nothing should be reported
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn untracked_single_file_skill_in_skills_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_skill("browser")],
+            install_targets: vec![local_target()],
+        };
+        let skills = tmp.path().join(".claude/skills");
+        std::fs::create_dir_all(&skills).unwrap();
+        std::fs::write(skills.join("browser.md"), "# tracked").unwrap();
+        std::fs::write(skills.join("rogue.md"), "# rogue").unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].path.ends_with("rogue.md"));
+        assert_eq!(result[0].entity_type, EntityType::Skill);
+    }
+
+    #[test]
+    fn untracked_deduplicates_across_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![],
+            install_targets: vec![local_target(), local_target()],
+        };
+        let agents = tmp.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("rogue.md"), "# rogue").unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert_eq!(result.len(), 1, "should deduplicate across targets");
     }
 }

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -87,6 +87,7 @@ impl UntrackedKind {
     }
 }
 
+#[derive(Debug)]
 pub struct UntrackedFile {
     pub entity_type: EntityType,
     pub path: PathBuf,
@@ -125,7 +126,15 @@ fn entry_covered_paths(
     } else if is_dir {
         vec![adapter.target_dir(entry.entity_type, ctx).join(&entry.name)]
     } else {
-        vec![adapter.installed_path(entry, ctx)]
+        let installed = adapter.installed_path(entry, ctx);
+        // Nested single-file: installed at {name}/SKILL.md — cover the parent
+        // dir too so the scanner (which operates one level deep) sees it.
+        if mode == DirInstallMode::Nested {
+            let dir = adapter.target_dir(entry.entity_type, ctx).join(&entry.name);
+            vec![installed, dir]
+        } else {
+            vec![installed]
+        }
     };
     if let SourceFields::Local { path } = &entry.source {
         paths.push(ctx.repo_root.join(path));
@@ -210,40 +219,44 @@ impl<'a> DirScanner<'a> {
                 ))
             });
         for (dir, spec) in specs {
-            scan_target_dir(&dir, spec, self);
+            self.scan_target_dir(&dir, spec);
         }
     }
 
-    fn into_sorted(mut self) -> Vec<UntrackedFile> {
-        self.items.sort_unstable_by(|a, b| a.path.cmp(&b.path));
-        self.items
+    fn scan_target_dir(&mut self, target_dir: &Path, spec: ScanSpec) {
+        let Ok(entries) = std::fs::read_dir(target_dir) else {
+            return;
+        };
+        for dir_entry in entries.flatten() {
+            self.consider_entry(&dir_entry, spec);
+        }
     }
-}
 
-fn scan_target_dir(target_dir: &Path, spec: ScanSpec, scanner: &mut DirScanner<'_>) {
-    let Ok(entries) = std::fs::read_dir(target_dir) else {
-        return;
-    };
-    for dir_entry in entries.flatten() {
+    fn consider_entry(&mut self, dir_entry: &std::fs::DirEntry, spec: ScanSpec) {
         let is_dir = dir_entry.file_type().is_ok_and(|ft| ft.is_dir());
         let path = dir_entry.path();
         let is_nested_dir = is_dir && spec.mode == DirInstallMode::Nested;
         if !is_nested_dir && !is_md_file(&path) {
-            continue;
+            return;
         }
-        if scanner.covered.contains(&path) || !scanner.seen.insert(path.clone()) {
-            continue;
+        if self.covered.contains(&path) || !self.seen.insert(path.clone()) {
+            return;
         }
         let kind = if is_nested_dir {
             UntrackedKind::Directory
         } else {
             UntrackedKind::File
         };
-        scanner.items.push(UntrackedFile {
+        self.items.push(UntrackedFile {
             entity_type: spec.entity_type,
-            path: relative_to(scanner.repo_root, &path),
+            path: relative_to(self.repo_root, &path),
             kind,
         });
+    }
+
+    fn into_sorted(mut self) -> Vec<UntrackedFile> {
+        self.items.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+        self.items
     }
 }
 
@@ -253,8 +266,7 @@ fn is_md_file(path: &Path) -> bool {
 }
 
 fn relative_to(base: &Path, path: &Path) -> PathBuf {
-    path.strip_prefix(base)
-        .map_or_else(|_| path.to_path_buf(), Path::to_path_buf)
+    path.strip_prefix(base).unwrap_or(path).to_path_buf()
 }
 
 fn first_target(manifest: &Manifest) -> Result<&'static dyn PlatformAdapter, SkillfileError> {
@@ -570,7 +582,9 @@ mod tests {
             install_targets: vec![local_target()],
         };
         let paths = covered_paths(&manifest, tmp.path());
-        assert!(paths.contains(&tmp.path().join(".claude/skills/browser.md")));
+        // Nested single-file: covered set includes both the leaf and parent dir
+        assert!(paths.contains(&tmp.path().join(".claude/skills/browser/SKILL.md")));
+        assert!(paths.contains(&tmp.path().join(".claude/skills/browser")));
     }
 
     #[test]
@@ -609,8 +623,11 @@ mod tests {
             ],
         };
         let paths = covered_paths(&manifest, tmp.path());
-        assert!(paths.contains(&tmp.path().join(".claude/skills/browser.md")));
-        assert!(paths.contains(&tmp.path().join(".cursor/skills/browser.md")));
+        // Nested single-file: both leaf and parent dir covered per adapter
+        assert!(paths.contains(&tmp.path().join(".claude/skills/browser/SKILL.md")));
+        assert!(paths.contains(&tmp.path().join(".claude/skills/browser")));
+        assert!(paths.contains(&tmp.path().join(".cursor/skills/browser/SKILL.md")));
+        assert!(paths.contains(&tmp.path().join(".cursor/skills/browser")));
     }
 
     #[test]
@@ -768,8 +785,10 @@ mod tests {
             install_targets: vec![local_target()],
         };
         let skills = tmp.path().join(".claude/skills");
-        std::fs::create_dir_all(&skills).unwrap();
-        std::fs::write(skills.join("browser.md"), "# tracked").unwrap();
+        // Nested layout: tracked skill is browser/SKILL.md
+        std::fs::create_dir_all(skills.join("browser")).unwrap();
+        std::fs::write(skills.join("browser/SKILL.md"), "# tracked").unwrap();
+        // Rogue file at top level
         std::fs::write(skills.join("rogue.md"), "# rogue").unwrap();
 
         let result = find_untracked(&manifest, tmp.path()).unwrap();

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -71,10 +71,26 @@ fn source_path_remote(entry: &Entry, repo_root: &Path) -> Option<PathBuf> {
 // Untracked file detection
 // ---------------------------------------------------------------------------
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UntrackedKind {
+    File,
+    Directory,
+}
+
+impl UntrackedKind {
+    #[must_use]
+    pub fn suffix(self) -> &'static str {
+        match self {
+            Self::File => "",
+            Self::Directory => "/",
+        }
+    }
+}
+
 pub struct UntrackedFile {
     pub entity_type: EntityType,
     pub path: PathBuf,
-    pub is_dir: bool,
+    pub kind: UntrackedKind,
 }
 
 fn covered_paths(manifest: &Manifest, repo_root: &Path) -> HashSet<PathBuf> {
@@ -166,25 +182,22 @@ impl<'a> DirScanner<'a> {
     }
 
     fn scan_adapter(&mut self, adapter: &dyn PlatformAdapter, ctx: &AdapterScope<'_>) {
-        let specs: Vec<_> = EntityType::ALL
+        let specs = EntityType::ALL
             .iter()
             .filter(|&&et| adapter.supports(et))
-            .map(|&et| {
+            .filter_map(|&et| {
                 let dir = adapter.target_dir(et, ctx);
                 let mode = adapter.dir_mode(et).unwrap_or(DirInstallMode::Nested);
-                (
+                dir.is_dir().then_some((
                     dir,
                     ScanSpec {
                         entity_type: et,
                         mode,
                     },
-                )
-            })
-            .filter(|(dir, _)| dir.is_dir())
-            .collect();
-
-        for (dir, spec) in &specs {
-            scan_target_dir(dir, *spec, self);
+                ))
+            });
+        for (dir, spec) in specs {
+            scan_target_dir(&dir, spec, self);
         }
     }
 
@@ -208,10 +221,15 @@ fn scan_target_dir(target_dir: &Path, spec: ScanSpec, scanner: &mut DirScanner<'
         if scanner.covered.contains(&path) || !scanner.seen.insert(path.clone()) {
             continue;
         }
+        let kind = if is_nested_dir {
+            UntrackedKind::Directory
+        } else {
+            UntrackedKind::File
+        };
         scanner.items.push(UntrackedFile {
             entity_type: spec.entity_type,
             path: relative_to(scanner.repo_root, &path),
-            is_dir: is_nested_dir,
+            kind,
         });
     }
 }
@@ -639,7 +657,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert!(result[0].path.ends_with("rogue.md"));
         assert_eq!(result[0].entity_type, EntityType::Agent);
-        assert!(!result[0].is_dir);
+        assert_eq!(result[0].kind, UntrackedKind::File);
     }
 
     #[test]
@@ -656,7 +674,7 @@ mod tests {
         let result = find_untracked(&manifest, tmp.path()).unwrap();
         assert_eq!(result.len(), 1);
         assert!(result[0].path.ends_with("docker"));
-        assert!(result[0].is_dir);
+        assert_eq!(result[0].kind, UntrackedKind::Directory);
     }
 
     #[test]

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -112,16 +112,29 @@ fn entry_covered_paths(
     ctx: &AdapterScope<'_>,
     entry: &Entry,
 ) -> Vec<PathBuf> {
-    let installed = if is_dir_entry(entry) {
-        adapter.target_dir(entry.entity_type, ctx).join(&entry.name)
+    let is_dir = is_dir_entry(entry) || is_local_dir(entry, ctx.repo_root);
+    let mode = adapter
+        .dir_mode(entry.entity_type)
+        .unwrap_or(DirInstallMode::Nested);
+    let mut paths = if is_dir && mode == DirInstallMode::Flat {
+        // Flat dir: individual files are deployed directly into target_dir
+        adapter
+            .installed_dir_files(entry, ctx)
+            .into_values()
+            .collect()
+    } else if is_dir {
+        vec![adapter.target_dir(entry.entity_type, ctx).join(&entry.name)]
     } else {
-        adapter.installed_path(entry, ctx)
+        vec![adapter.installed_path(entry, ctx)]
     };
-    let mut paths = vec![installed];
     if let SourceFields::Local { path } = &entry.source {
         paths.push(ctx.repo_root.join(path));
     }
     paths
+}
+
+fn is_local_dir(entry: &Entry, repo_root: &Path) -> bool {
+    matches!(&entry.source, SourceFields::Local { path } if repo_root.join(path).is_dir())
 }
 
 pub fn find_untracked(
@@ -529,6 +542,18 @@ mod tests {
         }
     }
 
+    fn github_agent_dir(name: &str) -> Entry {
+        Entry {
+            entity_type: EntityType::Agent,
+            name: name.into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: format!("agents/{name}"),
+                ref_: "main".into(),
+            },
+        }
+    }
+
     fn local_skill(name: &str, path: &str) -> Entry {
         Entry {
             entity_type: EntityType::Skill,
@@ -766,5 +791,63 @@ mod tests {
 
         let result = find_untracked(&manifest, tmp.path()).unwrap();
         assert_eq!(result.len(), 1, "should deduplicate across targets");
+    }
+
+    // -- BUG reproductions ---------------------------------------------------
+
+    #[test]
+    fn flat_agent_dir_entry_no_false_positives() {
+        // BUG 1: Flat-deployed dir entry files must be in covered set.
+        // A github agent dir entry deploys individual .md files flat into
+        // the agents dir. Those files must not be flagged as untracked.
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![github_agent_dir("my-agents")],
+            install_targets: vec![local_target()],
+        };
+        // Create vendor cache (installed_dir_files reads this for flat mode)
+        let vdir = tmp.path().join(".skillfile/cache/agents/my-agents");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(vdir.join("a.md"), "# A").unwrap();
+        std::fs::write(vdir.join("b.md"), "# B").unwrap();
+        // Create the flat-deployed files in the agents target dir
+        let agents = tmp.path().join(".claude/agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("a.md"), "# A").unwrap();
+        std::fs::write(agents.join("b.md"), "# B").unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert!(
+            result.is_empty(),
+            "flat-deployed dir entry files should not be flagged as untracked, got: {:?}",
+            result.iter().map(|f| &f.path).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn local_dir_skill_not_false_positive() {
+        // BUG 2: Local dir entry where source is outside the target dir.
+        // is_dir_entry() returns false for Local entries, so covered_paths
+        // computes the wrong installed path (name.md instead of name/).
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            entries: vec![local_skill("docker", "skills/docker")],
+            install_targets: vec![local_target()],
+        };
+        // Create source dir (outside target dir)
+        let source = tmp.path().join("skills/docker");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("SKILL.md"), "# Docker").unwrap();
+        // Create installed nested dir in target
+        let installed = tmp.path().join(".claude/skills/docker");
+        std::fs::create_dir_all(&installed).unwrap();
+        std::fs::write(installed.join("SKILL.md"), "# Docker").unwrap();
+
+        let result = find_untracked(&manifest, tmp.path()).unwrap();
+        assert!(
+            result.is_empty(),
+            "local dir skill should not be flagged as untracked, got: {:?}",
+            result.iter().map(|f| &f.path).collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -77,7 +77,7 @@ pub struct UntrackedFile {
     pub is_dir: bool,
 }
 
-pub fn covered_paths(manifest: &Manifest, repo_root: &Path) -> HashSet<PathBuf> {
+fn covered_paths(manifest: &Manifest, repo_root: &Path) -> HashSet<PathBuf> {
     let mut covered = HashSet::new();
     for_each_local_adapter(manifest, repo_root, |adapter, ctx| {
         for entry in manifest
@@ -189,7 +189,7 @@ impl<'a> DirScanner<'a> {
     }
 
     fn into_sorted(mut self) -> Vec<UntrackedFile> {
-        self.items.sort_by(|a, b| a.path.cmp(&b.path));
+        self.items.sort_unstable_by(|a, b| a.path.cmp(&b.path));
         self.items
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -493,3 +493,91 @@ fn resolve_abort_clears_conflict() {
         "conflict file should be cleared after --abort"
     );
 }
+
+// ---------------------------------------------------------------------------
+// validate --strict / status --untracked (untracked file detection)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_warns_on_untracked_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(
+        root.join("Skillfile"),
+        "install  claude-code  local\n\
+         github  agent  tracked  owner/repo  agents/tracked.md\n",
+    )
+    .unwrap();
+
+    // Create an untracked agent file alongside the tracked one
+    let agents = root.join(".claude/agents");
+    std::fs::create_dir_all(&agents).unwrap();
+    std::fs::write(agents.join("tracked.md"), "# Tracked").unwrap();
+    std::fs::write(agents.join("rogue.md"), "# Rogue").unwrap();
+
+    // Without --strict: succeeds but warns on stderr
+    let output = sf(root)
+        .arg("validate")
+        .output()
+        .expect("failed to execute");
+    assert!(output.status.success(), "validate should still pass");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("untracked"),
+        "should warn about untracked files, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("rogue.md"),
+        "warning should mention the file, got: {stderr}"
+    );
+}
+
+#[test]
+fn validate_strict_fails_on_untracked_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(root.join("Skillfile"), "install  claude-code  local\n").unwrap();
+
+    let agents = root.join(".claude/agents");
+    std::fs::create_dir_all(&agents).unwrap();
+    std::fs::write(agents.join("rogue.md"), "# Rogue").unwrap();
+
+    sf(root).args(["validate", "--strict"]).assert().failure();
+}
+
+#[test]
+fn status_untracked_shows_section() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(root.join("Skillfile"), "install  claude-code  local\n").unwrap();
+
+    let skills = root.join(".claude/skills");
+    std::fs::create_dir_all(skills.join("docker")).unwrap();
+
+    sf(root)
+        .args(["status", "--untracked"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Untracked:"))
+        .stdout(predicate::str::contains("docker"));
+}
+
+#[test]
+fn status_without_untracked_flag_hides_section() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(root.join("Skillfile"), "install  claude-code  local\n").unwrap();
+
+    let skills = root.join(".claude/skills");
+    std::fs::create_dir_all(skills.join("docker")).unwrap();
+
+    sf(root)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Untracked:").not());
+}


### PR DESCRIPTION
**SUMMARY**
Detect files in install target directories not covered by any Skillfile entry. Surfaces untracked files as warnings in `validate`, as errors with `validate --strict`, and as an opt-in section in `status --untracked`. Includes type-safe `UntrackedKind` enum, false-positive fixes for flat-deployed and local directory entries, and post-review cleanup.

**RATIONALE**
Users who create skills by hand (e.g. `.claude/skills/docker/`) but forget to declare them in the Skillfile leave teammates without access after cloning. Ghost files also linger after `skillfile remove`. This feature closes the "source of truth" gap: the Skillfile now reports what it does and does not manage. The `--strict` flag enables CI enforcement for teams that require all skills to be declared.

**CHANGES**
- `crates/deploy/src/paths.rs`: add `UntrackedFile` struct with typed `UntrackedKind` enum (`File`/`Directory`) and `suffix()` method, `covered_paths()` (private), `find_untracked()`, `DirScanner`, `ScanSpec`, `for_each_local_adapter()` helper, `is_local_dir` helper that checks the filesystem mirroring the deploy code's `req.source.is_dir()` pattern. Scans all local install targets (not just the first). Lenient mode: extra files inside managed nested dirs are not flagged. `entry_covered_paths` checks `is_dir_entry(entry) || is_local_dir(entry, repo_root)` to detect directory entries regardless of source type. For flat-mode dir entries, calls `adapter.installed_dir_files()` to cover the individual deployed file paths instead of the parent directory. `DirScanner::into_sorted` uses `sort_unstable_by` to match codebase convention. 17 new unit tests plus 2 false-positive regression tests (`flat_agent_dir_entry_no_false_positives`, `local_dir_skill_not_false_positive`).
- `crates/cli/src/commands/validate.rs`: add `print_untracked_warnings` presentation function (replaces removed `check_untracked` middle-man that mixed validation with formatting). `cmd_validate` calls `find_untracked` directly. Wire `--strict` flag. Warnings print to stderr, `--strict` promotes to errors and exits non-zero. Summary line appends `(N untracked)`. 3 new unit tests.
- `crates/cli/src/commands/status.rs`: add `--untracked` flag and `print_untracked()`. Appends an "Untracked:" section when flag is set. Uses `f.kind.suffix()` instead of inline bool check.
- `crates/cli/src/main.rs`: add `--strict` to `Validate`, `--untracked` to `Status` clap definitions.
- `tests/cli.rs`: 4 new functional tests covering `validate` warnings, `validate --strict` failure, `status --untracked` output, and the negative case (no flag hides section).
- `roadmap.md`: replace old untracked detection entry with full adversarial-reviewed spec. Remove completed "dirty change tracking" and "strip doc comments" entries from the idea pool.
