### PR TITLE
Handle multi-target `diff` and `pin` consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Track AI skills and agents declaratively, like dependencies. Pin them. Patch them. Deploy everywhere.**
 
-Declare your skills in a manifest. Pinned to exact commits. Deploys to Claude Code, Cursor, Gemini, and 5 more. Customize without losing upstream updates. Search 110K+ skills from the terminal.
+Declare your skills in a manifest. Pinned to exact commits. Deploys to Claude Code, Cursor, Codex, Antigravity, and more. Customize without losing upstream updates. Search 110K+ skills from the terminal.
 
 ![demo](https://github.com/eljulians/skillfile/raw/master/docs/demo.gif)
 
@@ -91,12 +91,13 @@ skillfile resolve browser                  # three-way merge in $MERGETOOL
 
 Patches live in `.skillfile/patches/` and are committed to version control. Your whole team gets the same customizations.
 
-## 8 platforms, one manifest
+## 9 platforms, one manifest
 
 Write your `Skillfile` once. Deploy to every AI coding tool you use.
 
 | Platform | Skills | Agents | Scopes |
 |---|---|---|---|
+| **antigravity** | `.agents/skills/` | - | local, global |
 | **claude-code** | `.claude/skills/` | `.claude/agents/` | local, global |
 | **codex** | `.codex/skills/` | - | local, global |
 | **copilot** | `.github/skills/` | `.github/agents/` | local, global |

--- a/crates/cli/src/commands/diff.rs
+++ b/crates/cli/src/commands/diff.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::Write as IoWrite;
 use std::path::Path;
 
@@ -7,11 +8,26 @@ use skillfile_core::lock::{lock_key, read_lock};
 use skillfile_core::models::{short_sha, Entry};
 use skillfile_core::parser::{find_entry_in, parse_manifest, MANIFEST_NAME};
 use skillfile_core::progress;
-use skillfile_deploy::paths::{installed_dir_files, installed_path};
 use skillfile_sources::strategy::{content_file, is_dir_entry};
 use skillfile_sources::sync::vendor_dir_for;
 
+use crate::commands::installed_variants::{installed_dir_variants, installed_single_file_variants};
+use crate::commands::multi_target::{
+    format_single_file_diff, modified_dir_variants, modified_single_file_variants, SingleFileDiff,
+};
 use crate::patch::walkdir;
+
+struct DirDiffCtx<'a> {
+    entry_name: &'a str,
+    sha: &'a str,
+    target_label: &'a str,
+    cache_files: &'a BTreeMap<String, std::path::PathBuf>,
+}
+
+struct ChangedFileRef<'a> {
+    filename: &'a str,
+    installed_text: &'a str,
+}
 
 fn diff_local_single(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), SkillfileError> {
     let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
@@ -31,8 +47,8 @@ fn diff_local_single(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), S
         )));
     }
 
-    let dest = installed_path(entry, &manifest, repo_root)?;
-    if !dest.exists() {
+    let installed = installed_single_file_variants(entry, &manifest, repo_root)?;
+    if installed.is_empty() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed — run `skillfile install` first",
             entry.name
@@ -40,24 +56,22 @@ fn diff_local_single(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), S
     }
 
     let upstream = std::fs::read_to_string(&cache_file)?;
-    let installed_text = std::fs::read_to_string(&dest)?;
-
-    let diff_text = similar::TextDiff::from_lines(upstream.as_str(), installed_text.as_str());
-    let formatted = diff_text
-        .unified_diff()
-        .context_radius(3)
-        .header(
-            &format!("a/{}.md (upstream sha={})", entry.name, short_sha(sha)),
-            &format!("b/{}.md (installed)", entry.name),
-        )
-        .to_string();
-
-    if formatted.is_empty() {
+    let modified = modified_single_file_variants(&upstream, &installed);
+    if modified.is_empty() {
         println!("'{}' is clean — no local modifications", entry.name);
     } else {
         let stdout = std::io::stdout();
         let mut out = stdout.lock();
-        out.write_all(formatted.as_bytes())?;
+        for variant in modified {
+            let formatted = format_single_file_diff(&SingleFileDiff {
+                entry_name: &entry.name,
+                sha: short_sha(sha),
+                target_label: &variant.label,
+                upstream: &upstream,
+                installed_text: &variant.content,
+            });
+            out.write_all(formatted.as_bytes())?;
+        }
     }
 
     Ok(())
@@ -73,7 +87,7 @@ fn diff_local_dir(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), Skil
         )));
     }
 
