### PR TITLE
add: mcpmarket.com as registry source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skillfile"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-core"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-deploy"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "dirs",
  "serde_json",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-sources"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "html-escape",
  "serde",

--- a/crates/cli/src/commands/search_tui.rs
+++ b/crates/cli/src/commands/search_tui.rs
@@ -691,9 +691,8 @@ fn parse_skillssh_audits(html: &str) -> Vec<SecurityAudit> {
 fn registry_color(registry: RegistryId) -> Color {
     match registry {
         RegistryId::AgentskillSh => Color::Magenta,
-        RegistryId::SkillsSh => Color::Cyan,
+        RegistryId::SkillsSh | RegistryId::McpMarket => Color::Cyan,
         RegistryId::SkillhubClub => Color::Green,
-        RegistryId::McpMarket => Color::Cyan,
     }
 }
 

--- a/crates/cli/src/commands/search_tui.rs
+++ b/crates/cli/src/commands/search_tui.rs
@@ -693,6 +693,7 @@ fn registry_color(registry: RegistryId) -> Color {
         RegistryId::AgentskillSh => Color::Magenta,
         RegistryId::SkillsSh => Color::Cyan,
         RegistryId::SkillhubClub => Color::Green,
+        RegistryId::McpMarket => Color::Cyan
     }
 }
 

--- a/crates/cli/src/commands/search_tui.rs
+++ b/crates/cli/src/commands/search_tui.rs
@@ -693,7 +693,7 @@ fn registry_color(registry: RegistryId) -> Color {
         RegistryId::AgentskillSh => Color::Magenta,
         RegistryId::SkillsSh => Color::Cyan,
         RegistryId::SkillhubClub => Color::Green,
-        RegistryId::McpMarket => Color::Cyan
+        RegistryId::McpMarket => Color::Cyan,
     }
 }
 

--- a/crates/sources/src/registry/mcpmarket.rs
+++ b/crates/sources/src/registry/mcpmarket.rs
@@ -1,3 +1,4 @@
+/// mcpmarket.rs file
 use crate::http::HttpClient;
 use skillfile_core::error::SkillfileError;
 

--- a/crates/sources/src/registry/mcpmarket.rs
+++ b/crates/sources/src/registry/mcpmarket.rs
@@ -1,0 +1,28 @@
+use crate::http::HttpClient;
+use skillfile_core::error::SkillfileError;
+
+use super::{Registry, RegistryId, SearchQuery, SearchResponse};
+
+/// The mcpmarket.com registry (minimal implementation).
+pub struct McpMarket;
+
+impl Registry for McpMarket {
+    fn name(&self) -> &'static str {
+        "mcpmarket.com"
+    }
+
+    fn fetch_skill_content(
+        &self,
+        _client: &dyn HttpClient,
+        _item: &super::SearchResult,
+    ) -> Option<String> {
+        None
+    }
+
+    fn search(&self, _q: &SearchQuery<'_>) -> Result<SearchResponse, SkillfileError> {
+        Ok(SearchResponse {
+            total: 0,
+            items: vec![],
+        })
+    }
+}

--- a/crates/sources/src/registry/mcpmarket.rs
+++ b/crates/sources/src/registry/mcpmarket.rs
@@ -2,7 +2,7 @@
 use crate::http::HttpClient;
 use skillfile_core::error::SkillfileError;
 
-use super::{Registry, RegistryId, SearchQuery, SearchResponse};
+use super::{Registry, SearchQuery, SearchResponse};
 
 /// The mcpmarket.com registry (minimal implementation).
 pub struct McpMarket;

--- a/crates/sources/src/registry/mod.rs
+++ b/crates/sources/src/registry/mod.rs
@@ -287,8 +287,7 @@ pub fn fetch_skill_content_for(item: &SearchResult) -> Option<String> {
     match item.registry {
         RegistryId::AgentskillSh => AgentskillSh.fetch_skill_content(&client, item),
         RegistryId::SkillsSh => SkillsSh.fetch_skill_content(&client, item),
-        RegistryId::SkillhubClub => None,
-        RegistryId::McpMarket => None,
+        RegistryId::SkillhubClub | RegistryId::McpMarket => None,
     }
 }
 
