### PR TITLE
feat(add): print install target summary after successful add

### DIFF
--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -198,6 +198,21 @@ fn add_selected(selected: &[String], args: &BulkAddArgs<'_>, repo_root: &Path) {
     );
 }
 
+/// Appends `entry` to the manifest at `path`, auto-formats, and returns
+/// (original manifest text, formatted text, line string).
+fn append_entry(entry: &Entry, path: &Path) -> Result<(String, String), SkillfileError> {
+    let original = std::fs::read_to_string(path)?;
+    let line = format_line(entry);
+    let mut raw = original.clone();
+    raw.push_str(&line);
+    raw.push('\n');
+    std::fs::write(path, &raw)?;
+    let result = parse_manifest(path)?;
+    let formatted = sorted_manifest_text(&result.manifest, &raw);
+    std::fs::write(path, &formatted)?;
+    Ok((original, line))
+}
+
 pub fn cmd_add(entry: &Entry, repo_root: &Path) -> Result<(), SkillfileError> {
     let manifest_path = repo_root.join(MANIFEST_NAME);
     if !manifest_path.exists() {
@@ -208,36 +223,22 @@ pub fn cmd_add(entry: &Entry, repo_root: &Path) -> Result<(), SkillfileError> {
     }
 
     let result = parse_manifest(&manifest_path)?;
-    let existing_names: std::collections::HashSet<String> = result
+    let existing: std::collections::HashSet<String> = result
         .manifest
         .entries
         .iter()
         .map(|e| e.name.clone())
         .collect();
-    if existing_names.contains(&entry.name) {
+    if existing.contains(&entry.name) {
         return Err(SkillfileError::Manifest(format!(
             "entry '{}' already exists in {MANIFEST_NAME}",
             entry.name
         )));
     }
 
-    let line = format_line(entry);
-    let original_manifest = std::fs::read_to_string(&manifest_path)?;
-
-    // Append the new entry
-    let mut content = original_manifest.clone();
-    content.push_str(&line);
-    content.push('\n');
-    std::fs::write(&manifest_path, &content)?;
-
-    // Auto-format the Skillfile silently
-    let result = parse_manifest(&manifest_path)?;
-    let formatted = sorted_manifest_text(&result.manifest, &content);
-    std::fs::write(&manifest_path, &formatted)?;
-
+    let (original, line) = append_entry(entry, &manifest_path)?;
     println!("Added: {line}");
 
-    // Re-parse to check install targets
     let result = parse_manifest(&manifest_path)?;
     if result.manifest.install_targets.is_empty() {
         println!(
@@ -246,31 +247,31 @@ pub fn cmd_add(entry: &Entry, repo_root: &Path) -> Result<(), SkillfileError> {
         return Ok(());
     }
 
-    // Auto sync + install with rollback on failure
     let lock_path = repo_root.join("Skillfile.lock");
-    let original_lock = if lock_path.exists() {
-        Some(std::fs::read_to_string(&lock_path)?)
-    } else {
-        None
-    };
-
-    let sync_install_result = sync_and_install(entry, repo_root, &result.manifest);
-
-    if let Err(e) = sync_install_result {
-        // Rollback
-        std::fs::write(&manifest_path, &original_manifest)?;
-        match &original_lock {
-            None => {
-                let _ = std::fs::remove_file(&lock_path);
-            }
-            Some(text) => {
-                std::fs::write(&lock_path, text)?;
-            }
+    let orig_lock: Option<String> = lock_path
+        .exists()
+        .then(|| std::fs::read_to_string(&lock_path))
+        .transpose()?;
+    if let Err(e) = sync_and_install(entry, repo_root, &result.manifest) {
+        std::fs::write(&manifest_path, &original)?;
+        match orig_lock.as_deref() {
+            None => drop(std::fs::remove_file(&lock_path)),
+            Some(t) => std::fs::write(&lock_path, t)?,
         }
         eprintln!("Rolled back: removed '{}' from {MANIFEST_NAME}", entry.name);
         return Err(e);
     }
 
+    println!(
+        "Installed to: {}",
+        result
+            .manifest
+            .install_targets
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
     Ok(())
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -414,6 +414,58 @@ fn add_local_subcommand_works() {
     );
 }
 
+#[test]
+fn add_local_no_install_targets_shows_guidance() {
+    // When there are no install targets, `add` should tell the user to run
+    // `skillfile init` and `skillfile install` rather than silently succeeding.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("Skillfile"), "# empty\n").unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/foo.md"), "# Foo\n").unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "skill", "skills/foo.md"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No install targets configured"),
+        "add without install targets should print guidance, got: {stdout}"
+    );
+}
+
+#[test]
+fn add_local_with_install_targets_shows_installed_summary() {
+    // After a successful add + install, the output should confirm which
+    // adapters the skill was deployed to.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/bar.md"), "# Bar\n").unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "skill", "skills/bar.md"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Installed to:"),
+        "add with install targets should print 'Installed to:' summary, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("claude-code"),
+        "summary should name the install target adapter, got: {stdout}"
+    );
+}
+
 /// Local directory entries must be deployed as directories, not empty .md files.
 ///
 /// Regression test: is_dir_entry() only inspected GitHub path_in_repo and


### PR DESCRIPTION
Closes #83.

When `skillfile add` succeeds and install targets are configured, it currently exits silently after deploying. The user has no feedback on where the skill landed. This fixes that.

## What changed

In `cmd_add`, after a successful `sync_and_install`, print:

```
Installed to: claude-code (local)
```

The adapter list comes from `manifest.install_targets` via their existing `Display` impl (`{adapter} ({scope})`), so multi-target setups print all of them comma-separated.

The no-targets path already had a message; this PR covers the success path that was missing.

Also extracts the append-and-format block into a small `append_entry` helper to keep `cmd_add` within the project's 60-line clippy limit, and adds two CLI tests covering both output paths.