-    let installed = installed_dir_files(entry, &manifest, repo_root)?;
+    let installed = installed_dir_variants(entry, &manifest, repo_root);
     if installed.is_empty() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed — run `skillfile install` first",
@@ -81,52 +95,80 @@ fn diff_local_dir(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), Skil
         )));
     }
 
+    let cache_files: BTreeMap<String, std::path::PathBuf> = walkdir(&vdir)
+        .into_iter()
+        .filter(|cache_file| cache_file.file_name().is_some_and(|name| name != ".meta"))
+        .filter_map(|cache_file| {
+            let filename = cache_file
+                .strip_prefix(&vdir)
+                .ok()
+                .and_then(|path| path.to_str())
+                .map(str::to_string)?;
+            Some((filename, cache_file))
+        })
+        .collect();
+
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    let mut any_diff = false;
+    let modified = modified_dir_variants(&cache_files, &installed)?;
 
-    for cache_file in walkdir(&vdir) {
-        if cache_file.file_name().is_some_and(|n| n == ".meta") {
-            continue;
-        }
-        let filename = match cache_file.strip_prefix(&vdir).ok().and_then(|p| p.to_str()) {
-            Some(f) => f.to_string(),
-            None => continue,
-        };
-        let Some(inst_path) = installed.get(&filename) else {
-            continue;
-        };
-        if !inst_path.exists() {
-            continue;
-        }
-
-        let original_text = std::fs::read_to_string(&cache_file)?;
-        let installed_text = std::fs::read_to_string(inst_path)?;
-        let diff_text =
-            similar::TextDiff::from_lines(original_text.as_str(), installed_text.as_str());
-        let formatted = diff_text
-            .unified_diff()
-            .context_radius(3)
-            .header(
-                &format!(
-                    "a/{}/{filename} (upstream sha={})",
-                    entry.name,
-                    short_sha(sha)
-                ),
-                &format!("b/{}/{filename} (installed)", entry.name),
-            )
-            .to_string();
-
-        if !formatted.is_empty() {
-            any_diff = true;
-            out.write_all(formatted.as_bytes())?;
-        }
-    }
-
-    if !any_diff {
+    if modified.is_empty() {
         println!("'{}' is clean — no local modifications", entry.name);
+    } else {
+        for (target_label, files) in modified {
+            let diff_ctx = DirDiffCtx {
+                entry_name: &entry.name,
+                sha: short_sha(sha),
+                target_label: &target_label,
+                cache_files: &cache_files,
+            };
+            write_dir_diff(&mut out, &diff_ctx, files)?;
+        }
     }
 
+    Ok(())
+}
+
+fn write_dir_diff(
+    out: &mut dyn IoWrite,
+    ctx: &DirDiffCtx<'_>,
+    files: BTreeMap<String, String>,
+) -> Result<(), SkillfileError> {
+    for (filename, installed_text) in files {
+        let changed = ChangedFileRef {
+            filename: &filename,
+            installed_text: &installed_text,
+        };
+        write_dir_file_diff(out, ctx, &changed)?;
+    }
+    Ok(())
+}
+
+fn write_dir_file_diff(
+    out: &mut dyn IoWrite,
+    ctx: &DirDiffCtx<'_>,
+    changed: &ChangedFileRef<'_>,
+) -> Result<(), SkillfileError> {
+    let Some(cache_file) = ctx.cache_files.get(changed.filename) else {
+        return Ok(());
+    };
+    let original_text = std::fs::read_to_string(cache_file)?;
+    let diff_text = similar::TextDiff::from_lines(original_text.as_str(), changed.installed_text);
+    let formatted = diff_text
+        .unified_diff()
+        .context_radius(3)
+        .header(
+            &format!(
+                "a/{}/{} (upstream sha={})",
+                ctx.entry_name, changed.filename, ctx.sha
+            ),
+            &format!(
+                "b/{}/{} (installed: {})",
+                ctx.entry_name, changed.filename, ctx.target_label
+            ),
+        )
+        .to_string();
+    out.write_all(formatted.as_bytes())?;
     Ok(())
 }
 

