### PR TITLE
fix(add): print outcome summary after add completes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -198,6 +198,41 @@ fn add_selected(selected: &[String], args: &BulkAddArgs<'_>, repo_root: &Path) {
     );
 }
 
+struct RollbackState<'a> {
+    manifest_path: &'a Path,
+    original_manifest: &'a str,
+    lock_path: &'a Path,
+    original_lock: Option<String>,
+}
+
+impl RollbackState<'_> {
+    fn rollback(&self, entry_name: &str) {
+        let _ = std::fs::write(self.manifest_path, self.original_manifest);
+        match &self.original_lock {
+            None => {
+                let _ = std::fs::remove_file(self.lock_path);
+            }
+            Some(text) => {
+                let _ = std::fs::write(self.lock_path, text);
+            }
+        }
+        eprintln!("Rolled back: removed '{entry_name}' from {MANIFEST_NAME}");
+    }
+}
+
+fn append_and_format_entry(entry: &Entry, manifest_path: &Path) -> Result<String, SkillfileError> {
+    let line = format_line(entry);
+    let original = std::fs::read_to_string(manifest_path)?;
+    let mut content = original.clone();
+    content.push_str(&line);
+    content.push('\n');
+    std::fs::write(manifest_path, &content)?;
+    let result = parse_manifest(manifest_path)?;
+    let formatted = sorted_manifest_text(&result.manifest, &content);
+    std::fs::write(manifest_path, &formatted)?;
+    Ok(original)
+}
+
 pub fn cmd_add(entry: &Entry, repo_root: &Path) -> Result<(), SkillfileError> {
     let manifest_path = repo_root.join(MANIFEST_NAME);
     if !manifest_path.exists() {
@@ -222,55 +257,39 @@ pub fn cmd_add(entry: &Entry, repo_root: &Path) -> Result<(), SkillfileError> {
     }
 
     let line = format_line(entry);
-    let original_manifest = std::fs::read_to_string(&manifest_path)?;
-
-    // Append the new entry
-    let mut content = original_manifest.clone();
-    content.push_str(&line);
-    content.push('\n');
-    std::fs::write(&manifest_path, &content)?;
-
-    // Auto-format the Skillfile silently
-    let result = parse_manifest(&manifest_path)?;
-    let formatted = sorted_manifest_text(&result.manifest, &content);
-    std::fs::write(&manifest_path, &formatted)?;
-
+    let original_manifest = append_and_format_entry(entry, &manifest_path)?;
     println!("Added: {line}");
 
-    // Re-parse to check install targets
     let result = parse_manifest(&manifest_path)?;
     if result.manifest.install_targets.is_empty() {
-        println!(
-            "No install targets configured — run `skillfile init` then `skillfile install` to deploy."
-        );
+        println!("No install targets configured yet. Run `skillfile init` to pick platforms.");
         return Ok(());
     }
 
-    // Auto sync + install with rollback on failure
     let lock_path = repo_root.join("Skillfile.lock");
-    let original_lock = if lock_path.exists() {
-        Some(std::fs::read_to_string(&lock_path)?)
-    } else {
-        None
+    let rb = RollbackState {
+        manifest_path: &manifest_path,
+        original_manifest: &original_manifest,
+        lock_path: &lock_path,
+        original_lock: lock_path
+            .exists()
+            .then(|| std::fs::read_to_string(&lock_path))
+            .transpose()?,
     };
 
-    let sync_install_result = sync_and_install(entry, repo_root, &result.manifest);
-
-    if let Err(e) = sync_install_result {
-        // Rollback
-        std::fs::write(&manifest_path, &original_manifest)?;
-        match &original_lock {
-            None => {
-                let _ = std::fs::remove_file(&lock_path);
-            }
-            Some(text) => {
-                std::fs::write(&lock_path, text)?;
-            }
-        }
-        eprintln!("Rolled back: removed '{}' from {MANIFEST_NAME}", entry.name);
+    if let Err(e) = sync_and_install(entry, repo_root, &result.manifest) {
+        rb.rollback(&entry.name);
         return Err(e);
     }
 
+    let target_list = result
+        .manifest
+        .install_targets
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("Installed to: {target_list}");
     Ok(())
 }
 

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -724,4 +724,144 @@ mod tests {
         let entry = entry_from_url("agent", "https://example.com/agent.md", Some("my-agent"));
         assert_eq!(entry.name, "my-agent");
     }
+
+    // --- append_and_format_entry tests ---
+
+    #[test]
+    fn append_and_format_entry_returns_original() {
+        let dir = tempfile::tempdir().unwrap();
+        let initial = "local  skill  skills/existing.md\n";
+        write_manifest(dir.path(), initial);
+        let entry = entry_from_local("skill", "skills/new.md", None);
+        let original = append_and_format_entry(&entry, &dir.path().join(MANIFEST_NAME)).unwrap();
+        assert_eq!(
+            original, initial,
+            "should return the pre-edit manifest text"
+        );
+        let updated = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
+        assert!(updated.contains("skills/new.md"));
+        assert!(updated.contains("skills/existing.md"));
+    }
+
+    #[test]
+    fn append_and_format_entry_empty_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "");
+        let entry = entry_from_local("skill", "skills/foo.md", None);
+        let original = append_and_format_entry(&entry, &dir.path().join(MANIFEST_NAME)).unwrap();
+        assert_eq!(original, "");
+        let updated = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
+        assert!(updated.contains("skills/foo.md"));
+    }
+
+    // --- RollbackState tests ---
+
+    #[test]
+    fn rollback_restores_manifest_and_removes_lock_when_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join(MANIFEST_NAME);
+        let lock_path = dir.path().join("Skillfile.lock");
+        let original = "local  skill  skills/foo.md\n";
+        std::fs::write(&manifest_path, "corrupted content").unwrap();
+        // No lock file pre-existed.
+        std::fs::write(&lock_path, "some lock").unwrap();
+        let rb = RollbackState {
+            manifest_path: &manifest_path,
+            original_manifest: original,
+            lock_path: &lock_path,
+            original_lock: None,
+        };
+        rb.rollback("foo");
+        let restored = std::fs::read_to_string(&manifest_path).unwrap();
+        assert_eq!(restored, original);
+        assert!(
+            !lock_path.exists(),
+            "lock should be removed when original was None"
+        );
+    }
+
+    #[test]
+    fn rollback_restores_manifest_and_lock_when_some() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join(MANIFEST_NAME);
+        let lock_path = dir.path().join("Skillfile.lock");
+        let original_manifest = "local  skill  skills/bar.md\n";
+        let original_lock = "lock content\n";
+        std::fs::write(&manifest_path, "corrupted").unwrap();
+        std::fs::write(&lock_path, "new lock").unwrap();
+        let rb = RollbackState {
+            manifest_path: &manifest_path,
+            original_manifest,
+            lock_path: &lock_path,
+            original_lock: Some(original_lock.to_string()),
+        };
+        rb.rollback("bar");
+        assert_eq!(
+            std::fs::read_to_string(&manifest_path).unwrap(),
+            original_manifest
+        );
+        assert_eq!(std::fs::read_to_string(&lock_path).unwrap(), original_lock);
+    }
+
+    // --- add_selected tests ---
+
+    #[test]
+    fn add_selected_single_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "");
+        let paths = vec!["skills/my-tool.md".to_string()];
+        let args = BulkAddArgs {
+            entity_type: "skill",
+            owner_repo: "owner/repo",
+            base_path: "skills",
+            ref_: None,
+            no_interactive: true,
+        };
+        add_selected(&paths, &args, dir.path());
+        let text = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
+        assert!(text.contains("owner/repo"));
+        assert!(text.contains("skills/my-tool.md"));
+    }
+
+    #[test]
+    fn add_selected_multiple_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "");
+        let paths = vec!["skills/alpha.md".to_string(), "skills/beta.md".to_string()];
+        let args = BulkAddArgs {
+            entity_type: "skill",
+            owner_repo: "owner/repo",
+            base_path: "skills",
+            ref_: None,
+            no_interactive: true,
+        };
+        add_selected(&paths, &args, dir.path());
+        let text = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
+        assert!(text.contains("skills/alpha.md"));
+        assert!(text.contains("skills/beta.md"));
+    }
+
+    #[test]
+    fn add_selected_skips_duplicate() {
+        let dir = tempfile::tempdir().unwrap();
+        // Pre-populate with "alpha"
+        write_manifest(dir.path(), "github  skill  owner/repo  skills/alpha.md\n");
+        let paths = vec![
+            "skills/alpha.md".to_string(), // duplicate — will be skipped
+            "skills/gamma.md".to_string(),
+        ];
+        let args = BulkAddArgs {
+            entity_type: "skill",
+            owner_repo: "owner/repo",
+            base_path: "skills",
+            ref_: None,
+            no_interactive: true,
+        };
+        add_selected(&paths, &args, dir.path());
+        let text = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
+        // gamma should have been added, alpha should still be there (not duplicated)
+        assert!(text.contains("skills/gamma.md"));
+        let alpha_count = text.matches("skills/alpha.md").count();
+        assert_eq!(alpha_count, 1, "alpha should appear exactly once");
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -414,6 +414,30 @@ fn add_local_subcommand_works() {
     );
 }
 
+#[test]
+fn add_prints_no_targets_message_when_none_configured() {
+    // When no install targets are in the Skillfile, `add` should tell the user
+    // what happened and what to do next.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("Skillfile"), "# empty\n").unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "skill", "skills/test.md"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No install targets configured yet"),
+        "should mention no install targets, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("skillfile init"),
+        "should point to `skillfile init`, got: {stdout}"
+    );
+}
+
 /// Local directory entries must be deployed as directories, not empty .md files.
 ///
 /// Regression test: is_dir_entry() only inspected GitHub path_in_repo and


### PR DESCRIPTION
When no install targets are configured the previous message was easy to miss
and mixed with unrelated output. Now cmd_add always ends with a clear line
describing what actually happened:

- targets present: "Added: <entry>" then "Installed to: <targets>"
- no targets:      "Added: <entry>" then "No install targets configured
  yet. Run `skillfile init` to pick platforms."

The change also extracts `append_and_format_entry` and `RollbackState`
to keep `cmd_add` within the project's 60-line Clippy threshold.

Test added in `tests/cli.rs` to assert the no-targets message is printed.

Closes #83