### PR TITLE
Fix install validation and add rollback cleanup

### DIFF
--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -1,16 +1,20 @@
 use std::io::IsTerminal;
-use std::path::Path;
-
-use skillfile_core::error::SkillfileError;
-use skillfile_core::lock::{read_lock, write_lock};
-use skillfile_core::models::{EntityType, Entry, SourceFields, DEFAULT_REF};
-use skillfile_core::parser::{infer_name, parse_manifest, MANIFEST_NAME};
-use skillfile_deploy::adapter::adapters;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::format::sorted_manifest_text;
-use skillfile_deploy::install::install_entry;
-use skillfile_sources::strategy::format_parts;
-use skillfile_sources::sync::{sync_entry, SyncContext};
+use skillfile_core::error::SkillfileError;
+use skillfile_core::lock::{read_lock, write_lock};
+use skillfile_core::models::{
+    EntityType, Entry, InstallTarget, Manifest, SourceFields, DEFAULT_REF,
+};
+use skillfile_core::parser::{infer_name, parse_manifest, MANIFEST_NAME};
+use skillfile_core::patch::walkdir;
+use skillfile_deploy::adapter::{adapters, AdapterScope, DirInstallMode};
+use skillfile_deploy::install::{install_entry_with_outcome, InstallOutcome, InstallSkipReason};
+use skillfile_deploy::paths::source_path;
+use skillfile_sources::strategy::{format_parts, is_dir_entry};
+use skillfile_sources::sync::{sync_entry, vendor_dir_for, SyncContext};
 
 fn format_line(entry: &Entry) -> String {
     let mut parts = vec![
@@ -21,37 +25,62 @@ fn format_line(entry: &Entry) -> String {
     parts.join("  ")
 }
 
+struct BackupCaptureCtx<'a> {
+    entry: &'a Entry,
+    manifest: &'a Manifest,
+    repo_root: &'a Path,
+}
+
+struct AddInstallCtx<'a, 'b> {
+    manifest: &'a Manifest,
+    rollback: &'a mut RollbackState,
+    repo_root: &'b Path,
+}
+
 fn sync_and_install(
     entry: &Entry,
-    repo_root: &Path,
-    manifest: &skillfile_core::models::Manifest,
-) -> Result<(), SkillfileError> {
-    let locked = read_lock(repo_root)?;
+    ctx: &mut AddInstallCtx<'_, '_>,
+) -> Result<InstallReport, SkillfileError> {
+    let locked = read_lock(ctx.repo_root)?;
     let client = skillfile_sources::http::UreqClient::new();
-    let mut ctx = SyncContext {
-        repo_root: repo_root.to_path_buf(),
+    let mut sync_ctx = SyncContext {
+        repo_root: ctx.repo_root.to_path_buf(),
         dry_run: false,
         update: false,
         sha_cache: std::collections::HashMap::new(),
         locked,
     };
-    sync_entry(&client, entry, &mut ctx)?;
-    write_lock(repo_root, &ctx.locked)?;
+    sync_entry(&client, entry, &mut sync_ctx)?;
+    write_lock(ctx.repo_root, &sync_ctx.locked)?;
+    let backup_ctx = BackupCaptureCtx {
+        entry,
+        manifest: ctx.manifest,
+        repo_root: ctx.repo_root,
+    };
+    ctx.rollback.capture_install_backups(&backup_ctx)?;
 
-    let all_adapters = adapters();
-    for target in &manifest.install_targets {
-        if all_adapters.contains(&target.adapter) {
-            install_entry(
-                entry,
-                target,
-                &skillfile_deploy::install::InstallCtx {
-                    repo_root,
-                    opts: None,
-                },
-            )?;
+    let mut report = InstallReport::default();
+    for target in &ctx.manifest.install_targets {
+        let outcome = install_entry_with_outcome(
+            entry,
+            target,
+            &skillfile_deploy::install::InstallCtx {
+                repo_root: ctx.repo_root,
+                opts: None,
+            },
+        )?;
+        let label = format!("{target}");
+        match outcome {
+            InstallOutcome::Installed => report.installed.push(label),
+            InstallOutcome::Skipped(reason) => {
+                report.skipped.push(format!(
+                    "{label} [{}]",
+                    skip_reason_text(reason, entry.entity_type)
+                ));
+            }
         }
     }
-    Ok(())
+    Ok(report)
 }
 
 pub struct GithubEntryArgs<'a> {
@@ -198,25 +227,274 @@ fn add_selected(selected: &[String], args: &BulkAddArgs<'_>, repo_root: &Path) {
     );
 }
 
-struct RollbackState<'a> {
-    manifest_path: &'a Path,
-    original_manifest: &'a str,
-    lock_path: &'a Path,
-    original_lock: Option<String>,
+#[derive(Default)]
+struct InstallReport {
+    installed: Vec<String>,
+    skipped: Vec<String>,
 }
 
-impl RollbackState<'_> {
-    fn rollback(&self, entry_name: &str) {
-        let _ = std::fs::write(self.manifest_path, self.original_manifest);
+impl InstallReport {
+    fn print(&self) {
+        if self.installed.is_empty() {
+            println!("No configured platforms were updated.");
+        } else {
+            println!("Installed to: {}", self.installed.join(", "));
+        }
+        if !self.skipped.is_empty() {
+            println!("Skipped: {}", self.skipped.join(", "));
+        }
+    }
+}
+
+fn skip_reason_text(reason: InstallSkipReason, entity_type: EntityType) -> String {
+    match reason {
+        InstallSkipReason::UnknownAdapter => "unknown platform".to_string(),
+        InstallSkipReason::UnsupportedEntity => format!("unsupported {entity_type}"),
+        InstallSkipReason::MissingSource => "source missing".to_string(),
+        InstallSkipReason::NothingDeployed => "nothing updated".to_string(),
+        InstallSkipReason::DryRun => "dry-run".to_string(),
+    }
+}
+
+struct PathBackup {
+    live_path: PathBuf,
+    snapshot_path: Option<PathBuf>,
+}
+
+#[derive(Default)]
+struct InstallBackups {
+    scratch_dir: Option<PathBuf>,
+    paths: Vec<PathBackup>,
+}
+
+impl Drop for InstallBackups {
+    fn drop(&mut self) {
+        if let Some(path) = &self.scratch_dir {
+            let _ = std::fs::remove_dir_all(path);
+        }
+    }
+}
+
+fn remove_path(path: &Path) -> Result<(), SkillfileError> {
+    if !(path.exists() || path.is_symlink()) {
+        return Ok(());
+    }
+    if path.is_dir() {
+        std::fs::remove_dir_all(path)?;
+    } else {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<(), SkillfileError> {
+    std::fs::create_dir_all(dest)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&source_path, &dest_path)?;
+        } else {
+            std::fs::copy(source_path, dest_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_path(source: &Path, dest: &Path) -> Result<(), SkillfileError> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if source.is_dir() {
+        copy_dir_recursive(source, dest)?;
+    } else {
+        std::fs::copy(source, dest)?;
+    }
+    Ok(())
+}
+
+fn backup_scratch_dir() -> Result<PathBuf, SkillfileError> {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| SkillfileError::Install(format!("clock error: {error}")))?
+        .as_nanos();
+    let scratch_dir = std::env::temp_dir()
+        .join("skillfile")
+        .join(format!("add-rollback-{}-{stamp}", std::process::id()));
+    std::fs::create_dir_all(&scratch_dir)?;
+    Ok(scratch_dir)
+}
+
+fn capture_path_backup(
+    path: &Path,
+    scratch_dir: &Path,
+    index: usize,
+) -> Result<PathBackup, SkillfileError> {
+    let snapshot_path = if path.exists() || path.is_symlink() {
+        let snapshot_path = scratch_dir.join(index.to_string());
+        copy_path(path, &snapshot_path)?;
+        Some(snapshot_path)
+    } else {
+        None
+    };
+    Ok(PathBackup {
+        live_path: path.to_path_buf(),
+        snapshot_path,
+    })
+}
+
+fn flat_backup_roots(source: &Path, target_dir: &Path) -> Vec<PathBuf> {
+    walkdir(source)
+        .into_iter()
+        .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
+        .filter_map(|path| path.file_name().map(|name| target_dir.join(name)))
+        .collect()
+}
+
+fn restore_path_backup(backup: &PathBackup) -> Result<(), SkillfileError> {
+    remove_path(&backup.live_path)?;
+    let Some(snapshot_path) = &backup.snapshot_path else {
+        return Ok(());
+    };
+    copy_path(snapshot_path, &backup.live_path)
+}
+
+fn target_backup_roots(entry: &Entry, target: &InstallTarget, repo_root: &Path) -> Vec<PathBuf> {
+    let Some(adapter) = adapters().get(&target.adapter) else {
+        return Vec::new();
+    };
+    if !adapter.supports(entry.entity_type) {
+        return Vec::new();
+    }
+    let Some(source) = source_path(entry, repo_root).filter(|path| path.exists()) else {
+        return Vec::new();
+    };
+
+    let scope = AdapterScope {
+        scope: target.scope,
+        repo_root,
+    };
+    let target_dir = adapter.target_dir(entry.entity_type, &scope);
+    if !is_dir_entry(entry) && !source.is_dir() {
+        return vec![adapter.installed_path(entry, &scope)];
+    }
+
+    if adapter.dir_mode(entry.entity_type) == Some(DirInstallMode::Flat) {
+        return flat_backup_roots(&source, &target_dir);
+    }
+
+    vec![target_dir.join(&entry.name)]
+}
+
+impl InstallBackups {
+    fn capture(&mut self, ctx: &BackupCaptureCtx<'_>) -> Result<(), SkillfileError> {
+        let mut roots = Vec::new();
+        for target in &ctx.manifest.install_targets {
+            roots.extend(target_backup_roots(ctx.entry, target, ctx.repo_root));
+        }
+        if roots.is_empty() {
+            return Ok(());
+        }
+
+        let scratch_dir = backup_scratch_dir()?;
+        self.scratch_dir = Some(scratch_dir.clone());
+        let mut seen = std::collections::HashSet::new();
+        roots.retain(|root| seen.insert(root.clone()));
+        for root in roots {
+            let backup = capture_path_backup(&root, &scratch_dir, self.paths.len())?;
+            self.paths.push(backup);
+        }
+        Ok(())
+    }
+
+    fn restore(&self) -> Result<(), SkillfileError> {
+        for backup in self.paths.iter().rev() {
+            restore_path_backup(backup)?;
+        }
+        Ok(())
+    }
+}
+
+fn record_io_result(errors: &mut Vec<String>, label: &str, result: std::io::Result<()>) {
+    if let Err(error) = result {
+        errors.push(format!("{label}: {error}"));
+    }
+}
+
+struct RollbackState {
+    manifest_path: PathBuf,
+    original_manifest: String,
+    lock_path: PathBuf,
+    original_lock: Option<String>,
+    cache_dir: PathBuf,
+    install_backups: InstallBackups,
+}
+
+impl RollbackState {
+    fn capture_install_backups(
+        &mut self,
+        ctx: &BackupCaptureCtx<'_>,
+    ) -> Result<(), SkillfileError> {
+        self.install_backups.capture(ctx)
+    }
+
+    fn rollback(&self, entry_name: &str) -> Result<(), SkillfileError> {
+        let mut errors = Vec::new();
+
+        if let Err(error) = self.install_backups.restore() {
+            errors.push(format!("restore installed files: {error}"));
+        }
+        record_io_result(
+            &mut errors,
+            &format!("restore {MANIFEST_NAME}"),
+            std::fs::write(&self.manifest_path, &self.original_manifest),
+        );
         match &self.original_lock {
-            None => {
-                let _ = std::fs::remove_file(self.lock_path);
-            }
-            Some(text) => {
-                let _ = std::fs::write(self.lock_path, text);
-            }
+            None if !self.lock_path.exists() => {}
+            None => record_io_result(
+                &mut errors,
+                "remove Skillfile.lock",
+                std::fs::remove_file(&self.lock_path),
+            ),
+            Some(text) => record_io_result(
+                &mut errors,
+                "restore Skillfile.lock",
+                std::fs::write(&self.lock_path, text),
+            ),
+        }
+        if self.cache_dir.exists() {
+            record_io_result(
+                &mut errors,
+                "remove cache dir",
+                std::fs::remove_dir_all(&self.cache_dir),
+            );
+        }
+
+        if !errors.is_empty() {
+            return Err(SkillfileError::Install(errors.join("; ")));
         }
         eprintln!("Rolled back: removed '{entry_name}' from {MANIFEST_NAME}");
+        Ok(())
+    }
+}
+
+fn finish_add_install(
+    entry_name: &str,
+    rollback: &RollbackState,
+    result: Result<InstallReport, SkillfileError>,
+) -> Result<InstallReport, SkillfileError> {
+    match result {
+        Ok(report) => Ok(report),
+        Err(original_error) => {
+            if let Err(rollback_error) = rollback.rollback(entry_name) {
+                return Err(SkillfileError::Install(format!(
+                    "failed to install '{entry_name}' and rollback also failed: {rollback_error}; \
+                     repository may need manual cleanup (original error: {original_error})"
+                )));
+            }
+            Err(original_error)
+        }
     }
 }
 
@@ -258,38 +536,38 @@ pub fn cmd_add(entry: &Entry, repo_root: &Path) -> Result<(), SkillfileError> {
 
     let line = format_line(entry);
     let original_manifest = append_and_format_entry(entry, &manifest_path)?;
-    println!("Added: {line}");
 
     let result = parse_manifest(&manifest_path)?;
     if result.manifest.install_targets.is_empty() {
+        println!("Added: {line}");
         println!("No install targets configured yet. Run `skillfile init` to pick platforms.");
         return Ok(());
     }
 
     let lock_path = repo_root.join("Skillfile.lock");
-    let rb = RollbackState {
-        manifest_path: &manifest_path,
-        original_manifest: &original_manifest,
-        lock_path: &lock_path,
+    let mut rb = RollbackState {
+        manifest_path: manifest_path.clone(),
+        original_manifest,
         original_lock: lock_path
             .exists()
             .then(|| std::fs::read_to_string(&lock_path))
             .transpose()?,
+        lock_path,
+        cache_dir: vendor_dir_for(entry, repo_root),
+        install_backups: InstallBackups::default(),
     };
+    let sync_result = {
+        let mut install_ctx = AddInstallCtx {
+            manifest: &result.manifest,
+            rollback: &mut rb,
+            repo_root,
+        };
+        sync_and_install(entry, &mut install_ctx)
+    };
+    let report = finish_add_install(&entry.name, &rb, sync_result)?;
 
-    if let Err(e) = sync_and_install(entry, repo_root, &result.manifest) {
-        rb.rollback(&entry.name);
-        return Err(e);
-    }
-
-    let target_list = result
-        .manifest
-        .install_targets
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join(", ");
-    println!("Installed to: {target_list}");
+    println!("Added: {line}");
+    report.print();
     Ok(())
 }
 
@@ -761,22 +1039,31 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join(MANIFEST_NAME);
         let lock_path = dir.path().join("Skillfile.lock");
+        let cache_dir = dir.path().join(".skillfile/cache/skills/foo");
         let original = "local  skill  skills/foo.md\n";
         std::fs::write(&manifest_path, "corrupted content").unwrap();
         // No lock file pre-existed.
         std::fs::write(&lock_path, "some lock").unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("foo.md"), "cached").unwrap();
         let rb = RollbackState {
-            manifest_path: &manifest_path,
-            original_manifest: original,
-            lock_path: &lock_path,
+            manifest_path,
+            original_manifest: original.to_string(),
+            lock_path,
             original_lock: None,
+            cache_dir: cache_dir.clone(),
+            install_backups: InstallBackups::default(),
         };
-        rb.rollback("foo");
-        let restored = std::fs::read_to_string(&manifest_path).unwrap();
+        rb.rollback("foo").unwrap();
+        let restored = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
         assert_eq!(restored, original);
         assert!(
-            !lock_path.exists(),
+            !dir.path().join("Skillfile.lock").exists(),
             "lock should be removed when original was None"
+        );
+        assert!(
+            !cache_dir.exists(),
+            "cache dir should be removed on rollback"
         );
     }
 
@@ -785,22 +1072,96 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let manifest_path = dir.path().join(MANIFEST_NAME);
         let lock_path = dir.path().join("Skillfile.lock");
+        let cache_dir = dir.path().join(".skillfile/cache/skills/bar");
         let original_manifest = "local  skill  skills/bar.md\n";
         let original_lock = "lock content\n";
         std::fs::write(&manifest_path, "corrupted").unwrap();
         std::fs::write(&lock_path, "new lock").unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
         let rb = RollbackState {
-            manifest_path: &manifest_path,
-            original_manifest,
-            lock_path: &lock_path,
+            manifest_path,
+            original_manifest: original_manifest.to_string(),
+            lock_path,
             original_lock: Some(original_lock.to_string()),
+            cache_dir: cache_dir.clone(),
+            install_backups: InstallBackups::default(),
         };
-        rb.rollback("bar");
+        rb.rollback("bar").unwrap();
         assert_eq!(
-            std::fs::read_to_string(&manifest_path).unwrap(),
+            std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap(),
             original_manifest
         );
-        assert_eq!(std::fs::read_to_string(&lock_path).unwrap(), original_lock);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("Skillfile.lock")).unwrap(),
+            original_lock
+        );
+        assert!(
+            !cache_dir.exists(),
+            "cache dir should be removed on rollback"
+        );
+    }
+
+    #[test]
+    fn rollback_returns_error_when_manifest_restore_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join(MANIFEST_NAME);
+        std::fs::create_dir_all(&manifest_path).unwrap();
+        let rb = RollbackState {
+            manifest_path,
+            original_manifest: "local  skill  skills/baz.md\n".to_string(),
+            lock_path: dir.path().join("Skillfile.lock"),
+            original_lock: None,
+            cache_dir: dir.path().join(".skillfile/cache/skills/baz"),
+            install_backups: InstallBackups::default(),
+        };
+        let result = rb.rollback("baz");
+        assert!(matches!(result, Err(SkillfileError::Install(message)) if
+            message.contains("restore Skillfile")));
+    }
+
+    #[test]
+    fn install_backups_restore_removes_new_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_path = dir.path().join(".claude/skills/foo");
+        let scratch_dir = backup_scratch_dir().unwrap();
+        let backup = capture_path_backup(&target_path, &scratch_dir, 0).unwrap();
+        let backups = InstallBackups {
+            scratch_dir: Some(scratch_dir),
+            paths: vec![backup],
+        };
+
+        std::fs::create_dir_all(&target_path).unwrap();
+        std::fs::write(target_path.join("SKILL.md"), "# New\n").unwrap();
+
+        backups.restore().unwrap();
+        assert!(
+            !target_path.exists(),
+            "rollback should remove paths that were absent before add"
+        );
+    }
+
+    #[test]
+    fn install_backups_restore_previous_directory_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_path = dir.path().join(".claude/skills/foo");
+        std::fs::create_dir_all(&target_path).unwrap();
+        std::fs::write(target_path.join("SKILL.md"), "# Old\n").unwrap();
+        let scratch_dir = backup_scratch_dir().unwrap();
+        let backup = capture_path_backup(&target_path, &scratch_dir, 0).unwrap();
+        let backups = InstallBackups {
+            scratch_dir: Some(scratch_dir),
+            paths: vec![backup],
+        };
+
+        std::fs::remove_dir_all(&target_path).unwrap();
+        std::fs::create_dir_all(&target_path).unwrap();
+        std::fs::write(target_path.join("SKILL.md"), "# New\n").unwrap();
+
+        backups.restore().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(target_path.join("SKILL.md")).unwrap(),
+            "# Old\n"
+        );
     }
 
     // --- add_selected tests ---