--- a/crates/cli/src/commands/installed_variants.rs
+++ b/crates/cli/src/commands/installed_variants.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use skillfile_core::error::SkillfileError;
+use skillfile_core::models::{Entry, Manifest};
+use skillfile_deploy::adapter::{adapters, AdapterScope};
+
+pub(crate) struct SingleFileVariant {
+    pub(crate) label: String,
+    pub(crate) content: String,
+}
+
+pub(crate) struct DirVariant {
+    pub(crate) label: String,
+    pub(crate) files: HashMap<String, std::path::PathBuf>,
+}
+
+pub(crate) fn installed_single_file_variants(
+    entry: &Entry,
+    manifest: &Manifest,
+    repo_root: &Path,
+) -> Result<Vec<SingleFileVariant>, SkillfileError> {
+    let all_adapters = adapters();
+    let mut variants = Vec::new();
+
+    for target in &manifest.install_targets {
+        let Some(adapter) = all_adapters.get(&target.adapter) else {
+            continue;
+        };
+        if !adapter.supports(entry.entity_type) {
+            continue;
+        }
+
+        let path = adapter.installed_path(
+            entry,
+            &AdapterScope {
+                scope: target.scope,
+                repo_root,
+            },
+        );
+        if !path.exists() {
+            continue;
+        }
+
+        variants.push(SingleFileVariant {
+            label: target.to_string(),
+            content: std::fs::read_to_string(path)?,
+        });
+    }
+
+    Ok(variants)
+}
+
+pub(crate) fn installed_dir_variants(
+    entry: &Entry,
+    manifest: &Manifest,
+    repo_root: &Path,
+) -> Vec<DirVariant> {
+    let all_adapters = adapters();
+    let mut variants = Vec::new();
+
+    for target in &manifest.install_targets {
+        let Some(adapter) = all_adapters.get(&target.adapter) else {
+            continue;
+        };
+        if !adapter.supports(entry.entity_type) {
+            continue;
+        }
+
+        let files = adapter.installed_dir_files(
+            entry,
+            &AdapterScope {
+                scope: target.scope,
+                repo_root,
+            },
+        );
+        if files.is_empty() {
+            continue;
+        }
+
+        variants.push(DirVariant {
+            label: target.to_string(),
+            files,
+        });
+    }
+
+    variants
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -3,6 +3,8 @@ pub mod add_tui;
 pub mod diff;
 pub mod format;
 pub mod init;
+mod installed_variants;
+mod multi_target;
 pub mod pin;
 pub mod remove;
 pub mod resolve;

--- a/crates/cli/src/commands/multi_target.rs
+++ b/crates/cli/src/commands/multi_target.rs
@@ -1,0 +1,82 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use skillfile_core::error::SkillfileError;
+
+use crate::commands::installed_variants::{DirVariant, SingleFileVariant};
+
+pub(crate) type DirContentMap = BTreeMap<String, String>;
+
+pub(crate) struct SingleFileDiff<'a> {
+    pub(crate) entry_name: &'a str,
+    pub(crate) sha: &'a str,
+    pub(crate) target_label: &'a str,
+    pub(crate) upstream: &'a str,
+    pub(crate) installed_text: &'a str,
+}
+
+pub(crate) fn divergent_targets_message(entry_name: &str, labels: &[String]) -> SkillfileError {
+    SkillfileError::Manifest(format!(
+        "'{entry_name}' has divergent edits across install targets: {} — reconcile them before pinning",
+        labels.join(", ")
+    ))
+}
+
+pub(crate) fn modified_single_file_variants<'a>(
+    cache_text: &str,
+    variants: &'a [SingleFileVariant],
+) -> Vec<&'a SingleFileVariant> {
+    variants
+        .iter()
+        .filter(|variant| variant.content != cache_text)
+        .collect()
+}
+
+pub(crate) fn format_single_file_diff(diff: &SingleFileDiff<'_>) -> String {
+    similar::TextDiff::from_lines(diff.upstream, diff.installed_text)
+        .unified_diff()
+        .context_radius(3)
+        .header(
+            &format!("a/{}.md (upstream sha={})", diff.entry_name, diff.sha),
+            &format!(
+                "b/{}.md (installed: {})",
+                diff.entry_name, diff.target_label
+            ),
+        )
+        .to_string()
+}
+
+pub(crate) fn modified_dir_content(
+    cache_files: &BTreeMap<String, PathBuf>,
+    variant: &DirVariant,
+) -> Result<DirContentMap, SkillfileError> {
+    let mut modified = BTreeMap::new();
+    for (filename, cache_file) in cache_files {
+        let Some(installed) = variant.files.get(filename) else {
+            continue;
+        };
+        if !installed.exists() {
+            continue;
+        }
+        let cache_text = std::fs::read_to_string(cache_file)?;
+        let installed_text = std::fs::read_to_string(installed)?;
+        if installed_text != cache_text {
+            modified.insert(filename.clone(), installed_text);
+        }
+    }
+    Ok(modified)
+}
+
+pub(crate) fn modified_dir_variants(
+    cache_files: &BTreeMap<String, PathBuf>,
+    variants: &[DirVariant],
+) -> Result<Vec<(String, DirContentMap)>, SkillfileError> {
+    let mut modified = Vec::new();
+    for variant in variants {
+        let changed = modified_dir_content(cache_files, variant)?;
+        if !changed.is_empty() {
+            modified.push((variant.label.clone(), changed));
+        }
+    }
+    Ok(modified)
+}

