### PR TITLE
Fix install target drift and nested skill cleanup

### DIFF
--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -537,6 +537,11 @@ mod tests {
     }
 
     #[test]
+    fn hint_for_antigravity_adapter() {
+        assert_eq!(supported_types_hint("antigravity"), "skill only");
+    }
+
+    #[test]
     fn hint_for_unknown_adapter() {
         assert_eq!(supported_types_hint("nonexistent"), "");
     }

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -6,13 +6,13 @@ use skillfile_core::lock::{lock_key, read_lock};
 use skillfile_core::models::{short_sha, EntityType, Entry, LockEntry, Manifest, SourceFields};
 use skillfile_core::parser::MANIFEST_NAME;
 use skillfile_core::patch::{has_dir_patch, has_patch, walkdir};
-use skillfile_deploy::paths::{installed_dir_files, installed_path};
+use skillfile_deploy::paths::{installed_dir_file_sets, installed_paths};
 use skillfile_sources::strategy::{content_file, is_dir_entry, meta_sha};
 use skillfile_sources::sync::vendor_dir_for;
 
 fn is_cache_file_modified(
-    cache_file: &std::path::PathBuf,
-    vdir: &std::path::PathBuf,
+    cache_file: &Path,
+    vdir: &Path,
     installed: &HashMap<String, std::path::PathBuf>,
 ) -> Result<bool, ()> {
     let filename = cache_file
@@ -34,23 +34,41 @@ fn check_dir_files_modified(
     manifest: &Manifest,
     repo_root: &Path,
 ) -> Result<bool, ()> {
-    let installed = installed_dir_files(entry, manifest, repo_root).map_err(|_| ())?;
-    if installed.is_empty() {
-        return Ok(false);
-    }
     // If pinned, the installed files are expected to differ from cache
     if has_dir_patch(entry, repo_root) {
+        return Ok(false);
+    }
+    let installed_sets = installed_dir_file_sets(entry, manifest, repo_root).map_err(|_| ())?;
+    if installed_sets.iter().all(HashMap::is_empty) {
         return Ok(false);
     }
     let vdir = vendor_dir_for(entry, repo_root);
     if !vdir.is_dir() {
         return Ok(false);
     }
-    for cache_file in walkdir(&vdir) {
-        if cache_file.file_name().is_none_or(|n| n == ".meta") {
+    let cache_files: Vec<_> = walkdir(&vdir)
+        .into_iter()
+        .filter(|cache_file| cache_file.file_name().is_some_and(|n| n != ".meta"))
+        .collect();
+
+    for installed in &installed_sets {
+        if installed.is_empty() {
             continue;
         }
-        if is_cache_file_modified(&cache_file, &vdir, &installed)? {
+        if installed_set_modified(&cache_files, &vdir, installed)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn installed_set_modified(
+    cache_files: &[std::path::PathBuf],
+    vdir: &Path,
+    installed: &HashMap<String, std::path::PathBuf>,
+) -> Result<bool, ()> {
+    for cache_file in cache_files {
+        if is_cache_file_modified(cache_file, vdir, installed)? {
             return Ok(true);
         }
     }
@@ -66,8 +84,12 @@ fn check_single_file_modified(
     manifest: &Manifest,
     repo_root: &Path,
 ) -> Result<bool, ()> {
-    let dest = installed_path(entry, manifest, repo_root).map_err(|_| ())?;
-    if !dest.exists() {
+    // If pinned, the installed file is expected to differ from cache
+    if has_patch(entry, repo_root) {
+        return Ok(false);
+    }
+    let installed_paths = installed_paths(entry, manifest, repo_root).map_err(|_| ())?;
+    if installed_paths.iter().all(|path| !path.exists()) {
         return Ok(false);
     }
     let vdir = vendor_dir_for(entry, repo_root);
@@ -79,13 +101,17 @@ fn check_single_file_modified(
     if !cache_file.exists() {
         return Ok(false);
     }
-    // If pinned, the installed file is expected to differ from cache
-    if has_patch(entry, repo_root) {
-        return Ok(false);
-    }
     let cache_text = std::fs::read_to_string(&cache_file).map_err(|_| ())?;
-    let installed_text = std::fs::read_to_string(&dest).map_err(|_| ())?;
-    Ok(installed_text != cache_text)
+    for installed_path in installed_paths {
+        if !installed_path.exists() {
+            continue;
+        }
+        let installed_text = std::fs::read_to_string(&installed_path).map_err(|_| ())?;
+        if installed_text != cache_text {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Check if an installed file differs from cache (local only, no network).
@@ -863,6 +889,103 @@ mod tests {
         assert!(
             out.contains("1 modified"),
             "expected modified flag, got: {out}"
+        );
+    }
+
+    #[test]
+    fn modified_detects_second_install_target_for_single_file_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "my-skill".into(),
+            source: SourceFields::Github {
+                owner_repo: "owner/repo".into(),
+                path_in_repo: "skills/my-skill.md".into(),
+                ref_: "main".into(),
+            },
+        };
+        let manifest = Manifest {
+            entries: vec![entry.clone()],
+            install_targets: vec![
+                claude_local_target(),
+                InstallTarget {
+                    adapter: "copilot".into(),
+                    scope: Scope::Local,
+                },
+            ],
+        };
+
+        write_lock(
+            dir.path(),
+            &serde_json::json!({"github/skill/my-skill": {"sha": SHA, "raw_url": "https://example.com"}}),
+        );
+        write_meta(
+            dir.path(),
+            &VendorEntry {
+                entity_type: "skill",
+                name: "my-skill",
+            },
+            SHA,
+        );
+        write_vendor_content(
+            dir.path(),
+            &VendorFile {
+                entry: &VendorEntry {
+                    entity_type: "skill",
+                    name: "my-skill",
+                },
+                filename: "my-skill.md",
+            },
+            ORIGINAL,
+        );
+        let installed = dir.path().join(".github/skills/my-skill");
+        std::fs::create_dir_all(&installed).unwrap();
+        std::fs::write(installed.join("SKILL.md"), MODIFIED).unwrap();
+
+        assert!(is_modified_local(&entry, &manifest, dir.path()));
+        let out = format_summary(&manifest, dir.path());
+        assert!(
+            out.contains("1 modified"),
+            "expected second-target modification to count, got: {out}"
+        );
+    }
+
+    #[test]
+    fn modified_detects_second_install_target_for_directory_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        write_lock(
+            dir.path(),
+            &serde_json::json!({"github/skill/my-dir": {"sha": SHA, "raw_url": "https://example.com"}}),
+        );
+        let vdir = dir.path().join(".skillfile/cache/skills/my-dir");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(vdir.join("tool.md"), ORIGINAL).unwrap();
+        std::fs::write(
+            vdir.join(".meta"),
+            serde_json::json!({"sha": SHA}).to_string(),
+        )
+        .unwrap();
+        let installed = dir.path().join(".github/skills/my-dir");
+        std::fs::create_dir_all(&installed).unwrap();
+        std::fs::write(installed.join("tool.md"), MODIFIED).unwrap();
+
+        let manifest = Manifest {
+            entries: dir_skill_manifest().entries,
+            install_targets: vec![
+                claude_local_target(),
+                InstallTarget {
+                    adapter: "copilot".into(),
+                    scope: Scope::Local,
+                },
+            ],
+        };
+        let entry = &manifest.entries[0];
+
+        assert!(is_modified_local(entry, &manifest, dir.path()));
+        let out = format_summary(&manifest, dir.path());
+        assert!(
+            out.contains("1 modified"),
+            "expected second-target directory modification to count, got: {out}"
         );
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,9 +6,10 @@ use skillfile::config;
 use std::path::{Path, PathBuf};
 use std::process;
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use skillfile_core::error::SkillfileError;
+use skillfile_deploy::adapter::known_adapters;
 
 /// Read entry names from the Skillfile in the current directory for shell completion.
 fn complete_entry_names() -> Vec<CompletionCandidate> {
@@ -32,23 +33,32 @@ fn parse_entity_type(s: &str) -> Result<String, String> {
     }
 }
 
-#[derive(Parser)]
-#[command(
-    name = "skillfile",
-    about = "Tool-agnostic AI skill & agent manager",
-    long_about = "\
+fn cli_long_about() -> String {
+    let supported = known_adapters().join(", ");
+    format!(
+        "\
 Tool-agnostic AI skill & agent manager - the Brewfile for your AI tooling.
 
 Declare skills and agents in a Skillfile, lock them to exact SHAs, and deploy
 to any supported platform with a single command.
 
-Supported platforms: claude-code, codex, copilot, cursor, factory,
-gemini-cli, opencode, windsurf.
+Supported platforms: {supported}.
 
 Quick start:
   skillfile init                          # configure platforms
   skillfile add github skill owner/repo path/to/SKILL.md
-  skillfile install                       # fetch + deploy",
+  skillfile install                       # fetch + deploy"
+    )
+}
+
+fn cli_command() -> clap::Command {
+    Cli::command().long_about(cli_long_about())
+}
+
+#[derive(Parser)]
+#[command(
+    name = "skillfile",
+    about = "Tool-agnostic AI skill & agent manager",
     version,
     after_long_help = "\
 ENVIRONMENT VARIABLES:
@@ -526,8 +536,8 @@ fn run() -> Result<(), SkillfileError> {
     // populated by `github_token()`). This runs once; subsequent calls are no-ops.
     skillfile_sources::http::set_config_token(crate::config::read_config_token());
 
-    let cli = match Cli::try_parse() {
-        Ok(cli) => cli,
+    let cli = match cli_command().try_get_matches() {
+        Ok(matches) => Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit()),
         Err(e)
             if e.kind() == clap::error::ErrorKind::DisplayHelp
                 || e.kind() == clap::error::ErrorKind::DisplayVersion =>
@@ -548,7 +558,7 @@ fn run() -> Result<(), SkillfileError> {
 fn main() {
     // Handle dynamic shell completion requests before any other initialization.
     // Shells call the binary with COMPLETE=<shell> to get completions at runtime.
-    clap_complete::CompleteEnv::with_factory(Cli::command).complete();
+    clap_complete::CompleteEnv::with_factory(cli_command).complete();
 
     // Spawn background update check (non-blocking)
     let update_rx = update_check::should_check().then(update_check::spawn_check);
@@ -583,11 +593,20 @@ mod tests {
 
     fn completions_non_empty(shell: clap_complete::Shell) {
         let mut buf = Vec::new();
-        clap_complete::generate(shell, &mut Cli::command(), "skillfile", &mut buf);
+        clap_complete::generate(shell, &mut cli_command(), "skillfile", &mut buf);
         assert!(
             !buf.is_empty(),
             "completions for {shell:?} should produce output"
         );
+    }
+
+    #[test]
+    fn long_about_lists_dynamic_supported_platforms() {
+        let long_about = cli_command().get_long_about().unwrap().to_string();
+        assert!(long_about.contains("antigravity"));
+        for name in known_adapters() {
+            assert!(long_about.contains(name), "missing adapter: {name}");
+        }
     }
 
     #[test]

--- a/crates/deploy/src/adapter.rs
+++ b/crates/deploy/src/adapter.rs
@@ -111,6 +111,14 @@ impl FileSystemAdapter {
             .get(&entity_type)
             .is_some_and(|c| c.dir_mode == DirInstallMode::Flat)
     }
+
+    fn single_file_install_path(&self, entry: &Entry, target_dir: &Path) -> PathBuf {
+        if self.is_flat_mode(entry.entity_type) {
+            target_dir.join(format!("{}.md", entry.name))
+        } else {
+            target_dir.join(&entry.name).join("SKILL.md")
+        }
+    }
 }
 
 impl PlatformAdapter for FileSystemAdapter {
@@ -167,13 +175,8 @@ impl PlatformAdapter for FileSystemAdapter {
 
         let dest = if is_dir {
             target_dir.join(&req.entry.name)
-        } else if self.is_flat_mode(req.entry.entity_type) {
-            // Single files in flat mode deploy as {name}.md
-            let name = &req.entry.name;
-            target_dir.join(format!("{name}.md"))
         } else {
-            // Single files in nested mode deploy as {name}/SKILL.md
-            target_dir.join(&req.entry.name).join("SKILL.md")
+            self.single_file_install_path(req.entry, &target_dir)
         };
 
         if !place_file(
@@ -188,10 +191,9 @@ impl PlatformAdapter for FileSystemAdapter {
             return HashMap::new();
         }
 
-        // Migration: if we just deployed a single-file skill as {name}/SKILL.md (nested mode),
-        // remove any leftover flat {name}.md from a previous install to prevent agents that
-        // do broad directory scans from loading both the old and new versions simultaneously.
-        if !is_dir && !self.is_flat_mode(req.entry.entity_type) {
+        // Migration: nested-mode installs may leave behind a legacy flat {name}.md from an older
+        // layout. Remove it after a successful install to avoid duplicate skill loading.
+        if !self.is_flat_mode(req.entry.entity_type) {
             remove_orphan_flat_file(&req.entry.name, &target_dir);
         }
 
@@ -205,15 +207,7 @@ impl PlatformAdapter for FileSystemAdapter {
 
     fn installed_path(&self, entry: &Entry, ctx: &AdapterScope<'_>) -> PathBuf {
         let target_dir = self.target_dir(entry.entity_type, ctx);
-
-        if self.is_flat_mode(entry.entity_type) {
-            // Flat mode: skill is at {target}/name.md
-            let name = &entry.name;
-            target_dir.join(format!("{name}.md"))
-        } else {
-            // Nested mode: skill is at {target}/name/SKILL.md
-            target_dir.join(&entry.name).join("SKILL.md")
-        }
+        self.single_file_install_path(entry, &target_dir)
     }
 
     fn installed_dir_files(
@@ -1457,6 +1451,42 @@ mod tests {
         });
         assert!(result.contains_key("SKILL.md"));
         assert!(result.contains_key("examples.md"));
+    }
+
+    #[test]
+    fn deploy_entry_nested_mode_removes_legacy_flat_file_for_directory_sources() {
+        use skillfile_core::models::{EntityType, SourceFields};
+
+        let dir = tempfile::tempdir().unwrap();
+        let source_dir = dir.path().join(".skillfile/cache/skills/my-skill");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::write(source_dir.join("SKILL.md"), "# Skill\n").unwrap();
+
+        let target_dir = dir.path().join(".claude/skills");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join("my-skill.md"), "# Legacy flat\n").unwrap();
+
+        let entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "my-skill".into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: "skills/my-skill".into(),
+                ref_: "main".into(),
+            },
+        };
+        let a = adapters().get("claude-code").unwrap();
+        let result = a.deploy_entry(&DeployRequest {
+            entry: &entry,
+            source: &source_dir,
+            scope: Scope::Local,
+            repo_root: dir.path(),
+            opts: &InstallOptions::default(),
+        });
+
+        assert!(result.contains_key("SKILL.md"));
+        assert!(target_dir.join("my-skill/SKILL.md").exists());
+        assert!(!target_dir.join("my-skill.md").exists());
     }
 
     // -- antigravity adapter --

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -33,6 +33,27 @@ pub fn installed_path(
     Ok(adapter.installed_path(entry, &ctx))
 }
 
+/// Installed paths for a single-file entry across all install targets.
+pub fn installed_paths(
+    entry: &Entry,
+    manifest: &Manifest,
+    repo_root: &Path,
+) -> Result<Vec<PathBuf>, SkillfileError> {
+    let mut paths = Vec::new();
+    for target in &manifest.install_targets {
+        let adapter = adapter_for(target)?;
+        if !adapter.supports(entry.entity_type) {
+            continue;
+        }
+        let ctx = AdapterScope {
+            scope: target.scope,
+            repo_root,
+        };
+        paths.push(adapter.installed_path(entry, &ctx));
+    }
+    Ok(paths)
+}
+
 /// Installed files for a directory entry (first install target).
 pub fn installed_dir_files(
     entry: &Entry,
@@ -45,6 +66,27 @@ pub fn installed_dir_files(
         repo_root,
     };
     Ok(adapter.installed_dir_files(entry, &ctx))
+}
+
+/// Installed file maps for a directory entry across all install targets.
+pub fn installed_dir_file_sets(
+    entry: &Entry,
+    manifest: &Manifest,
+    repo_root: &Path,
+) -> Result<Vec<HashMap<String, PathBuf>>, SkillfileError> {
+    let mut file_sets = Vec::new();
+    for target in &manifest.install_targets {
+        let adapter = adapter_for(target)?;
+        if !adapter.supports(entry.entity_type) {
+            continue;
+        }
+        let ctx = AdapterScope {
+            scope: target.scope,
+            repo_root,
+        };
+        file_sets.push(adapter.installed_dir_files(entry, &ctx));
+    }
+    Ok(file_sets)
 }
 
 #[must_use]
@@ -73,10 +115,15 @@ fn first_target(manifest: &Manifest) -> Result<&'static dyn PlatformAdapter, Ski
             "no install targets configured — run `skillfile install` first".into(),
         ));
     }
-    let t = &manifest.install_targets[0];
+    adapter_for(&manifest.install_targets[0])
+}
+
+fn adapter_for(
+    target: &skillfile_core::models::InstallTarget,
+) -> Result<&'static dyn PlatformAdapter, SkillfileError> {
     adapters()
-        .get(&t.adapter)
-        .ok_or_else(|| SkillfileError::Manifest(format!("unknown adapter '{}'", t.adapter)))
+        .get(&target.adapter)
+        .ok_or_else(|| SkillfileError::Manifest(format!("unknown adapter '{}'", target.adapter)))
 }
 
 #[cfg(test)]
@@ -176,6 +223,38 @@ mod tests {
     }
 
     #[test]
+    fn installed_paths_returns_all_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "test".into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: "skills/test.md".into(),
+                ref_: "main".into(),
+            },
+        };
+        let manifest = Manifest {
+            entries: vec![entry.clone()],
+            install_targets: vec![
+                InstallTarget {
+                    adapter: "claude-code".into(),
+                    scope: Scope::Local,
+                },
+                InstallTarget {
+                    adapter: "copilot".into(),
+                    scope: Scope::Local,
+                },
+            ],
+        };
+
+        let result = installed_paths(&entry, &manifest, tmp.path()).unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&tmp.path().join(".claude/skills/test/SKILL.md")));
+        assert!(result.contains(&tmp.path().join(".github/skills/test/SKILL.md")));
+    }
+
+    #[test]
     fn installed_dir_files_no_targets() {
         let entry = Entry {
             entity_type: EntityType::Agent,
@@ -219,6 +298,43 @@ mod tests {
 
         let result = installed_dir_files(&entry, &manifest, tmp.path()).unwrap();
         assert!(result.contains_key("SKILL.md"));
+    }
+
+    #[test]
+    fn installed_dir_file_sets_returns_all_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "my-skill".into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: "skills".into(),
+                ref_: "main".into(),
+            },
+        };
+        let manifest = Manifest {
+            entries: vec![entry.clone()],
+            install_targets: vec![
+                InstallTarget {
+                    adapter: "claude-code".into(),
+                    scope: Scope::Local,
+                },
+                InstallTarget {
+                    adapter: "copilot".into(),
+                    scope: Scope::Local,
+                },
+            ],
+        };
+        let claude_dir = tmp.path().join(".claude/skills/my-skill");
+        let copilot_dir = tmp.path().join(".github/skills/my-skill");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::create_dir_all(&copilot_dir).unwrap();
+        std::fs::write(claude_dir.join("SKILL.md"), "# Skill\n").unwrap();
+        std::fs::write(copilot_dir.join("SKILL.md"), "# Skill\n").unwrap();
+
+        let result = installed_dir_file_sets(&entry, &manifest, tmp.path()).unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|files| files.contains_key("SKILL.md")));
     }
 
     #[test]


### PR DESCRIPTION
**SUMMARY**
Align install status, deployment cleanup, and CLI platform metadata with the adapter registry. This fixes stale help output, catches modified installs across all supported targets, and removes legacy flat skill files after nested installs.

**RATIONALE**
The release delta introduced two kinds of drift. Deployment and status logic still assumed a first target or an older flat skill layout, which left false negatives in `status` and duplicate installed skills after a layout migration. CLI help also hardcoded the adapter list, so adding `antigravity` updated behavior but not the public interface.

Keeping these rules in one place is the Rustacean move here: the adapter registry defines supported platforms, and adapter path policy defines where installed files live. The CLI and status code should read from those sources instead of re-encoding them.

**CHANGES**
- Refactor `crates/deploy/src/adapter.rs` to centralize single-file install path selection in `single_file_install_path()`.
- Remove legacy flat `{name}.md` orphans after any successful nested install, including directory-source installs.
- Add regression coverage for nested directory installs that migrate from flat to nested skill layout.
- Add `installed_paths()` and `installed_dir_file_sets()` to `crates/deploy/src/paths.rs` so callers can inspect all supported install targets instead of only the first one.
- Update `crates/cli/src/commands/status.rs` to detect modified single-file and directory installs across all targets.
- Add status regressions that prove modifications on a non-first target are reported in the summary.
- Refactor `crates/cli/src/main.rs` so long help and shell completion generation use a shared dynamic `clap::Command`.
- Build the supported platform list from `known_adapters()` instead of a hardcoded string, and add coverage for the dynamic help text.
- Add `antigravity` coverage in `crates/cli/src/commands/init.rs`.