### PR TITLE
feat(init): surface shell completions during onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ skillfile add github skill anthropics/skills skills/    # or add directly
 
 That's it. Skills are fetched, locked to exact SHAs, and deployed. On a fresh clone, `skillfile install` reproduces the exact same setup.
 
+Optional: set up tab completion with `skillfile completions <bash|zsh|fish>` — see [Shell completions](#shell-completions) below.
+
 > Looking for skills to install? See [awesome-agents-and-skills](https://github.com/eljulians/awesome-agents-and-skills) for a curated collection with a ready-to-use Skillfile.
 
 ## Add skills from anywhere

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -404,7 +404,8 @@ pub fn cmd_init(repo_root: &Path) -> Result<(), SkillfileError> {
     cliclack::outro(format!(
         "{outro}\n  \
          \u{2795} `skillfile add` to add a skill or agent\n  \
-         \u{1f50d} `skillfile search` to discover community skills"
+         \u{1f50d} `skillfile search` to discover community skills\n  \
+         \u{1f4ac} `skillfile completions <bash|zsh|fish>` for tab completion"
     ))?;
 
     Ok(())

--- a/install.sh
+++ b/install.sh
@@ -148,6 +148,10 @@ print_success() {
             log "To make it permanent, add that line to your shell profile (~/.bashrc, ~/.zshrc, etc.)."
             ;;
     esac
+
+    log ""
+    log "Tip: enable tab completions with:"
+    log "  skillfile completions bash   # or zsh, fish, powershell"
 }
 
 has() {


### PR DESCRIPTION
Shell completions already exist but are buried in the README. New users walking through `skillfile init` or running the install script have no idea they're there.

Three small changes:

- `init` outro now includes a hint: `skillfile completions <bash|zsh|fish>`
- `install.sh` prints the same hint after a successful install
- README quick-start adds one line pointing to the completions section

No behavior changes, no new tests needed (the outro text isn't asserted anywhere).

Closes #86