--- a/crates/cli/src/commands/pin.rs
+++ b/crates/cli/src/commands/pin.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use skillfile_core::error::SkillfileError;
@@ -5,10 +6,13 @@ use skillfile_core::lock::{lock_key, read_lock};
 use skillfile_core::models::Entry;
 use skillfile_core::parser::{find_entry_in, parse_manifest, MANIFEST_NAME};
 use skillfile_deploy::install::install_entry;
-use skillfile_deploy::paths::{installed_dir_files, installed_path};
 use skillfile_sources::strategy::{content_file, is_dir_entry};
 use skillfile_sources::sync::vendor_dir_for;
 
+use crate::commands::installed_variants::{installed_dir_variants, installed_single_file_variants};
+use crate::commands::multi_target::{
+    divergent_targets_message, modified_dir_variants, modified_single_file_variants,
+};
 use crate::patch::{
     dir_patch_path, generate_patch, has_dir_patch, has_patch, remove_all_dir_patches,
     remove_dir_patch, remove_patch, walkdir, write_dir_patch, write_patch,
@@ -20,35 +24,135 @@ struct PinCtx<'a> {
     dry_run: bool,
 }
 
-struct DirFileRef<'a> {
-    cache: &'a std::path::Path,
-    installed: &'a std::path::Path,
-    filename: &'a str,
+struct DirPinPlan<'a> {
+    cache_files: BTreeMap<String, std::path::PathBuf>,
+    representative: &'a crate::commands::multi_target::DirContentMap,
 }
 