--- a/crates/deploy/src/adapter.rs
+++ b/crates/deploy/src/adapter.rs
@@ -332,23 +332,25 @@ fn deploy_flat(source_dir: &Path, target_dir: &Path, opts: &InstallOptions) -> D
         return HashMap::new();
     }
 
-    std::fs::create_dir_all(target_dir).ok();
+    if std::fs::create_dir_all(target_dir).is_err() {
+        return HashMap::new();
+    }
     let mut result = HashMap::new();
     for src in &md_files {
         let Some(name) = src.file_name() else {
             continue;
         };
         let dest = target_dir.join(name);
-        if !opts.overwrite && dest.is_file() {
+        if !place_file(
+            &PlaceOp {
+                source: src,
+                dest: &dest,
+                is_dir: false,
+            },
+            opts,
+        ) {
             continue;
         }
-        if dest.exists() {
-            std::fs::remove_file(&dest).ok();
-        }
-        if std::fs::copy(src, &dest).is_err() {
-            continue;
-        }
-        progress!("  {} -> {}", name.to_string_lossy(), dest.display());
         if let Ok(rel) = src.strip_prefix(source_dir) {
             result.insert(forward_slash(rel), dest);
         }
@@ -362,14 +364,37 @@ struct PlaceOp<'a> {
     is_dir: bool,
 }
 
+fn remove_existing_path(path: &Path) -> std::io::Result<()> {
+    if !(path.exists() || path.is_symlink()) {
+        return Ok(());
+    }
+    if path.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
+}
+
+fn cleanup_failed_path(path: &Path) {
+    let _ = remove_existing_path(path);
+}
+
+fn copy_to_destination(op: &PlaceOp<'_>) -> std::io::Result<()> {
+    if let Some(parent) = op.dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    remove_existing_path(op.dest)?;
+    if op.is_dir {
+        copy_dir_recursive(op.source, op.dest)
+    } else {
+        std::fs::copy(op.source, op.dest).map(|_| ())
+    }
+}
+
 fn place_file(op: &PlaceOp<'_>, opts: &InstallOptions) -> bool {
-    if !opts.overwrite && !opts.dry_run {
-        if op.is_dir && op.dest.is_dir() {
-            return false;
-        }
-        if !op.is_dir && op.dest.is_file() {
-            return false;
-        }
+    if !opts.overwrite && !opts.dry_run && (op.dest.exists() || op.dest.is_symlink()) {
+        return false;
     }
 
     let label = format!(
@@ -383,23 +408,9 @@ fn place_file(op: &PlaceOp<'_>, opts: &InstallOptions) -> bool {
         return true;
     }
 
-    if let Some(parent) = op.dest.parent() {
-        std::fs::create_dir_all(parent).ok();
-    }
-
-    // Remove existing
-    if op.dest.exists() || op.dest.is_symlink() {
-        if op.dest.is_dir() {
-            std::fs::remove_dir_all(op.dest).ok();
-        } else {
-            std::fs::remove_file(op.dest).ok();
-        }
-    }
-
-    if op.is_dir {
-        copy_dir_recursive(op.source, op.dest).ok();
-    } else {
-        std::fs::copy(op.source, op.dest).ok();
+    if copy_to_destination(op).is_err() {
+        cleanup_failed_path(op.dest);
+        return false;
     }
 
     progress!("{label}");

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use skillfile_core::conflict::{read_conflict, write_conflict};
@@ -16,7 +16,7 @@ use skillfile_core::progress;
 use skillfile_sources::strategy::{content_file, is_dir_entry};
 use skillfile_sources::sync::{cmd_sync, vendor_dir_for};
 
-use crate::adapter::{adapters, DeployRequest};
+use crate::adapter::{adapters, AdapterScope, DeployRequest, DirInstallMode, PlatformAdapter};
 use crate::paths::{installed_dir_files, installed_path, source_path};
 
 // ---------------------------------------------------------------------------
@@ -311,33 +311,220 @@ pub struct InstallCtx<'a> {
     pub opts: Option<&'a InstallOptions>,
 }
 
-/// Returns `Err(PatchConflict)` if a stored patch fails to apply cleanly.
+/// Why an install target was skipped instead of being updated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallSkipReason {
+    UnknownAdapter,
+    UnsupportedEntity,
+    MissingSource,
+    NothingDeployed,
+    DryRun,
+}
+
+/// Outcome of attempting to deploy one entry to one install target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallOutcome {
+    Installed,
+    Skipped(InstallSkipReason),
+}
+
 pub fn install_entry(
     entry: &Entry,
     target: &InstallTarget,
     ctx: &InstallCtx<'_>,
 ) -> Result<(), SkillfileError> {
+    let _ = install_entry_with_outcome(entry, target, ctx)?;
+    Ok(())
+}
+
+fn install_failure(entry: &Entry, target: &InstallTarget, detail: &str) -> SkillfileError {
+    SkillfileError::Install(format!(
+        "failed to install '{}' to {target}: {detail}",
+        entry.name
+    ))
+}
+
+fn forward_slash(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+struct InstallValidationCtx<'a> {
+    entry: &'a Entry,
+    target: &'a InstallTarget,
+    repo_root: &'a Path,
+    source: &'a Path,
+    adapter: &'a dyn PlatformAdapter,
+    is_dir: bool,
+    opts: &'a InstallOptions,
+}
+
+struct InstallPlan {
+    expected: HashMap<String, PathBuf>,
+    existing_before: HashSet<String>,
+}
+
+struct ValidatedInstall {
+    installed: HashMap<String, PathBuf>,
+    outcome: InstallOutcome,
+}
+
+fn flat_expected_paths(source: &Path, target_dir: &Path) -> HashMap<String, PathBuf> {
+    walkdir(source)
+        .into_iter()
+        .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
+        .filter_map(|path| {
+            let rel = path.strip_prefix(source).ok()?;
+            let name = path.file_name()?;
+            Some((forward_slash(rel), target_dir.join(name)))
+        })
+        .collect()
+}
+
+fn nested_expected_paths(source: &Path, dest_root: &Path) -> HashMap<String, PathBuf> {
+    walkdir(source)
+        .into_iter()
+        .filter(|path| path.file_name().is_none_or(|name| name != ".meta"))
+        .filter_map(|path| {
+            let rel = path.strip_prefix(source).ok()?;
+            Some((forward_slash(rel), dest_root.join(rel)))
+        })
+        .collect()
+}
+
+fn planned_install_paths(ctx: &InstallValidationCtx<'_>) -> HashMap<String, PathBuf> {
+    let scope = AdapterScope {
+        scope: ctx.target.scope,
+        repo_root: ctx.repo_root,
+    };
+    let target_dir = ctx.adapter.target_dir(ctx.entry.entity_type, &scope);
+    if !ctx.is_dir {
+        let key = format!("{}.md", ctx.entry.name);
+        return HashMap::from([(key, ctx.adapter.installed_path(ctx.entry, &scope))]);
+    }
+
+    match ctx.adapter.dir_mode(ctx.entry.entity_type) {
+        Some(DirInstallMode::Flat) => flat_expected_paths(ctx.source, &target_dir),
+        _ => nested_expected_paths(ctx.source, &target_dir.join(&ctx.entry.name)),
+    }
+}
+
+fn build_install_plan(ctx: &InstallValidationCtx<'_>) -> InstallPlan {
+    let expected = planned_install_paths(ctx);
+    let existing_before = expected
+        .iter()
+        .filter_map(|(key, path)| path.is_file().then_some(key.clone()))
+        .collect();
+    InstallPlan {
+        expected,
+        existing_before,
+    }
+}
+
+fn cleanup_created_files(plan: &InstallPlan, installed: &HashMap<String, PathBuf>) {
+    for (key, path) in installed {
+        if plan.existing_before.contains(key) {
+            continue;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+fn validate_installed_files(
+    ctx: &InstallValidationCtx<'_>,
+    plan: &InstallPlan,
+    installed: HashMap<String, PathBuf>,
+) -> Result<ValidatedInstall, SkillfileError> {
+    let reported_count = installed.len();
+    let existing = installed
+        .into_iter()
+        .filter(|(_, path)| path.is_file())
+        .collect::<HashMap<_, _>>();
+
+    if existing.len() != reported_count {
+        return Err(install_failure(
+            ctx.entry,
+            ctx.target,
+            "adapter reported installed files that do not exist on disk",
+        ));
+    }
+
+    let expected = plan.expected.len();
+    if expected == 0 {
+        return Ok(ValidatedInstall {
+            installed: existing,
+            outcome: InstallOutcome::Skipped(InstallSkipReason::NothingDeployed),
+        });
+    }
+
+    let present = plan.expected.values().filter(|path| path.is_file()).count();
+    if present == 0 {
+        cleanup_created_files(plan, &existing);
+        return Err(install_failure(
+            ctx.entry,
+            ctx.target,
+            "no files were written to the target platform directory",
+        ));
+    }
+
+    if present < expected {
+        cleanup_created_files(plan, &existing);
+        return Err(install_failure(
+            ctx.entry,
+            ctx.target,
+            &format!("only {present} of {expected} expected file(s) were written"),
+        ));
+    }
+
+    let outcome = if ctx.opts.overwrite || plan.existing_before.len() != expected {
+        InstallOutcome::Installed
+    } else {
+        InstallOutcome::Skipped(InstallSkipReason::NothingDeployed)
+    };
+    Ok(ValidatedInstall {
+        installed: existing,
+        outcome,
+    })
+}
+
+/// Returns `Err(PatchConflict)` if a stored patch fails to apply cleanly.
+pub fn install_entry_with_outcome(
+    entry: &Entry,
+    target: &InstallTarget,
+    ctx: &InstallCtx<'_>,
+) -> Result<InstallOutcome, SkillfileError> {
     let default_opts = InstallOptions::default();
     let opts = ctx.opts.unwrap_or(&default_opts);
 
     let all_adapters = adapters();
     let Some(adapter) = all_adapters.get(&target.adapter) else {
-        return Ok(());
+        return Ok(InstallOutcome::Skipped(InstallSkipReason::UnknownAdapter));
     };
 
     if !adapter.supports(entry.entity_type) {
-        return Ok(());
+        return Ok(InstallOutcome::Skipped(
+            InstallSkipReason::UnsupportedEntity,
+        ));
     }
 
     let source = match source_path(entry, ctx.repo_root) {
         Some(p) if p.exists() => p,
         _ => {
             eprintln!("  warning: source missing for {}, skipping", entry.name);
-            return Ok(());
+            return Ok(InstallOutcome::Skipped(InstallSkipReason::MissingSource));
         }
     };
 
     let is_dir = is_dir_entry(entry) || source.is_dir();
+    let validation_ctx = InstallValidationCtx {
+        entry,
+        target,
+        repo_root: ctx.repo_root,
+        source: &source,
+        adapter,
+        is_dir,
+        opts,
+    };
+    let plan = build_install_plan(&validation_ctx);
     let installed = adapter.deploy_entry(&DeployRequest {
         entry,
         source: &source,
@@ -346,8 +533,12 @@ pub fn install_entry(
         opts,
     });
 
-    if installed.is_empty() || opts.dry_run {
-        return Ok(());
+    if opts.dry_run {
+        return Ok(InstallOutcome::Skipped(InstallSkipReason::DryRun));
+    }
+    let validated = validate_installed_files(&validation_ctx, &plan, installed)?;
+    if let InstallOutcome::Skipped(reason) = validated.outcome {
+        return Ok(InstallOutcome::Skipped(reason));
     }
 
     let patch_ctx = PatchCtx {
@@ -355,15 +546,15 @@ pub fn install_entry(
         repo_root: ctx.repo_root,
     };
     if is_dir {
-        apply_dir_patches(&patch_ctx, &installed, &source)?;
+        apply_dir_patches(&patch_ctx, &validated.installed, &source)?;
     } else {
         let key = format!("{}.md", entry.name);
-        if let Some(dest) = installed.get(&key) {
+        if let Some(dest) = validated.installed.get(&key) {
             apply_single_file_patch(&patch_ctx, dest, &source)?;
         }
     }
 
-    Ok(())
+    Ok(InstallOutcome::Installed)
 }
 
 // ---------------------------------------------------------------------------
@@ -731,7 +922,7 @@ mod tests {
 
         let entry = make_local_entry("my-skill", "skills/my-skill.md");
         let target = make_target("claude-code", Scope::Local);
-        install_entry(
+        let outcome = install_entry_with_outcome(
             &entry,
             &target,
             &InstallCtx {
@@ -740,6 +931,7 @@ mod tests {
             },
         )
         .unwrap();
+        assert_eq!(outcome, InstallOutcome::Installed);
 
         let dest = dir.path().join(".claude/skills/my-skill/SKILL.md");
         assert!(dest.exists());
@@ -798,7 +990,7 @@ mod tests {
             dry_run: true,
             ..Default::default()
         };
-        install_entry(
+        let outcome = install_entry_with_outcome(
             &entry,
             &target,
             &InstallCtx {
@@ -807,6 +999,7 @@ mod tests {
             },
         )
         .unwrap();
+        assert_eq!(outcome, InstallOutcome::Skipped(InstallSkipReason::DryRun));
 
         let dest = dir.path().join(".claude/skills/my-skill/SKILL.md");
         assert!(!dest.exists());
@@ -949,8 +1142,7 @@ mod tests {
         let entry = make_agent_entry("my-agent");
         let target = make_target("claude-code", Scope::Local);
 
-        // Should return Ok without error — just a warning
-        install_entry(
+        let outcome = install_entry_with_outcome(
             &entry,
             &target,
             &InstallCtx {
@@ -959,6 +1151,59 @@ mod tests {
             },
         )
         .unwrap();
+        assert_eq!(
+            outcome,
+            InstallOutcome::Skipped(InstallSkipReason::MissingSource)
+        );
+    }
+
+    #[test]
+    fn install_entry_unknown_adapter_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_file = dir.path().join("skills/my-skill.md");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::write(&source_file, "# My Skill").unwrap();
+
+        let entry = make_local_entry("my-skill", "skills/my-skill.md");
+        let target = make_target("unknown-adapter", Scope::Local);
+        let outcome = install_entry_with_outcome(
+            &entry,
+            &target,
+            &InstallCtx {
+                repo_root: dir.path(),
+                opts: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            outcome,
+            InstallOutcome::Skipped(InstallSkipReason::UnknownAdapter)
+        );
+    }
+
+    #[test]
+    fn install_entry_errors_when_target_path_is_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_file = dir.path().join("skills/my-skill.md");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::write(&source_file, "# My Skill").unwrap();
+        std::fs::write(dir.path().join(".claude"), "not a directory").unwrap();
+
+        let entry = make_local_entry("my-skill", "skills/my-skill.md");
+        let target = make_target("claude-code", Scope::Local);
+        let result = install_entry(
+            &entry,
+            &target,
+            &InstallCtx {
+                repo_root: dir.path(),
+                opts: None,
+            },
+        );
+        assert!(matches!(
+            result,
+            Err(SkillfileError::Install(message))
+                if message.contains("failed to install 'my-skill' to claude-code (local)")
+        ));
     }
 
     // -- Patch application during install --
@@ -1106,7 +1351,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let entry = make_agent_entry("my-agent");
         let target = make_target("codex", Scope::Local);
-        install_entry(
+        let outcome = install_entry_with_outcome(
             &entry,
             &target,
             &InstallCtx {
@@ -1115,6 +1360,10 @@ mod tests {
             },
         )
         .unwrap();
+        assert_eq!(
+            outcome,
+            InstallOutcome::Skipped(InstallSkipReason::UnsupportedEntity)
+        );
 
         assert!(!dir.path().join(".codex").exists());
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -456,6 +456,287 @@ fn add_prints_no_targets_message_when_none_configured() {
     );
 }
 
+#[test]
+fn add_reports_only_targets_that_were_updated() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("agents")).unwrap();
+    std::fs::write(dir.path().join("agents/test.md"), "# Test Agent\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         install  codex  local\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "agent", "agents/test.md"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Installed to: claude-code (local)"),
+        "should report the supported target, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Skipped: codex (local) [unsupported agent]"),
+        "should report skipped unsupported targets, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Installed to: claude-code (local), codex (local)"),
+        "must not claim unsupported targets were installed, got: {stdout}"
+    );
+    assert!(
+        !dir.path().join(".skillfile/tmp").exists(),
+        "successful add should not leave repo-local transaction scratch dirs behind"
+    );
+}
+
+#[test]
+fn add_reports_when_no_configured_platforms_were_updated() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("agents")).unwrap();
+    std::fs::write(dir.path().join("agents/test.md"), "# Test Agent\n").unwrap();
+    std::fs::write(dir.path().join("Skillfile"), "install  codex  local\n").unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "agent", "agents/test.md"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No configured platforms were updated."),
+        "should report that all configured targets were skipped, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Skipped: codex (local) [unsupported agent]"),
+        "should explain why nothing was updated, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Installed to:"),
+        "must not print an install-success summary when nothing was updated, got: {stdout}"
+    );
+}
+
+#[test]
+fn add_missing_source_does_not_claim_install_success() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "skill", "skills/missing.md"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("No configured platforms were updated."),
+        "should not report install success when the source is missing, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Skipped: claude-code (local) [source missing]"),
+        "should summarize the skipped target, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Installed to:"),
+        "must not claim install success for a missing source, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("warning: source missing"),
+        "missing source warning should still be emitted, got: {stderr}"
+    );
+}
+
+#[test]
+fn add_rolls_back_when_install_target_path_is_blocked() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/test.md"), "# Test Skill\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join(".claude"), "not a directory\n").unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "skill", "skills/test.md"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !output.status.success(),
+        "command should fail when install target is blocked"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stdout.contains("Added:"),
+        "failed add must not print a success banner, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("Rolled back: removed 'test' from Skillfile"),
+        "rollback message should be emitted, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("failed to install 'test' to claude-code (local)"),
+        "install failure should be surfaced, got: {stderr}"
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("Skillfile")).unwrap(),
+        "install  claude-code  local\n"
+    );
+    assert!(
+        !dir.path().join("Skillfile.lock").exists(),
+        "lock file should be removed on rollback"
+    );
+    assert!(
+        !dir.path().join(".skillfile/cache/skills/test").exists(),
+        "cache dir should be removed on rollback"
+    );
+    assert!(
+        !dir.path().join(".skillfile/tmp").exists(),
+        "rollback should not leave repo-local transaction scratch dirs behind"
+    );
+}
+
+#[test]
+fn add_removes_earlier_platform_files_when_later_target_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/test.md"), "# Test Skill\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         install  cursor  local\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join(".cursor"), "not a directory\n").unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "skill", "skills/test.md"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !output.status.success(),
+        "command should fail when a later target is blocked"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stdout.contains("Added:"),
+        "rolled-back add must not print a success banner, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("Rolled back: removed 'test' from Skillfile"),
+        "rollback should still be announced, got: {stderr}"
+    );
+    assert!(
+        !dir.path().join(".claude/skills/test/SKILL.md").exists(),
+        "files written to earlier targets must be removed on rollback"
+    );
+    assert!(
+        !dir.path().join(".skillfile/tmp").exists(),
+        "rolled-back add should not leave repo-local transaction scratch dirs behind"
+    );
+}
+
+#[test]
+fn install_fails_when_nested_target_path_is_blocked_without_update() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/test.md"), "# Test Skill\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         local  skill  test  skills/test.md\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join(".claude"), "not a directory\n").unwrap();
+
+    let output = sf(dir.path())
+        .arg("install")
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !output.status.success(),
+        "default install should fail when the target path is blocked"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to install 'test' to claude-code (local)"),
+        "install failure should be surfaced, got: {stderr}"
+    );
+    assert!(
+        !stdout.contains("Done."),
+        "failed install must not report success, got: {stdout}"
+    );
+    assert!(
+        !dir.path().join(".claude/skills/test/SKILL.md").exists(),
+        "blocked install must not leave a deployed file behind"
+    );
+}
+
+#[test]
+fn install_cleans_up_partial_flat_write_failures() {
+    let dir = tempfile::tempdir().unwrap();
+    let agent_dir = dir.path().join("agents/core-dev");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("alpha.md"), "# Alpha\n").unwrap();
+    std::fs::write(agent_dir.join("beta.md"), "# Beta\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         local  agent  core-dev  agents/core-dev\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/agents/alpha.md")).unwrap();
+
+    let output = sf(dir.path())
+        .arg("install")
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !output.status.success(),
+        "install should fail when only part of a flat directory can be deployed"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to install 'core-dev' to claude-code (local)"),
+        "partial flat failure should be surfaced, got: {stderr}"
+    );
+    assert!(
+        dir.path().join(".claude/agents/alpha.md").is_dir(),
+        "the pre-existing blocking path should remain untouched"
+    );
+    assert!(
+        !dir.path().join(".claude/agents/beta.md").exists(),
+        "newly written files must be cleaned up after partial failure"
+    );
+}
+
 /// Local directory entries must be deployed as directories, not empty .md files.
 ///
 /// Regression test: is_dir_entry() only inspected GitHub path_in_repo and


### PR DESCRIPTION
**SUMMARY**
Tighten `install` and `add` so they only report success after files are written and the transaction commits. Rollback now restores deployed platform files and keeps transaction scratch data out of the repo.

**RATIONALE**
`skillfile add` and `skillfile install` were reporting success on blocked, skipped, and partial filesystem writes. That breaks the CLI contract, leaves residue behind on failure, and makes multi-target installs unsafe.

**CHANGES**
- keep `install_entry()` stable and add `install_entry_with_outcome()` plus `InstallOutcome` and `InstallSkipReason` in `crates/deploy/src/install.rs`
- validate planned target files against the filesystem after deploy and fail on blocked or partial writes instead of returning false success
- harden `deploy_flat()` and `place_file()` in `crates/deploy/src/adapter.rs` so failed copies clean up partial output and blocked paths stay untouched
- move `cmd_add` success reporting until after install completes, print installed versus skipped targets accurately, and roll back manifest, lock, cache, and deployed platform files on failure
- store rollback scratch data under `std::env::temp_dir()` rather than `.skillfile/tmp` and add CLI regressions for cleanup, blocked paths, partial flat writes, and multi-target rollback