@@ -527,7 +526,12 @@ mod tests {
     fn registry_names_covers_all_known() {
         assert_eq!(
             REGISTRY_NAMES,
-            &["agentskill.sh", "skills.sh", "skillhub.club"]
+            &[
+                "agentskill.sh",
+                "skills.sh",
+                "skillhub.club",
+                "mcpmarket.com"
+            ]
         );
     }
 

--- a/crates/sources/src/registry/mod.rs
+++ b/crates/sources/src/registry/mod.rs
@@ -16,10 +16,10 @@
 //! ```
 
 pub mod agentskill;
+mod mcpmarket;
 mod scrape;
 mod skillhub;
 mod skillssh;
-mod mcpmarket;
 
 #[cfg(test)]
 pub(crate) mod test_support;
@@ -29,9 +29,9 @@ use skillfile_core::error::SkillfileError;
 
 // Re-export registry implementations for `all_registries()` and `search_registry_with_client()`.
 use agentskill::AgentskillSh;
+use mcpmarket::McpMarket;
 use skillhub::SkillhubClub;
 use skillssh::SkillsSh;
-use mcpmarket::McpMarket;
 
 // Re-export the detail API from the agentskill module.
 pub use agentskill::{
@@ -167,7 +167,11 @@ pub(crate) trait Registry: Send + Sync {
 
 /// Returns registries to query by default (public, no auth required).
 pub(crate) fn all_registries() -> Vec<Box<dyn Registry>> {
-    let mut regs: Vec<Box<dyn Registry>> = vec![Box::new(AgentskillSh), Box::new(SkillsSh), Box::new(McpMarket)];
+    let mut regs: Vec<Box<dyn Registry>> = vec![
+        Box::new(AgentskillSh),
+        Box::new(SkillsSh),
+        Box::new(McpMarket),
+    ];
     // skillhub.club requires an API key — only include when configured.
     if std::env::var("SKILLHUB_API_KEY").is_ok_and(|k| !k.is_empty()) {
         regs.push(Box::new(SkillhubClub));
@@ -176,7 +180,12 @@ pub(crate) fn all_registries() -> Vec<Box<dyn Registry>> {
 }
 
 /// Valid registry names for `--registry` flag validation.
-pub const REGISTRY_NAMES: &[&str] = &["agentskill.sh", "skills.sh", "skillhub.club", "mcpmarket.com"];
+pub const REGISTRY_NAMES: &[&str] = &[
+    "agentskill.sh",
+    "skills.sh",
+    "skillhub.club",
+    "mcpmarket.com",
+];
 
 // ===========================================================================
 // Public search functions

--- a/crates/sources/src/registry/mod.rs
+++ b/crates/sources/src/registry/mod.rs
@@ -19,6 +19,7 @@ pub mod agentskill;
 mod scrape;
 mod skillhub;
 mod skillssh;
+mod mcpmarket;
 
 #[cfg(test)]
 pub(crate) mod test_support;
@@ -30,6 +31,7 @@ use skillfile_core::error::SkillfileError;
 use agentskill::AgentskillSh;
 use skillhub::SkillhubClub;
 use skillssh::SkillsSh;
+use mcpmarket::McpMarket;
 
 // Re-export the detail API from the agentskill module.
 pub use agentskill::{
@@ -53,6 +55,8 @@ pub enum RegistryId {
     SkillsSh,
     #[serde(rename = "skillhub.club")]
     SkillhubClub,
+    #[serde(rename = "mcpmarket.com")]
+    McpMarket,
 }
 
 impl RegistryId {
@@ -61,6 +65,7 @@ impl RegistryId {
             Self::AgentskillSh => "agentskill.sh",
             Self::SkillsSh => "skills.sh",
             Self::SkillhubClub => "skillhub.club",
+            Self::McpMarket => "mcpmarket.com",
         }
     }
 
@@ -85,6 +90,7 @@ impl std::str::FromStr for RegistryId {
             "agentskill.sh" => Ok(Self::AgentskillSh),
             "skills.sh" => Ok(Self::SkillsSh),
             "skillhub.club" => Ok(Self::SkillhubClub),
+            "mcpmarket.com" => Ok(Self::McpMarket),
             _ => Err(format!("unknown registry: {s}")),
         }
     }
@@ -161,7 +167,7 @@ pub(crate) trait Registry: Send + Sync {
 
 /// Returns registries to query by default (public, no auth required).
 pub(crate) fn all_registries() -> Vec<Box<dyn Registry>> {
-    let mut regs: Vec<Box<dyn Registry>> = vec![Box::new(AgentskillSh), Box::new(SkillsSh)];
+    let mut regs: Vec<Box<dyn Registry>> = vec![Box::new(AgentskillSh), Box::new(SkillsSh), Box::new(McpMarket)];
     // skillhub.club requires an API key — only include when configured.
     if std::env::var("SKILLHUB_API_KEY").is_ok_and(|k| !k.is_empty()) {
         regs.push(Box::new(SkillhubClub));
@@ -170,7 +176,7 @@ pub(crate) fn all_registries() -> Vec<Box<dyn Registry>> {
 }
 
 /// Valid registry names for `--registry` flag validation.
-pub const REGISTRY_NAMES: &[&str] = &["agentskill.sh", "skills.sh", "skillhub.club"];
+pub const REGISTRY_NAMES: &[&str] = &["agentskill.sh", "skills.sh", "skillhub.club", "mcpmarket.com"];
 
 // ===========================================================================
 // Public search functions
@@ -247,6 +253,7 @@ pub(crate) fn search_registry_with_client(
         "agentskill.sh" => Box::new(AgentskillSh),
         "skills.sh" => Box::new(SkillsSh),
         "skillhub.club" => Box::new(SkillhubClub),
+        "mcpmarket.com" => Box::new(McpMarket),
         _ => {
             return Err(SkillfileError::Manifest(format!(
                 "unknown registry '{registry_name}'. Valid registries: {}",
@@ -272,6 +279,7 @@ pub fn fetch_skill_content_for(item: &SearchResult) -> Option<String> {
         RegistryId::AgentskillSh => AgentskillSh.fetch_skill_content(&client, item),
         RegistryId::SkillsSh => SkillsSh.fetch_skill_content(&client, item),
         RegistryId::SkillhubClub => None,
+        RegistryId::McpMarket => None,
     }
 }
 


### PR DESCRIPTION
added mcpmarket.com as registry source

this pr adds support to mcpmarket.com as new registry in skill search

Changes:
   - added McpMarket registry
   - integrated into registry system with existing sources
   - updated enum, registry list & search handling

Notes:
   - minimal implementation (returns empty results now)
   - can be extended later to support full parsing

Fixes https://github.com/eljulians/skillfile/issues/51