-/// Process a single file in a dir entry: generate a patch and write or remove it.
-/// Returns the filename if the file was pinned (patch is non-empty), or `None`.
-fn process_dir_file(
+struct SinglePinPlan<'a> {
+    cache_text: &'a str,
+    installed: &'a [crate::commands::installed_variants::SingleFileVariant],
+}
+
+#[derive(Clone, Copy)]
+struct DirPatchInput<'a> {
+    filename: &'a str,
+    original_text: &'a str,
+    installed_text: &'a str,
+}
+
+fn process_dir_file_text(
     ctx: &PinCtx<'_>,
-    file: &DirFileRef<'_>,
+    input: &DirPatchInput<'_>,
 ) -> Result<Option<String>, SkillfileError> {
-    let original_text = std::fs::read_to_string(file.cache)?;
-    let inst_text = std::fs::read_to_string(file.installed)?;
-    let patch_text = generate_patch(&original_text, &inst_text, file.filename);
+    let patch_text = generate_patch(input.original_text, input.installed_text, input.filename);
 
     if patch_text.is_empty() {
         if !ctx.dry_run {
-            remove_dir_patch(ctx.entry, file.filename, ctx.repo_root)?;
+            remove_dir_patch(ctx.entry, input.filename, ctx.repo_root)?;
         }
         return Ok(None);
     }
     if !ctx.dry_run {
         write_dir_patch(
-            &dir_patch_path(ctx.entry, file.filename, ctx.repo_root),
+            &dir_patch_path(ctx.entry, input.filename, ctx.repo_root),
             &patch_text,
         )?;
     }
-    Ok(Some(file.filename.to_string()))
+    Ok(Some(input.filename.to_string()))
+}
+
+fn load_cache_files(vdir: &Path) -> BTreeMap<String, std::path::PathBuf> {
+    walkdir(vdir)
+        .into_iter()
+        .filter(|cache_file| cache_file.file_name().is_some_and(|name| name != ".meta"))
+        .filter_map(|cache_file| {
+            let filename = cache_file
+                .strip_prefix(vdir)
+                .ok()
+                .and_then(|path| path.to_str())
+                .map(str::to_string)?;
+            Some((filename, cache_file))
+        })
+        .collect()
+}
+
+fn representative_dir_changes<'a>(
+    entry_name: &str,
+    modified: &'a [(String, crate::commands::multi_target::DirContentMap)],
+) -> Result<&'a crate::commands::multi_target::DirContentMap, SkillfileError> {
+    let labels: Vec<String> = modified.iter().map(|(label, _)| label.clone()).collect();
+    let representative = &modified[0].1;
+    if modified
+        .iter()
+        .any(|(_, changed)| changed != representative)
+    {
+        return Err(divergent_targets_message(entry_name, &labels));
+    }
+    Ok(representative)
+}
+
+fn apply_dir_pin_changes(
+    ctx: &PinCtx<'_>,
+    plan: DirPinPlan<'_>,
+) -> Result<Vec<String>, SkillfileError> {
+    let mut pinned = Vec::new();
+
+    for (filename, cache_file) in plan.cache_files {
+        if let Some(installed_text) = plan.representative.get(&filename) {
+            let original_text = std::fs::read_to_string(&cache_file)?;
+            let input = DirPatchInput {
+                filename: &filename,
+                original_text: &original_text,
+                installed_text,
+            };
+            let pinned_file = process_dir_file_text(ctx, &input)?;
+            pinned.extend(pinned_file);
+            continue;
+        }
+        if !ctx.dry_run {
+            remove_dir_patch(ctx.entry, &filename, ctx.repo_root)?;
+        }
+    }
+
+    Ok(pinned)
+}
+
+fn pin_single_file_content(
+    ctx: &PinCtx<'_>,
+    plan: &SinglePinPlan<'_>,
+) -> Result<String, SkillfileError> {
+    let modified = modified_single_file_variants(plan.cache_text, plan.installed);
+    if modified.is_empty() {
+        return Ok(format!(
+            "'{}' matches upstream — nothing to pin",
+            ctx.entry.name
+        ));
+    }
+
+    let representative = &modified[0].content;
+    if modified
+        .iter()
+        .any(|variant| variant.content != *representative)
+    {
+        let labels: Vec<String> = modified
+            .iter()
+            .map(|variant| variant.label.clone())
+            .collect();
+        return Err(divergent_targets_message(&ctx.entry.name, &labels));
+    }
+
+    let patch_text = generate_patch(
+        plan.cache_text,
+        representative,
+        &format!("{}.md", ctx.entry.name),
+    );
+    if !ctx.dry_run {
+        write_patch(ctx.entry, &patch_text, ctx.repo_root)?;
+    }
+
+    let prefix = if ctx.dry_run { "Would pin" } else { "Pinned" };
+    Ok(format!("{prefix} '{}'", ctx.entry.name))
 }
 
 fn pin_dir_entry(entry: &Entry, repo_root: &Path, dry_run: bool) -> Result<String, SkillfileError> {
@@ -61,7 +165,7 @@ fn pin_dir_entry(entry: &Entry, repo_root: &Path, dry_run: bool) -> Result<Strin
     }
 
     let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
