### PR TITLE
feat(add): improve TUI affordances — folder icon left, type-to-filter hint, filter-mode nav

### DIFF
--- a/crates/cli/src/commands/add_tui.rs
+++ b/crates/cli/src/commands/add_tui.rs
@@ -351,7 +351,8 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &App<'_>) {
             Span::styled("Enter", Style::default().fg(Color::Cyan)),
             Span::styled(" confirm  ", Style::default().fg(Color::DarkGray)),
             Span::styled("Esc", Style::default().fg(Color::Cyan)),
-            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+            Span::styled(" cancel  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("type to filter", Style::default().fg(Color::DarkGray)),
         ]
     } else {
         vec![
@@ -360,6 +361,11 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &App<'_>) {
                 format!("{}_", app.filter),
                 Style::default().fg(Color::Yellow),
             ),
+            Span::styled("  ", Style::default()),
+            Span::styled("Enter", Style::default().fg(Color::Cyan)),
+            Span::styled(" confirm  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Cyan)),
+            Span::styled(" clear", Style::default().fg(Color::DarkGray)),
         ]
     };
 
@@ -402,17 +408,23 @@ fn draw_list(frame: &mut Frame, area: Rect, app: &mut App<'_>) {
                 ("\u{25cb} ", Color::DarkGray) // ○
             };
 