-    let installed = installed_dir_files(entry, &manifest, repo_root)?;
+    let installed = installed_dir_variants(entry, &manifest, repo_root);
     if installed.is_empty() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed — run `skillfile install` first",
@@ -69,43 +173,27 @@ fn pin_dir_entry(entry: &Entry, repo_root: &Path, dry_run: bool) -> Result<Strin
         )));
     }
 
+    let cache_files = load_cache_files(&vdir);
+    let modified = modified_dir_variants(&cache_files, &installed)?;
+    if modified.is_empty() {
+        return Ok(format!(
+            "'{}' matches upstream — nothing to pin",
+            entry.name
+        ));
+    }
+    let representative = representative_dir_changes(&entry.name, &modified)?;
     let pin_ctx = PinCtx {
         entry,
         repo_root,
         dry_run,
     };
-    let mut pinned: Vec<String> = Vec::new();
-
-    for cache_file in walkdir(&vdir) {
-        if cache_file.file_name().is_some_and(|n| n == ".meta") {
-            continue;
-        }
-        let filename = cache_file
-            .strip_prefix(&vdir)
-            .ok()
-            .and_then(|p| p.to_str())
-            .unwrap_or("")
-            .to_string();
-        if filename.is_empty() {
-            continue;
-        }
-        let Some(inst_path) = installed.get(&filename) else {
-            continue;
-        };
-        if !inst_path.exists() {
-            continue;
-        }
-        if let Some(f) = process_dir_file(
-            &pin_ctx,
-            &DirFileRef {
-                cache: &cache_file,
-                installed: inst_path,
-                filename: &filename,
-            },
-        )? {
-            pinned.push(f);
-        }
-    }
+    let pinned = apply_dir_pin_changes(
+        &pin_ctx,
+        DirPinPlan {
+            cache_files,
+            representative,
+        },
+    )?;
 
     let prefix = if dry_run { "Would pin" } else { "Pinned" };
     if pinned.is_empty() {
@@ -156,31 +244,27 @@ fn pin_entry(entry: &Entry, repo_root: &Path, dry_run: bool) -> Result<String, S
     }
 
     let manifest = crate::config::parse_and_resolve(&repo_root.join(MANIFEST_NAME))?;
-    let dest = installed_path(entry, &manifest, repo_root)?;
-    if !dest.exists() {
+    let installed = installed_single_file_variants(entry, &manifest, repo_root)?;
+    if installed.is_empty() {
         return Err(SkillfileError::Manifest(format!(
             "'{}' is not installed — run `skillfile install` first",
             entry.name
         )));
     }
 
-    let label = format!("{}.md", entry.name);
     let cache_text = std::fs::read_to_string(&cache_file)?;
-    let dest_text = std::fs::read_to_string(&dest)?;
-    let patch_text = generate_patch(&cache_text, &dest_text, &label);
-
-    if patch_text.is_empty() {
-        return Ok(format!(
-            "'{}' matches upstream — nothing to pin",
-            entry.name
-        ));
-    }
-
-    if !dry_run {
-        write_patch(entry, &patch_text, repo_root)?;
-    }
-    let prefix = if dry_run { "Would pin" } else { "Pinned" };
-    Ok(format!("{prefix} '{}'", entry.name))
+    let pin_ctx = PinCtx {
+        entry,
+        repo_root,
+        dry_run,
+    };
+    pin_single_file_content(
+        &pin_ctx,
+        &SinglePinPlan {
+            cache_text: &cache_text,
+            installed: &installed,
+        },
+    )
 }
 
 pub fn cmd_pin(name: &str, repo_root: &Path, dry_run: bool) -> Result<(), SkillfileError> {
@@ -421,6 +505,70 @@ mod tests {
         // No patch written
         let patch_path = dir.path().join(".skillfile/patches/skills/test.patch");
         assert!(!patch_path.exists());
+    }
+
+    #[test]
+    fn pin_entry_uses_second_target_when_first_is_clean() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "install  claude-code  local\n\
+             install  copilot  local\n\
+             github  skill  owner/repo  skills/test.md\n",
+        );
+        write_lock(dir.path(), &make_lock_json("test", "skill"));
+
+        let vdir = dir.path().join(".skillfile/cache/skills/test");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(vdir.join("test.md"), "original\n").unwrap();
+
+        let first_target = dir.path().join(".claude/skills/test");
+        std::fs::create_dir_all(&first_target).unwrap();
+        std::fs::write(first_target.join("SKILL.md"), "original\n").unwrap();
+
+        let second_target = dir.path().join(".github/skills/test");
+        std::fs::create_dir_all(&second_target).unwrap();
+        std::fs::write(second_target.join("SKILL.md"), "modified\n").unwrap();
+
+        let entry = github_entry_skill("test", "skills/test.md");
+        let result = pin_entry(&entry, dir.path(), false).unwrap();
+        assert!(result.contains("Pinned 'test'"));
+
+        let patch_path = dir.path().join(".skillfile/patches/skills/test.patch");
+        let patch_text = std::fs::read_to_string(&patch_path).unwrap();
+        assert!(patch_text.contains("+modified"));
+    }
+
+    #[test]
+    fn pin_entry_errors_on_divergent_multi_target_edits() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "install  claude-code  local\n\
+             install  copilot  local\n\
+             github  skill  owner/repo  skills/test.md\n",
+        );
+        write_lock(dir.path(), &make_lock_json("test", "skill"));
+
+        let vdir = dir.path().join(".skillfile/cache/skills/test");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(vdir.join("test.md"), "original\n").unwrap();
+
+        let first_target = dir.path().join(".claude/skills/test");
+        std::fs::create_dir_all(&first_target).unwrap();
+        std::fs::write(first_target.join("SKILL.md"), "modified one\n").unwrap();
+
+        let second_target = dir.path().join(".github/skills/test");
+        std::fs::create_dir_all(&second_target).unwrap();
+        std::fs::write(second_target.join("SKILL.md"), "modified two\n").unwrap();
+
+        let entry = github_entry_skill("test", "skills/test.md");
+        let result = pin_entry(&entry, dir.path(), false);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("divergent edits across install targets"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -151,6 +151,50 @@ fn write_local_manifest(dir: &Path) {
     std::fs::write(dir.join("skills/my-skill.md"), "# My Skill\n").unwrap();
 }
 
+fn write_multi_target_skill_fixture(dir: &Path, name: &str) {
+    let manifest = format!(
+        "install  claude-code  local\n\
+         install  copilot  local\n\
+         github  skill  {name}  owner/repo  skills/{name}.md  main\n"
+    );
+    std::fs::write(dir.join("Skillfile"), manifest).unwrap();
+
+    let lock_json = serde_json::json!({
+        format!("github/skill/{name}"): {
+            "sha": "abc123def456abc123def456abc123def456abc1",
+            "raw_url": format!("https://raw.githubusercontent.com/owner/repo/abc123/skills/{name}.md")
+        }
+    });
+    std::fs::write(
+        dir.join("Skillfile.lock"),
+        serde_json::to_string_pretty(&lock_json).unwrap(),
+    )
+    .unwrap();
+
+    let vdir = dir.join(format!(".skillfile/cache/skills/{name}"));
+    std::fs::create_dir_all(&vdir).unwrap();
+    std::fs::write(
+        vdir.join(format!("{name}.md")),
+        "# Skill\n\nUpstream content.\n",
+    )
+    .unwrap();
+    std::fs::write(
+        vdir.join(".meta"),
+        r#"{"sha":"abc123def456abc123def456abc123def456abc1"}"#,
+    )
+    .unwrap();
+
+    for platform_dir in [".claude/skills", ".github/skills"] {
+        let installed_dir = dir.join(platform_dir).join(name);
+        std::fs::create_dir_all(&installed_dir).unwrap();
+        std::fs::write(
+            installed_dir.join("SKILL.md"),
+            "# Skill\n\nUpstream content.\n",
+        )
+        .unwrap();
+    }
+}
+
 #[test]
 fn install_first_run_shows_platform_hint() {
     let dir = tempfile::tempdir().unwrap();
@@ -458,6 +502,71 @@ fn diff_shows_changes_between_cache_and_installed() {
         .assert()
         .success()
         .stdout(predicate::str::contains("User addition"));
+}
+
+#[test]
+fn diff_surfaces_secondary_target_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_multi_target_skill_fixture(root, "multi-skill");
+
+    std::fs::write(
+        root.join(".github/skills/multi-skill/SKILL.md"),
+        "# Skill\n\nUpstream content.\n\nSecondary target edit.\n",
+    )
+    .unwrap();
+
+    sf(root)
+        .args(["diff", "multi-skill"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Secondary target edit."))
+        .stdout(predicate::str::contains("installed: copilot (local)"));
+}
+
+#[test]
+fn pin_and_unpin_round_trip_secondary_target_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_multi_target_skill_fixture(root, "pin-skill");
+
+    std::fs::write(
+        root.join(".github/skills/pin-skill/SKILL.md"),
+        "# Skill\n\nUpstream content.\n\nPinned from second target.\n",
+    )
+    .unwrap();
+
+    sf(root).args(["pin", "pin-skill"]).assert().success();
+
+    let patch_path = root.join(".skillfile/patches/skills/pin-skill.patch");
+    assert!(patch_path.exists(), "pin should write a patch");
+    assert!(
+        std::fs::read_to_string(&patch_path)
+            .unwrap()
+            .contains("Pinned from second target."),
+        "patch should capture second-target edit"
+    );
+
+    std::fs::remove_file(root.join(".claude/skills/pin-skill/SKILL.md")).unwrap();
+
+    sf(root).arg("install").assert().success();
+    assert!(
+        std::fs::read_to_string(root.join(".claude/skills/pin-skill/SKILL.md"))
+            .unwrap()
+            .contains("Pinned from second target."),
+        "install should apply the stored patch when redeploying the first target"
+    );
+
+    sf(root).args(["unpin", "pin-skill"]).assert().success();
+    assert!(!patch_path.exists(), "unpin should remove patch");
+    assert_eq!(
+        std::fs::read_to_string(root.join(".claude/skills/pin-skill/SKILL.md")).unwrap(),
+        "# Skill\n\nUpstream content.\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(root.join(".github/skills/pin-skill/SKILL.md")).unwrap(),
+        "# Skill\n\nUpstream content.\n"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**SUMMARY**
Make `diff` and `pin` inspect every installed target instead of only the first one. Add shared helpers and regression coverage for secondary-target edits and divergent target state.

**RATIONALE**
`status` already checks all install targets, so leaving `diff` and `pin` on first-target-only lookup created a real mismatch. Edits made only in a secondary target looked modified in `status` but invisible to `diff`, and `pin` could not capture them.

**CHANGES**
- update `crates/cli/src/commands/diff.rs` to diff all installed targets and label output with the target that changed
- update `crates/cli/src/commands/pin.rs` to pin from any modified target and reject divergent edits across targets
- add `crates/cli/src/commands/installed_variants.rs` to collect installed single-file and directory variants across targets
- add `crates/cli/src/commands/multi_target.rs` for shared multi-target diff and change-detection helpers
- register the new command helpers in `crates/cli/src/commands/mod.rs`
- add CLI regressions in `tests/cli.rs` for secondary-target `diff` and `pin` plus `unpin` round-trips
- add unit regressions in `crates/cli/src/commands/pin.rs` for secondary-target pinning and divergent target edits