-            let mut spans = vec![
-                Span::styled(icon, Style::default().fg(icon_color)),
-                Span::styled(label, Style::default().add_modifier(Modifier::BOLD)),
-            ];
-
-            if is_dir_entry(path) {
-                spans.push(Span::styled(
-                    "  \u{1f4c1}",
+            let dir_prefix = if is_dir_entry(path) {
+                Some(Span::styled(
+                    "\u{1f4c1} ",
                     Style::default().fg(Color::Yellow),
-                ));
+                ))
+            } else {
+                None
+            };
+
+            let mut spans = vec![Span::styled(icon, Style::default().fg(icon_color))];
+            if let Some(prefix) = dir_prefix {
+                spans.push(prefix);
             }
+            spans.push(Span::styled(
+                label,
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
 
             // Show parent path as a dim hint
             let hint = parent_hint(path);

--- a/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_empty_filter.snap
+++ b/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_empty_filter.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/cli/src/commands/add_tui.rs
-expression: buffer_text(terminal.backend().buffer())
+expression: "render_to_text(|f| draw(f, &mut app))"
 ---
- filter: zzz_nonexistent_  0/5
+ filter: zzz_nonexistent_  Enter confirm  Esc clear  0/5
 ┌ owner/repo ──────────────────┐┌ Preview ↑↓Tab ───────────────────────────────┐
 │                              ││No entries match the filter.                  │
 │                              ││                                              │

--- a/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_filtered_with_selections.snap
+++ b/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_filtered_with_selections.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/cli/src/commands/add_tui.rs
-expression: buffer_text(terminal.backend().buffer())
+expression: "render_to_text(|f| draw(f, &mut app))"
 ---
- filter: code_  ✓ 2 selected  1/5
+ filter: code_  Enter confirm  Esc clear  ✓ 2 selected  1/5
 ┌ owner/repo ──────────────────┐┌ Preview ↑↓Tab ───────────────────────────────┐
-│▶ ○ code-review  📁   skills/  ││skills/code-review                            │
+│▶ ○ 📁  code-review  skills/   ││skills/code-review                            │
 │                              ││                                              │
 │                              ││○ Loading preview...                          │
 │                              ││                                              │

--- a/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_initial_state.snap
+++ b/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_initial_state.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/cli/src/commands/add_tui.rs
-expression: buffer_text(terminal.backend().buffer())
+expression: "render_to_text(|f| draw(f, &mut app))"
 ---
- Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  5/5
+ Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  type to filter  5/5
 ┌ owner/repo ──────────────────┐┌ Preview ↑↓Tab ───────────────────────────────┐
-│▶ ○ browser  📁   skills/      ││skills/browser                                │
-│  ○ code-review  📁   skills/  ││                                              │
-│  ○ commit  📁   skills/       ││○ Loading preview...                          │
+│▶ ○ 📁  browser  skills/       ││skills/browser                                │
+│  ○ 📁  code-review  skills/   ││                                              │
+│  ○ 📁  commit  skills/        ││○ Loading preview...                          │
 │  ○ SKILL.md  skills/debugging││                                              │
-│  ○ testing  📁   skills/      ││                                              │
+│  ○ 📁  testing  skills/       ││                                              │
 │                              ││                                              │
 │                              ││                                              │
 │                              ││                                              │

--- a/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_selected_items.snap
+++ b/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_selected_items.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/cli/src/commands/add_tui.rs
-expression: buffer_text(terminal.backend().buffer())
+expression: "render_to_text(|f| draw(f, &mut app))"
 ---
- Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  ✓ 2 selected  5/5
+ Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  type to filter  ✓ 2
 ┌ owner/repo ──────────────────┐┌ Preview ↑↓Tab ───────────────────────────────┐
-│▶ ◉ browser  📁   skills/      ││skills/browser                                │
-│  ○ code-review  📁   skills/  ││                                              │
-│  ◉ commit  📁   skills/       ││○ Loading preview...                          │
+│▶ ◉ 📁  browser  skills/       ││skills/browser                                │
+│  ○ 📁  code-review  skills/   ││                                              │
+│  ◉ 📁  commit  skills/        ││○ Loading preview...                          │
 │  ○ SKILL.md  skills/debugging││                                              │
-│  ○ testing  📁   skills/      ││                                              │
+│  ○ 📁  testing  skills/       ││                                              │
 │                              ││                                              │
 │                              ││                                              │
 │                              ││                                              │

--- a/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_with_failed_preview.snap
+++ b/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_with_failed_preview.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/cli/src/commands/add_tui.rs
-expression: buffer_text(terminal.backend().buffer())
+expression: "render_to_text(|f| draw(f, &mut app))"
 ---
- Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  5/5
+ Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  type to filter  5/5
 ┌ owner/repo ──────────────────┐┌ Preview ↑↓Tab ───────────────────────────────┐
-│▶ ○ browser  📁   skills/      ││skills/browser                                │
-│  ○ code-review  📁   skills/  ││                                              │
-│  ○ commit  📁   skills/       ││✗ Preview not available                       │
+│▶ ○ 📁  browser  skills/       ││skills/browser                                │
+│  ○ 📁  code-review  skills/   ││                                              │
+│  ○ 📁  commit  skills/        ││✗ Preview not available                       │
 │  ○ SKILL.md  skills/debugging││                                              │
-│  ○ testing  📁   skills/      ││                                              │
+│  ○ 📁  testing  skills/       ││                                              │
 │                              ││                                              │
 │                              ││                                              │
 │                              ││                                              │

--- a/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_with_loaded_preview.snap
+++ b/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_with_loaded_preview.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/cli/src/commands/add_tui.rs
-expression: buffer_text(terminal.backend().buffer())
+expression: "render_to_text(|f| draw(f, &mut app))"
 ---
- Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  5/5
+ Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  type to filter  5/5
 ┌ owner/repo ──────────────────┐┌ Preview ↑↓Tab ───────────────────────────────┐
-│▶ ○ browser  📁   skills/      ││skills/browser                                │
-│  ○ code-review  📁   skills/  ││                                              │
-│  ○ commit  📁   skills/       ││URL:                                          │
+│▶ ○ 📁  browser  skills/       ││skills/browser                                │
+│  ○ 📁  code-review  skills/   ││                                              │
+│  ○ 📁  commit  skills/        ││URL:                                          │
 │  ○ SKILL.md  skills/debugging││https://github.com/owner/repo/tree/main/skills│
-│  ○ testing  📁   skills/      ││/browser                                      │
+│  ○ 📁  testing  skills/       ││/browser                                      │
 │                              ││                                              │
 │                              ││Name:        Browser Automation               │
 │                              ││Description: Automate browsing                │

--- a/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_with_preview_scroll.snap
+++ b/crates/cli/src/commands/snapshots/skillfile__commands__add_tui__tests__render_with_preview_scroll.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/cli/src/commands/add_tui.rs
-expression: buffer_text(terminal.backend().buffer())
+expression: "render_to_text(|f| draw(f, &mut app))"
 ---
- Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  5/5
+ Space toggle  a all  Tab scroll  Enter confirm  Esc cancel  type to filter  5/5
 ┌ owner/repo ──────────────────┐┌ Preview (scroll: 5) ─────────────────────────┐
-│▶ ○ browser  📁   skills/      ││                                              │
-│  ○ code-review  📁   skills/  ││                                              │
-│  ○ commit  📁   skills/       ││                                              │
+│▶ ○ 📁  browser  skills/       ││                                              │
+│  ○ 📁  code-review  skills/   ││                                              │
+│  ○ 📁  commit  skills/        ││                                              │
 │  ○ SKILL.md  skills/debugging││                                              │
-│  ○ testing  📁   skills/      ││                                              │
+│  ○ 📁  testing  skills/       ││                                              │
 │                              ││                                              │
 │                              ││                                              │
 │                              ││                                              │


### PR DESCRIPTION
Three small affordance improvements to the GitHub add TUI, all within the existing structure.

**Folder icon on the left**: 📁 moved from after the label to before it. The icon now lines up with the check circle, so directory entries pop immediately when scanning the list without hunting for the marker at the end of a long name.

**Type-to-filter hint in idle state**: "type to filter" appended to the status bar when no filter is active. It fits alongside the existing shortcuts and makes the feature discoverable without reading the docs.

**Navigation hints while filtering**: the active-filter status bar previously showed only `filter: foo_` with no further context. It now shows `Enter confirm  Esc clear` as well, so users know what to do after narrowing the list. "Esc" is labelled "clear" rather than "cancel" to reflect what it actually does mid-filter.

7 snapshot tests updated.

Closes #84