### PR TITLE
Harden rollback paths and close QA gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skillfile"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-core"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-deploy"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "dirs",
  "serde_json",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-sources"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "html-escape",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
@@ -15,9 +15,9 @@ categories = ["command-line-utilities", "development-tools"]
 
 [workspace.dependencies]
 # Internal crates
-skillfile-core = { path = "crates/core", version = "1.0.0" }
-skillfile-sources = { path = "crates/sources", version = "1.0.0" }
-skillfile-deploy = { path = "crates/deploy", version = "1.0.0" }
+skillfile-core = { path = "crates/core", version = "1.6.0" }
+skillfile-sources = { path = "crates/sources", version = "1.6.0" }
+skillfile-deploy = { path = "crates/deploy", version = "1.6.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Names are inferred from filenames when omitted. Full format specification in [SP
 | `sync` | Fetch into cache without deploying |
 | `search` | Browse community registries |
 | `status` | Show state of all entries |
+| `info` | Show detailed state for one entry |
 | `validate` | Check for errors in the Skillfile |
 | `format` | Sort and canonicalize the Skillfile |
 | `pin` | Capture local edits as a patch |
@@ -214,7 +215,7 @@ skillfile completions zsh > ~/.zfunc/_skillfile
 skillfile completions fish > ~/.config/fish/completions/skillfile.fish
 ```
 
-Tab completion covers all commands, flags, and entry names (for `remove`, `pin`, `unpin`, `diff`, `resolve`).
+Tab completion covers all commands, flags, and entry names (for `info`, `remove`, `pin`, `unpin`, `diff`, `resolve`).
 
 ## Security
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -48,9 +48,3 @@ pkg-fmt = "bin"
 
 [lints]
 workspace = true
-
-[profile.release]
-opt-level = "s"
-lto = true
-strip = true
-codegen-units = 1

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -1,19 +1,16 @@
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::format::sorted_manifest_text;
 use skillfile_core::error::SkillfileError;
 use skillfile_core::lock::{read_lock, write_lock};
-use skillfile_core::models::{
-    EntityType, Entry, InstallTarget, Manifest, SourceFields, DEFAULT_REF,
-};
+use skillfile_core::models::{EntityType, Entry, Manifest, SourceFields, DEFAULT_REF};
 use skillfile_core::parser::{infer_name, parse_manifest, MANIFEST_NAME};
-use skillfile_core::patch::walkdir;
-use skillfile_deploy::adapter::{adapters, AdapterScope, DirInstallMode};
-use skillfile_deploy::install::{install_entry_with_outcome, InstallOutcome, InstallSkipReason};
-use skillfile_deploy::paths::source_path;
-use skillfile_sources::strategy::{format_parts, is_dir_entry};
+use skillfile_deploy::install::{
+    capture_install_snapshot, install_entry_with_outcome, InstallOutcome, InstallSkipReason,
+    InstallSnapshot,
+};
+use skillfile_sources::strategy::format_parts;
 use skillfile_sources::sync::{sync_entry, vendor_dir_for, SyncContext};
 
 fn format_line(entry: &Entry) -> String {
@@ -25,16 +22,16 @@ fn format_line(entry: &Entry) -> String {
     parts.join("  ")
 }
 
-struct BackupCaptureCtx<'a> {
-    entry: &'a Entry,
-    manifest: &'a Manifest,
-    repo_root: &'a Path,
-}
-
 struct AddInstallCtx<'a, 'b> {
     manifest: &'a Manifest,
     rollback: &'a mut RollbackState,
     repo_root: &'b Path,
+}
+
+struct InstallSnapshotCapture<'a> {
+    entry: &'a Entry,
+    manifest: &'a Manifest,
+    repo_root: &'a Path,
 }
 
 fn sync_and_install(
@@ -52,12 +49,12 @@ fn sync_and_install(
     };
     sync_entry(&client, entry, &mut sync_ctx)?;
     write_lock(ctx.repo_root, &sync_ctx.locked)?;
-    let backup_ctx = BackupCaptureCtx {
-        entry,
-        manifest: ctx.manifest,
-        repo_root: ctx.repo_root,
-    };
-    ctx.rollback.capture_install_backups(&backup_ctx)?;
+    ctx.rollback
+        .capture_install_snapshot(&InstallSnapshotCapture {
+            entry,
+            manifest: ctx.manifest,
+            repo_root: ctx.repo_root,
+        })?;
 
     let mut report = InstallReport::default();
     for target in &ctx.manifest.install_targets {
@@ -256,166 +253,6 @@ fn skip_reason_text(reason: InstallSkipReason, entity_type: EntityType) -> Strin
     }
 }
 
-struct PathBackup {
-    live_path: PathBuf,
-    snapshot_path: Option<PathBuf>,
-}
-
-#[derive(Default)]
-struct InstallBackups {
-    scratch_dir: Option<PathBuf>,
-    paths: Vec<PathBackup>,
-}
-
-impl Drop for InstallBackups {
-    fn drop(&mut self) {
-        if let Some(path) = &self.scratch_dir {
-            let _ = std::fs::remove_dir_all(path);
-        }
-    }
-}
-
-fn remove_path(path: &Path) -> Result<(), SkillfileError> {
-    if !(path.exists() || path.is_symlink()) {
-        return Ok(());
-    }
-    if path.is_dir() {
-        std::fs::remove_dir_all(path)?;
-    } else {
-        std::fs::remove_file(path)?;
-    }
-    Ok(())
-}
-
-fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<(), SkillfileError> {
-    std::fs::create_dir_all(dest)?;
-    for entry in std::fs::read_dir(source)? {
-        let entry = entry?;
-        let source_path = entry.path();
-        let dest_path = dest.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            copy_dir_recursive(&source_path, &dest_path)?;
-        } else {
-            std::fs::copy(source_path, dest_path)?;
-        }
-    }
-    Ok(())
-}
-
-fn copy_path(source: &Path, dest: &Path) -> Result<(), SkillfileError> {
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    if source.is_dir() {
-        copy_dir_recursive(source, dest)?;
-    } else {
-        std::fs::copy(source, dest)?;
-    }
-    Ok(())
-}
-
-fn backup_scratch_dir() -> Result<PathBuf, SkillfileError> {
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|error| SkillfileError::Install(format!("clock error: {error}")))?
-        .as_nanos();
-    let scratch_dir = std::env::temp_dir()
-        .join("skillfile")
-        .join(format!("add-rollback-{}-{stamp}", std::process::id()));
-    std::fs::create_dir_all(&scratch_dir)?;
-    Ok(scratch_dir)
-}
-
-fn capture_path_backup(
-    path: &Path,
-    scratch_dir: &Path,
-    index: usize,
-) -> Result<PathBackup, SkillfileError> {
-    let snapshot_path = if path.exists() || path.is_symlink() {
-        let snapshot_path = scratch_dir.join(index.to_string());
-        copy_path(path, &snapshot_path)?;
-        Some(snapshot_path)
-    } else {
-        None
-    };
-    Ok(PathBackup {
-        live_path: path.to_path_buf(),
-        snapshot_path,
-    })
-}
-
-fn flat_backup_roots(source: &Path, target_dir: &Path) -> Vec<PathBuf> {
-    walkdir(source)
-        .into_iter()
-        .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
-        .filter_map(|path| path.file_name().map(|name| target_dir.join(name)))
-        .collect()
-}
-
-fn restore_path_backup(backup: &PathBackup) -> Result<(), SkillfileError> {
-    remove_path(&backup.live_path)?;
-    let Some(snapshot_path) = &backup.snapshot_path else {
-        return Ok(());
-    };
-    copy_path(snapshot_path, &backup.live_path)
-}
-
-fn target_backup_roots(entry: &Entry, target: &InstallTarget, repo_root: &Path) -> Vec<PathBuf> {
-    let Some(adapter) = adapters().get(&target.adapter) else {
-        return Vec::new();
-    };
-    if !adapter.supports(entry.entity_type) {
-        return Vec::new();
-    }
-    let Some(source) = source_path(entry, repo_root).filter(|path| path.exists()) else {
-        return Vec::new();
-    };
-
-    let scope = AdapterScope {
-        scope: target.scope,
-        repo_root,
-    };
-    let target_dir = adapter.target_dir(entry.entity_type, &scope);
-    if !is_dir_entry(entry) && !source.is_dir() {
-        return vec![adapter.installed_path(entry, &scope)];
-    }
-
-    if adapter.dir_mode(entry.entity_type) == Some(DirInstallMode::Flat) {
-        return flat_backup_roots(&source, &target_dir);
-    }
-
-    vec![target_dir.join(&entry.name)]
-}
-
-impl InstallBackups {
-    fn capture(&mut self, ctx: &BackupCaptureCtx<'_>) -> Result<(), SkillfileError> {
-        let mut roots = Vec::new();
-        for target in &ctx.manifest.install_targets {
-            roots.extend(target_backup_roots(ctx.entry, target, ctx.repo_root));
-        }
-        if roots.is_empty() {
-            return Ok(());
-        }
-
-        let scratch_dir = backup_scratch_dir()?;
-        self.scratch_dir = Some(scratch_dir.clone());
-        let mut seen = std::collections::HashSet::new();
-        roots.retain(|root| seen.insert(root.clone()));
-        for root in roots {
-            let backup = capture_path_backup(&root, &scratch_dir, self.paths.len())?;
-            self.paths.push(backup);
-        }
-        Ok(())
-    }
-
-    fn restore(&self) -> Result<(), SkillfileError> {
-        for backup in self.paths.iter().rev() {
-            restore_path_backup(backup)?;
-        }
-        Ok(())
-    }
-}
-
 fn record_io_result(errors: &mut Vec<String>, label: &str, result: std::io::Result<()>) {
     if let Err(error) = result {
         errors.push(format!("{label}: {error}"));
@@ -428,21 +265,23 @@ struct RollbackState {
     lock_path: PathBuf,
     original_lock: Option<String>,
     cache_dir: PathBuf,
-    install_backups: InstallBackups,
+    install_snapshot: InstallSnapshot,
 }
 
 impl RollbackState {
-    fn capture_install_backups(
+    fn capture_install_snapshot(
         &mut self,
-        ctx: &BackupCaptureCtx<'_>,
+        ctx: &InstallSnapshotCapture<'_>,
     ) -> Result<(), SkillfileError> {
-        self.install_backups.capture(ctx)
+        self.install_snapshot =
+            capture_install_snapshot(ctx.entry, &ctx.manifest.install_targets, ctx.repo_root)?;
+        Ok(())
     }
 
     fn rollback(&self, entry_name: &str) -> Result<(), SkillfileError> {
         let mut errors = Vec::new();
 
-        if let Err(error) = self.install_backups.restore() {
+        if let Err(error) = self.install_snapshot.restore() {
             errors.push(format!("restore installed files: {error}"));
         }
         record_io_result(
@@ -554,7 +393,7 @@ pub fn cmd_add(entry: &Entry, repo_root: &Path) -> Result<(), SkillfileError> {
             .transpose()?,
         lock_path,
         cache_dir: vendor_dir_for(entry, repo_root),
-        install_backups: InstallBackups::default(),
+        install_snapshot: InstallSnapshot::default(),
     };
     let sync_result = {
         let mut install_ctx = AddInstallCtx {
@@ -1052,7 +891,7 @@ mod tests {
             lock_path,
             original_lock: None,
             cache_dir: cache_dir.clone(),
-            install_backups: InstallBackups::default(),
+            install_snapshot: InstallSnapshot::default(),
         };
         rb.rollback("foo").unwrap();
         let restored = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
@@ -1084,7 +923,7 @@ mod tests {
             lock_path,
             original_lock: Some(original_lock.to_string()),
             cache_dir: cache_dir.clone(),
-            install_backups: InstallBackups::default(),
+            install_snapshot: InstallSnapshot::default(),
         };
         rb.rollback("bar").unwrap();
         assert_eq!(
@@ -1112,56 +951,11 @@ mod tests {
             lock_path: dir.path().join("Skillfile.lock"),
             original_lock: None,
             cache_dir: dir.path().join(".skillfile/cache/skills/baz"),
-            install_backups: InstallBackups::default(),
+            install_snapshot: InstallSnapshot::default(),
         };
         let result = rb.rollback("baz");
         assert!(matches!(result, Err(SkillfileError::Install(message)) if
             message.contains("restore Skillfile")));
-    }
-
-    #[test]
-    fn install_backups_restore_removes_new_paths() {
-        let dir = tempfile::tempdir().unwrap();
-        let target_path = dir.path().join(".claude/skills/foo");
-        let scratch_dir = backup_scratch_dir().unwrap();
-        let backup = capture_path_backup(&target_path, &scratch_dir, 0).unwrap();
-        let backups = InstallBackups {
-            scratch_dir: Some(scratch_dir),
-            paths: vec![backup],
-        };
-
-        std::fs::create_dir_all(&target_path).unwrap();
-        std::fs::write(target_path.join("SKILL.md"), "# New\n").unwrap();
-
-        backups.restore().unwrap();
-        assert!(
-            !target_path.exists(),
-            "rollback should remove paths that were absent before add"
-        );
-    }
-
-    #[test]
-    fn install_backups_restore_previous_directory_contents() {
-        let dir = tempfile::tempdir().unwrap();
-        let target_path = dir.path().join(".claude/skills/foo");
-        std::fs::create_dir_all(&target_path).unwrap();
-        std::fs::write(target_path.join("SKILL.md"), "# Old\n").unwrap();
-        let scratch_dir = backup_scratch_dir().unwrap();
-        let backup = capture_path_backup(&target_path, &scratch_dir, 0).unwrap();
-        let backups = InstallBackups {
-            scratch_dir: Some(scratch_dir),
-            paths: vec![backup],
-        };
-
-        std::fs::remove_dir_all(&target_path).unwrap();
-        std::fs::create_dir_all(&target_path).unwrap();
-        std::fs::write(target_path.join("SKILL.md"), "# New\n").unwrap();
-
-        backups.restore().unwrap();
-        assert_eq!(
-            std::fs::read_to_string(target_path.join("SKILL.md")).unwrap(),
-            "# Old\n"
-        );
     }
 
     // --- add_selected tests ---

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -88,6 +88,17 @@ fn ok_label() -> StyledObject<&'static str> {
     style("Skillfile OK").green().bold()
 }
 
+fn parse_warning_as_error(warning: &str) -> String {
+    warning
+        .strip_prefix("warning: ")
+        .unwrap_or(warning)
+        .to_string()
+}
+
+fn should_promote_parse_warning(warning: &str) -> bool {
+    !warning.contains("duplicate entry name")
+}
+
 pub fn cmd_validate(repo_root: &Path) -> Result<(), SkillfileError> {
     let manifest_path = repo_root.join(MANIFEST_NAME);
     if !manifest_path.exists() {
@@ -98,11 +109,13 @@ pub fn cmd_validate(repo_root: &Path) -> Result<(), SkillfileError> {
     }
 
     let result = parse_manifest(&manifest_path)?;
-    for w in &result.warnings {
-        eprintln!("{w}");
-    }
+    let mut errors: Vec<String> = result
+        .warnings
+        .iter()
+        .filter(|warning| should_promote_parse_warning(warning))
+        .map(|warning| parse_warning_as_error(warning))
+        .collect();
     let manifest = result.manifest;
-    let mut errors: Vec<String> = Vec::new();
 
     check_duplicate_names(&manifest, &mut errors);
     check_local_paths(&manifest, repo_root, &mut errors);
@@ -211,6 +224,13 @@ mod tests {
         );
         let result = cmd_validate(dir.path());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_name_parser_warning_not_promoted_twice() {
+        assert!(!should_promote_parse_warning(
+            "warning: line 2: duplicate entry name 'dup'"
+        ));
     }
 
     #[test]

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -32,6 +32,8 @@ use skillfile_core::error::SkillfileError;
 use skillfile_core::models::{InstallTarget, Manifest, Scope};
 use skillfile_core::parser::parse_manifest;
 
+const CONFIG_PATH_OVERRIDE_ENV: &str = "SKILLFILE_CONFIG_PATH";
+
 // ---------------------------------------------------------------------------
 // TOML schema
 // ---------------------------------------------------------------------------
@@ -89,7 +91,14 @@ impl InstallEntry {
 ///
 /// Returns `None` if the platform has no config directory.
 pub fn config_path() -> Option<PathBuf> {
+    if let Some(path) = config_path_override(std::env::var_os(CONFIG_PATH_OVERRIDE_ENV)) {
+        return Some(path);
+    }
     dirs::config_dir().map(|d| d.join("skillfile").join("config.toml"))
+}
+
+fn config_path_override(path: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    path.filter(|p| !p.is_empty()).map(PathBuf::from)
 }
 
 /// Read install targets from a TOML config file at the given path.
@@ -227,6 +236,17 @@ mod tests {
             assert!(path.ends_with("skillfile/config.toml"));
         }
         // On platforms without config_dir, returns None — that's fine.
+    }
+
+    #[test]
+    fn config_path_override_uses_explicit_file_path() {
+        let path = config_path_override(Some("/tmp/skillfile-config.toml".into()));
+        assert_eq!(path, Some(PathBuf::from("/tmp/skillfile-config.toml")));
+    }
+
+    #[test]
+    fn config_path_override_ignores_empty_value() {
+        assert_eq!(config_path_override(Some("".into())), None);
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -257,6 +257,10 @@ Examples:
     #[command(name = "__search-tui-test", hide = true)]
     SearchTuiTest,
 
+    #[cfg(debug_assertions)]
+    #[command(name = "__github-auth-test", hide = true)]
+    GithubAuthTest,
+
     // -- Validation (display_order 30-39) -------------------------------------
     /// Check the Skillfile for errors
     #[command(display_order = 30)]
@@ -551,6 +555,8 @@ fn run_source_commands(repo_root: &Path, cmd: Command) -> Result<(), SkillfileEr
         }),
         #[cfg(debug_assertions)]
         Command::SearchTuiTest => run_search_tui_test(),
+        #[cfg(debug_assertions)]
+        Command::GithubAuthTest => run_github_auth_test(),
         _ => Ok(()), // covered by run_content_commands
     }
 }
@@ -574,6 +580,19 @@ fn run_search_tui_test() -> Result<(), SkillfileError> {
     commands::search_tui::run_tui(&items, items.len())
         .map(|_| ())
         .map_err(|e| SkillfileError::Install(format!("TUI error: {e}")))
+}
+
+#[cfg(debug_assertions)]
+fn run_github_auth_test() -> Result<(), SkillfileError> {
+    if skillfile_sources::http::github_token()
+        .for_url("https://api.github.com/user")
+        .is_some()
+    {
+        println!("available");
+        Ok(())
+    } else {
+        Err(SkillfileError::Install("github auth unavailable".into()))
+    }
 }
 
 fn run() -> Result<(), SkillfileError> {

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -1,5 +1,8 @@
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use skillfile_core::conflict::{read_conflict, write_conflict};
 use skillfile_core::error::SkillfileError;
@@ -9,8 +12,8 @@ use skillfile_core::models::{
 };
 use skillfile_core::parser::{parse_manifest, MANIFEST_NAME};
 use skillfile_core::patch::{
-    apply_patch_pure, dir_patch_path, generate_patch, has_patch, patches_root, read_patch,
-    remove_patch, walkdir, write_dir_patch, write_patch,
+    apply_patch_pure, dir_patch_path, generate_patch, has_patch, patch_path, patches_root,
+    read_patch, remove_patch, walkdir, write_dir_patch, write_patch,
 };
 use skillfile_core::progress;
 use skillfile_sources::strategy::{content_file, is_dir_entry};
@@ -18,6 +21,8 @@ use skillfile_sources::sync::{cmd_sync, vendor_dir_for};
 
 use crate::adapter::{adapters, AdapterScope, DeployRequest, DirInstallMode, PlatformAdapter};
 use crate::paths::{installed_dir_files, installed_path, source_path};
+
+static SNAPSHOT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 // ---------------------------------------------------------------------------
 // Patch application helpers
@@ -344,6 +349,197 @@ fn install_failure(entry: &Entry, target: &InstallTarget, detail: &str) -> Skill
     ))
 }
 
+struct PathSnapshot {
+    live_path: PathBuf,
+    snapshot_path: Option<PathBuf>,
+}
+
+#[derive(Default)]
+pub struct InstallSnapshot {
+    scratch_dir: Option<PathBuf>,
+    paths: Vec<PathSnapshot>,
+    preserve_scratch: Cell<bool>,
+}
+
+impl Drop for InstallSnapshot {
+    fn drop(&mut self) {
+        if self.preserve_scratch.get() {
+            return;
+        }
+        if let Some(path) = &self.scratch_dir {
+            let _ = std::fs::remove_dir_all(path);
+            remove_empty_dir(path.parent());
+        }
+    }
+}
+
+fn remove_empty_dir(path: Option<&Path>) {
+    let Some(path) = path else {
+        return;
+    };
+    if path
+        .read_dir()
+        .is_ok_and(|mut entries| entries.next().is_none())
+    {
+        let _ = std::fs::remove_dir(path);
+    }
+}
+
+fn remove_path(path: &Path) -> std::io::Result<()> {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    if metadata.file_type().is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
+}
+
+#[cfg(unix)]
+fn create_symlink(target: &Path, link: &Path, _is_dir: bool) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn create_symlink(target: &Path, link: &Path, is_dir: bool) -> std::io::Result<()> {
+    if is_dir {
+        std::os::windows::fs::symlink_dir(target, link)
+    } else {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+}
+
+#[cfg(windows)]
+fn symlink_is_dir(path: &Path) -> std::io::Result<bool> {
+    use std::os::windows::fs::FileTypeExt as _;
+
+    Ok(std::fs::symlink_metadata(path)?
+        .file_type()
+        .is_symlink_dir())
+}
+
+#[cfg(windows)]
+fn copy_symlink(source: &Path, dest: &Path) -> std::io::Result<()> {
+    let target = std::fs::read_link(source)?;
+    create_symlink(&target, dest, symlink_is_dir(source)?)
+}
+
+#[cfg(not(windows))]
+fn copy_symlink(source: &Path, dest: &Path) -> std::io::Result<()> {
+    let target = std::fs::read_link(source)?;
+    create_symlink(&target, dest, false)
+}
+
+fn copy_path(source: &Path, dest: &Path) -> std::io::Result<()> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let metadata = std::fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() {
+        copy_symlink(source, dest)
+    } else if metadata.is_dir() {
+        copy_snapshot_dir(source, dest)
+    } else {
+        std::fs::copy(source, dest).map(|_| ())
+    }
+}
+
+fn copy_snapshot_dir(source: &Path, dest: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dest)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        copy_path(&source_path, &dest_path)?;
+    }
+    Ok(())
+}
+
+fn snapshot_scratch_dir(repo_root: &Path) -> std::io::Result<PathBuf> {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let seq = SNAPSHOT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = repo_root.join(".skillfile").join("tmp").join(format!(
+        "install-snapshot-{}-{stamp}-{seq}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn capture_path_snapshot(
+    live_path: PathBuf,
+    scratch_dir: &Path,
+    index: usize,
+) -> std::io::Result<PathSnapshot> {
+    let snapshot_path = if live_path.exists() || live_path.is_symlink() {
+        let snapshot_path = scratch_dir.join(index.to_string());
+        copy_path(&live_path, &snapshot_path)?;
+        Some(snapshot_path)
+    } else {
+        None
+    };
+    Ok(PathSnapshot {
+        live_path,
+        snapshot_path,
+    })
+}
+
+impl InstallSnapshot {
+    fn capture(repo_root: &Path, paths: Vec<PathBuf>) -> Result<Self, SkillfileError> {
+        let mut seen = HashSet::new();
+        let paths: Vec<PathBuf> = paths
+            .into_iter()
+            .filter(|path| seen.insert(path.clone()))
+            .collect();
+        if paths.is_empty() {
+            return Ok(Self::default());
+        }
+
+        let scratch_dir = snapshot_scratch_dir(repo_root)?;
+        let mut snapshot = Self {
+            scratch_dir: Some(scratch_dir.clone()),
+            paths: Vec::new(),
+            preserve_scratch: Cell::new(false),
+        };
+        for (index, path) in paths.into_iter().enumerate() {
+            snapshot
+                .paths
+                .push(capture_path_snapshot(path, &scratch_dir, index)?);
+        }
+        Ok(snapshot)
+    }
+
+    pub fn restore(&self) -> Result<(), SkillfileError> {
+        for snapshot in self.paths.iter().rev() {
+            self.restore_path(snapshot)?;
+        }
+        Ok(())
+    }
+
+    fn scratch_dir(&self) -> Option<&Path> {
+        self.scratch_dir.as_deref()
+    }
+
+    fn restore_path(&self, snapshot: &PathSnapshot) -> Result<(), SkillfileError> {
+        let result = restore_path_snapshot(snapshot);
+        if result.is_err() {
+            self.preserve_scratch.set(true);
+        }
+        result.map_err(SkillfileError::from)
+    }
+}
+
+fn restore_path_snapshot(snapshot: &PathSnapshot) -> std::io::Result<()> {
+    remove_path(&snapshot.live_path)?;
+    let Some(snapshot_path) = &snapshot.snapshot_path else {
+        return Ok(());
+    };
+    copy_path(snapshot_path, &snapshot.live_path)
+}
+
 fn forward_slash(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
@@ -406,6 +602,79 @@ fn planned_install_paths(ctx: &InstallValidationCtx<'_>) -> HashMap<String, Path
         Some(DirInstallMode::Flat) => flat_expected_paths(ctx.source, &target_dir),
         _ => nested_expected_paths(ctx.source, &target_dir.join(&ctx.entry.name)),
     }
+}
+
+fn patch_effect_path(ctx: &InstallValidationCtx<'_>) -> PathBuf {
+    if ctx.is_dir {
+        patches_root(ctx.repo_root)
+            .join(ctx.entry.entity_type.dir_name())
+            .join(&ctx.entry.name)
+    } else {
+        patch_path(ctx.entry, ctx.repo_root)
+    }
+}
+
+fn install_effect_paths(ctx: &InstallValidationCtx<'_>) -> Vec<PathBuf> {
+    let scope = AdapterScope {
+        scope: ctx.target.scope,
+        repo_root: ctx.repo_root,
+    };
+    let target_dir = ctx.adapter.target_dir(ctx.entry.entity_type, &scope);
+    let mut paths = if !ctx.is_dir {
+        vec![ctx.adapter.installed_path(ctx.entry, &scope)]
+    } else if ctx.adapter.dir_mode(ctx.entry.entity_type) == Some(DirInstallMode::Flat) {
+        flat_expected_paths(ctx.source, &target_dir)
+            .into_values()
+            .collect()
+    } else {
+        vec![target_dir.join(&ctx.entry.name)]
+    };
+
+    if ctx.adapter.dir_mode(ctx.entry.entity_type) != Some(DirInstallMode::Flat) {
+        paths.push(target_dir.join(format!("{}.md", ctx.entry.name)));
+    }
+    paths.push(patch_effect_path(ctx));
+    paths
+}
+
+pub fn capture_install_snapshot(
+    entry: &Entry,
+    targets: &[InstallTarget],
+    repo_root: &Path,
+) -> Result<InstallSnapshot, SkillfileError> {
+    let mut paths = Vec::new();
+    for target in targets {
+        paths.extend(install_effect_paths_for_target(entry, target, repo_root));
+    }
+    InstallSnapshot::capture(repo_root, paths)
+}
+
+fn install_effect_paths_for_target(
+    entry: &Entry,
+    target: &InstallTarget,
+    repo_root: &Path,
+) -> Vec<PathBuf> {
+    let all_adapters = adapters();
+    let Some(adapter) = all_adapters.get(&target.adapter) else {
+        return Vec::new();
+    };
+    if !adapter.supports(entry.entity_type) {
+        return Vec::new();
+    }
+    let Some(source) = source_path(entry, repo_root).filter(|path| path.exists()) else {
+        return Vec::new();
+    };
+    let default_opts = InstallOptions::default();
+    let validation_ctx = InstallValidationCtx {
+        entry,
+        target,
+        repo_root,
+        source: &source,
+        adapter,
+        is_dir: is_dir_entry(entry) || source.is_dir(),
+        opts: &default_opts,
+    };
+    install_effect_paths(&validation_ctx)
 }
 
 fn build_install_plan(ctx: &InstallValidationCtx<'_>) -> InstallPlan {
@@ -486,6 +755,66 @@ fn validate_installed_files(
     })
 }
 
+fn restore_on_install_error(snapshot: &InstallSnapshot, error: SkillfileError) -> SkillfileError {
+    match snapshot.restore() {
+        Ok(()) => error,
+        Err(rollback_error) => {
+            let snapshot_hint = snapshot.scratch_dir().map_or_else(String::new, |path| {
+                format!("; rollback snapshot kept at {}", path.display())
+            });
+            let rollback_detail = format!(
+                "rollback failed: {rollback_error}{snapshot_hint}; target may need manual cleanup"
+            );
+            match error {
+                SkillfileError::PatchConflict {
+                    message,
+                    entry_name,
+                } => SkillfileError::PatchConflict {
+                    message: format!("{message}; {rollback_detail}"),
+                    entry_name,
+                },
+                other => SkillfileError::Install(format!("{other}; {rollback_detail}")),
+            }
+        }
+    }
+}
+
+fn deploy_and_patch_entry(
+    validation_ctx: &InstallValidationCtx<'_>,
+    plan: &InstallPlan,
+) -> Result<InstallOutcome, SkillfileError> {
+    let installed = validation_ctx.adapter.deploy_entry(&DeployRequest {
+        entry: validation_ctx.entry,
+        source: validation_ctx.source,
+        scope: validation_ctx.target.scope,
+        repo_root: validation_ctx.repo_root,
+        opts: validation_ctx.opts,
+    });
+
+    if validation_ctx.opts.dry_run {
+        return Ok(InstallOutcome::Skipped(InstallSkipReason::DryRun));
+    }
+    let validated = validate_installed_files(validation_ctx, plan, installed)?;
+    if let InstallOutcome::Skipped(reason) = validated.outcome {
+        return Ok(InstallOutcome::Skipped(reason));
+    }
+
+    let patch_ctx = PatchCtx {
+        entry: validation_ctx.entry,
+        repo_root: validation_ctx.repo_root,
+    };
+    if validation_ctx.is_dir {
+        apply_dir_patches(&patch_ctx, &validated.installed, validation_ctx.source)?;
+    } else {
+        let key = format!("{}.md", validation_ctx.entry.name);
+        if let Some(dest) = validated.installed.get(&key) {
+            apply_single_file_patch(&patch_ctx, dest, validation_ctx.source)?;
+        }
+    }
+
+    Ok(InstallOutcome::Installed)
+}
+
 /// Returns `Err(PatchConflict)` if a stored patch fails to apply cleanly.
 pub fn install_entry_with_outcome(
     entry: &Entry,
@@ -525,36 +854,13 @@ pub fn install_entry_with_outcome(
         opts,
     };
     let plan = build_install_plan(&validation_ctx);
-    let installed = adapter.deploy_entry(&DeployRequest {
-        entry,
-        source: &source,
-        scope: target.scope,
-        repo_root: ctx.repo_root,
-        opts,
-    });
-
-    if opts.dry_run {
-        return Ok(InstallOutcome::Skipped(InstallSkipReason::DryRun));
-    }
-    let validated = validate_installed_files(&validation_ctx, &plan, installed)?;
-    if let InstallOutcome::Skipped(reason) = validated.outcome {
-        return Ok(InstallOutcome::Skipped(reason));
-    }
-
-    let patch_ctx = PatchCtx {
-        entry,
-        repo_root: ctx.repo_root,
-    };
-    if is_dir {
-        apply_dir_patches(&patch_ctx, &validated.installed, &source)?;
+    let snapshot = if opts.dry_run {
+        InstallSnapshot::default()
     } else {
-        let key = format!("{}.md", entry.name);
-        if let Some(dest) = validated.installed.get(&key) {
-            apply_single_file_patch(&patch_ctx, dest, &source)?;
-        }
-    }
-
-    Ok(InstallOutcome::Installed)
+        InstallSnapshot::capture(ctx.repo_root, install_effect_paths(&validation_ctx))?
+    };
+    deploy_and_patch_entry(&validation_ctx, &plan)
+        .map_err(|error| restore_on_install_error(&snapshot, error))
 }
 
 // ---------------------------------------------------------------------------
@@ -645,6 +951,18 @@ fn handle_patch_conflict(
     )))
 }
 
+fn append_rollback_detail(error: SkillfileError, patch_message: &str) -> SkillfileError {
+    if !patch_message.contains("rollback failed") {
+        return error;
+    }
+    match error {
+        SkillfileError::Install(message) => {
+            SkillfileError::Install(format!("{message}\nRollback warning: {patch_message}"))
+        }
+        other => other,
+    }
+}
+
 fn install_entry_or_conflict(
     entry: &Entry,
     target: &InstallTarget,
@@ -656,9 +974,11 @@ fn install_entry_or_conflict(
     };
     match install_entry(entry, target, &install_ctx) {
         Ok(()) => Ok(()),
-        Err(SkillfileError::PatchConflict { entry_name, .. }) => {
-            handle_patch_conflict(entry, &entry_name, ctx)
-        }
+        Err(SkillfileError::PatchConflict {
+            entry_name,
+            message,
+        }) => handle_patch_conflict(entry, &entry_name, ctx)
+            .map_err(|error| append_rollback_detail(error, &message)),
         Err(e) => Err(e),
     }
 }
@@ -1206,6 +1526,217 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn install_snapshot_restores_previous_directory_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_dir = dir.path().join("skills/foo");
+        let dest_dir = dir.path().join(".claude/skills/foo");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+        std::fs::write(source_dir.join("SKILL.md"), "# Source\n").unwrap();
+        std::fs::write(dest_dir.join("SKILL.md"), "# Old\n").unwrap();
+
+        let entry = make_local_entry("foo", "skills/foo");
+        let target = make_target("claude-code", Scope::Local);
+        let snapshot =
+            capture_install_snapshot(&entry, std::slice::from_ref(&target), dir.path()).unwrap();
+
+        std::fs::remove_dir_all(&dest_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+        std::fs::write(dest_dir.join("SKILL.md"), "# New\n").unwrap();
+
+        snapshot.restore().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest_dir.join("SKILL.md")).unwrap(),
+            "# Old\n"
+        );
+    }
+
+    #[test]
+    fn install_snapshot_restores_legacy_flat_file_side_effect() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_file = dir.path().join("skills/foo.md");
+        let legacy_file = dir.path().join(".claude/skills/foo.md");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(legacy_file.parent().unwrap()).unwrap();
+        std::fs::write(&source_file, "# Source\n").unwrap();
+        std::fs::write(&legacy_file, "# Legacy\n").unwrap();
+
+        let entry = make_local_entry("foo", "skills/foo.md");
+        let target = make_target("claude-code", Scope::Local);
+        let snapshot =
+            capture_install_snapshot(&entry, std::slice::from_ref(&target), dir.path()).unwrap();
+
+        std::fs::remove_file(&legacy_file).unwrap();
+        snapshot.restore().unwrap();
+        assert_eq!(std::fs::read_to_string(&legacy_file).unwrap(), "# Legacy\n");
+    }
+
+    #[test]
+    fn install_snapshot_restores_patch_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_file = dir.path().join("skills/foo.md");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::write(&source_file, "# Source\n").unwrap();
+
+        let entry = make_local_entry("foo", "skills/foo.md");
+        let patch = patch_fixture_path(dir.path(), &entry);
+        std::fs::create_dir_all(patch.parent().unwrap()).unwrap();
+        std::fs::write(&patch, "old patch").unwrap();
+
+        let target = make_target("claude-code", Scope::Local);
+        let snapshot =
+            capture_install_snapshot(&entry, std::slice::from_ref(&target), dir.path()).unwrap();
+        std::fs::write(&patch, "new patch").unwrap();
+
+        snapshot.restore().unwrap();
+        assert_eq!(std::fs::read_to_string(&patch).unwrap(), "old patch");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_entry_restores_existing_directory_when_copy_fails() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source_dir = dir.path().join("skills/foo");
+        let dest_dir = dir.path().join(".claude/skills/foo");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+        std::fs::write(source_dir.join("SKILL.md"), "# New\n").unwrap();
+        symlink("missing-target.md", source_dir.join("dangling.md")).unwrap();
+        std::fs::write(dest_dir.join("SKILL.md"), "# Old\n").unwrap();
+        std::fs::write(dest_dir.join("keep.md"), "# Keep\n").unwrap();
+
+        let entry = make_local_entry("foo", "skills/foo");
+        let target = make_target("claude-code", Scope::Local);
+        let result = install_entry(
+            &entry,
+            &target,
+            &InstallCtx {
+                repo_root: dir.path(),
+                opts: None,
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(SkillfileError::Install(message))
+                if message.contains("failed to install 'foo' to claude-code (local)")
+        ));
+        assert_eq!(
+            std::fs::read_to_string(dest_dir.join("SKILL.md")).unwrap(),
+            "# Old\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest_dir.join("keep.md")).unwrap(),
+            "# Keep\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_snapshot_restores_symlink_as_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join(".claude/skills/foo.md");
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        symlink("target.md", &link).unwrap();
+        let snapshot = InstallSnapshot::capture(dir.path(), vec![link.clone()]).unwrap();
+
+        std::fs::remove_file(&link).unwrap();
+        std::fs::write(&link, "# regular file\n").unwrap();
+
+        snapshot.restore().unwrap();
+        assert!(std::fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            std::fs::read_link(&link).unwrap(),
+            PathBuf::from("target.md")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn install_snapshot_restores_dangling_directory_symlink_kind() {
+        use std::os::windows::fs::{symlink_dir, FileTypeExt as _};
+
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join(".claude/skills/foo");
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        if symlink_dir("missing-dir", &link).is_err() {
+            return;
+        }
+        let snapshot = InstallSnapshot::capture(dir.path(), vec![link.clone()]).unwrap();
+
+        remove_path(&link).unwrap();
+        std::fs::write(&link, "# regular file\n").unwrap();
+
+        snapshot.restore().unwrap();
+        let file_type = std::fs::symlink_metadata(&link).unwrap().file_type();
+        assert!(file_type.is_symlink_dir());
+        assert_eq!(
+            std::fs::read_link(&link).unwrap(),
+            PathBuf::from("missing-dir")
+        );
+    }
+
+    #[test]
+    fn install_snapshot_keeps_scratch_dir_when_restore_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let live_path = dir.path().join("target/foo.md");
+        std::fs::create_dir_all(live_path.parent().unwrap()).unwrap();
+        std::fs::write(&live_path, "# old\n").unwrap();
+        let snapshot = InstallSnapshot::capture(dir.path(), vec![live_path.clone()]).unwrap();
+        let scratch_dir = snapshot.scratch_dir().unwrap().to_path_buf();
+
+        std::fs::remove_dir_all(live_path.parent().unwrap()).unwrap();
+        std::fs::write(live_path.parent().unwrap(), "parent is a file").unwrap();
+
+        let result = snapshot.restore();
+        assert!(result.is_err());
+        drop(snapshot);
+        assert!(scratch_dir.exists());
+
+        std::fs::remove_dir_all(&scratch_dir).unwrap();
+        remove_empty_dir(scratch_dir.parent());
+    }
+
+    #[test]
+    fn patch_conflict_type_survives_rollback_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let live_path = dir.path().join("target/foo.md");
+        std::fs::create_dir_all(live_path.parent().unwrap()).unwrap();
+        std::fs::write(&live_path, "# old\n").unwrap();
+        let snapshot = InstallSnapshot::capture(dir.path(), vec![live_path.clone()]).unwrap();
+        let scratch_dir = snapshot.scratch_dir().unwrap().to_path_buf();
+
+        std::fs::remove_dir_all(live_path.parent().unwrap()).unwrap();
+        std::fs::write(live_path.parent().unwrap(), "parent is a file").unwrap();
+
+        let error = restore_on_install_error(
+            &snapshot,
+            SkillfileError::PatchConflict {
+                message: "patch failed".to_string(),
+                entry_name: "foo".to_string(),
+            },
+        );
+        assert!(matches!(
+            error,
+            SkillfileError::PatchConflict { ref message, ref entry_name }
+                if entry_name == "foo"
+                    && message.contains("patch failed")
+                    && message.contains("rollback failed")
+        ));
+        drop(snapshot);
+
+        std::fs::remove_dir_all(&scratch_dir).unwrap();
+        remove_empty_dir(scratch_dir.parent());
+    }
+
     // -- Patch application during install --
 
     #[test]
@@ -1294,6 +1825,45 @@ mod tests {
         assert!(result.is_err());
         // Should be a PatchConflict error
         matches!(result.unwrap_err(), SkillfileError::PatchConflict { .. });
+    }
+
+    #[test]
+    fn install_patch_conflict_restores_previous_installed_file() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let vdir = dir.path().join(".skillfile/cache/skills/test");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(vdir.join("test.md"), "# New upstream\n").unwrap();
+
+        let entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "test".into(),
+            source: SourceFields::Github {
+                owner_repo: "owner/repo".into(),
+                path_in_repo: "skills/test.md".into(),
+                ref_: "main".into(),
+            },
+        };
+        let bad_patch =
+            "--- a/test.md\n+++ b/test.md\n@@ -1 +1 @@\n-expected_original_line\n+modified\n";
+        write_patch_fixture(dir.path(), &entry, bad_patch);
+
+        let dest = dir.path().join(".claude/skills/test/SKILL.md");
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        std::fs::write(&dest, "# Old installed\n").unwrap();
+
+        let target = make_target("claude-code", Scope::Local);
+        let result = install_entry(
+            &entry,
+            &target,
+            &InstallCtx {
+                repo_root: dir.path(),
+                opts: None,
+            },
+        );
+
+        assert!(matches!(result, Err(SkillfileError::PatchConflict { .. })));
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "# Old installed\n");
     }
 
     // -- Multi-adapter --

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -389,7 +389,16 @@ fn remove_path(path: &Path) -> std::io::Result<()> {
     let Ok(metadata) = std::fs::symlink_metadata(path) else {
         return Ok(());
     };
-    if metadata.file_type().is_dir() {
+    let file_type = metadata.file_type();
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileTypeExt as _;
+
+        if file_type.is_symlink_dir() {
+            return std::fs::remove_dir(path);
+        }
+    }
+    if file_type.is_dir() {
         std::fs::remove_dir_all(path)
     } else {
         std::fs::remove_file(path)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -71,8 +71,7 @@ fn no_args_exits_nonzero() {
 #[test]
 fn github_auth_test_detects_config_file_token() {
     let dir = tempfile::tempdir().unwrap();
-    let config_root = dir.path().join("config-root");
-    let config_path = config_root.join("skillfile").join("config.toml");
+    let config_path = dir.path().join("config.toml");
     std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
     std::fs::write(&config_path, "github_token = \"ghp_from_config\"\n").unwrap();
 
@@ -80,9 +79,7 @@ fn github_auth_test_detects_config_file_token() {
         .arg("__github-auth-test")
         .env_remove("GITHUB_TOKEN")
         .env_remove("GH_TOKEN")
-        .env("XDG_CONFIG_HOME", &config_root)
-        .env("HOME", &config_root)
-        .env("APPDATA", &config_root)
+        .env("SKILLFILE_CONFIG_PATH", &config_path)
         .env("PATH", fake_gh_path(dir.path()))
         .assert()
         .success()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,6 +12,30 @@ fn normalize_separators(text: &str) -> String {
     text.replace('\\', "/")
 }
 
+#[cfg(unix)]
+fn write_fake_gh(dir: &Path) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let gh = dir.join("gh");
+    std::fs::write(&gh, "#!/bin/sh\nexit 1\n").unwrap();
+    let perms = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(&gh, perms).unwrap();
+}
+
+#[cfg(windows)]
+fn write_fake_gh(dir: &Path) {
+    std::fs::write(dir.join("gh.cmd"), "@echo off\r\nexit /b 1\r\n").unwrap();
+}
+
+fn fake_gh_path(root: &Path) -> std::ffi::OsString {
+    let bin_dir = root.join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    write_fake_gh(&bin_dir);
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let paths = std::iter::once(bin_dir).chain(std::env::split_paths(&current));
+    std::env::join_paths(paths).unwrap()
+}
+
 // ---------------------------------------------------------------------------
 // Smoke tests (binary boots up)
 // ---------------------------------------------------------------------------
@@ -33,7 +57,7 @@ fn version_flag_exits_zero() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("skillfile"));
+        .stdout(predicate::str::starts_with("skillfile "));
 }
 
 #[test]
@@ -42,6 +66,27 @@ fn no_args_exits_nonzero() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Usage"));
+}
+
+#[test]
+fn github_auth_test_detects_config_file_token() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_root = dir.path().join("config-root");
+    let config_path = config_root.join("skillfile").join("config.toml");
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(&config_path, "github_token = \"ghp_from_config\"\n").unwrap();
+
+    sf(dir.path())
+        .arg("__github-auth-test")
+        .env_remove("GITHUB_TOKEN")
+        .env_remove("GH_TOKEN")
+        .env("XDG_CONFIG_HOME", &config_root)
+        .env("HOME", &config_root)
+        .env("APPDATA", &config_root)
+        .env("PATH", fake_gh_path(dir.path()))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("available"));
 }
 
 // ---------------------------------------------------------------------------
@@ -134,6 +179,61 @@ fn validate_error_output_is_plain_text_when_captured() {
     assert!(
         !stderr.contains("\u{1b}["),
         "captured validate stderr should stay plain text: {stderr:?}"
+    );
+}
+
+#[test]
+fn validate_parse_warnings_fail_as_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("Skillfile"), "svn  skill  bad\n").unwrap();
+
+    let output = sf(dir.path()).arg("validate").output().unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+    assert!(
+        !output.status.success(),
+        "validate should fail for malformed manifest lines"
+    );
+    assert_eq!(stdout, "", "error path should not write to stdout");
+    assert!(
+        stderr.contains("error: line 1: unknown source type 'svn', skipping"),
+        "unexpected validate stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("\u{1b}["),
+        "captured validate stderr should stay plain text: {stderr:?}"
+    );
+}
+
+#[test]
+fn validate_duplicate_name_reported_once() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/a.md"), "# A\n").unwrap();
+    std::fs::write(dir.path().join("skills/b.md"), "# B\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "local  skill  dup  skills/a.md\n\
+         local  skill  dup  skills/b.md\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path()).arg("validate").output().unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+    assert!(
+        !output.status.success(),
+        "validate should fail on duplicate names"
+    );
+    assert_eq!(
+        stderr.matches("duplicate").count(),
+        1,
+        "duplicate name should be reported once, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("error: duplicate name 'dup'"),
+        "unexpected validate stderr:\n{stderr}"
     );
 }
 
@@ -657,6 +757,48 @@ fn add_removes_earlier_platform_files_when_later_target_fails() {
 }
 
 #[test]
+fn add_restores_legacy_flat_file_when_later_target_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::create_dir_all(dir.path().join(".claude/skills")).unwrap();
+    std::fs::write(dir.path().join("skills/foo.md"), "# New Foo\n").unwrap();
+    std::fs::write(dir.path().join(".claude/skills/foo.md"), "# Legacy Foo\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         install  copilot  local\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join(".github"), "not a directory\n").unwrap();
+
+    let output = sf(dir.path())
+        .args(["add", "local", "skill", "skills/foo.md", "--name", "foo"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !output.status.success(),
+        "command should fail when a later target is blocked"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Rolled back: removed 'foo' from Skillfile"),
+        "rollback should be announced, got: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join(".claude/skills/foo.md")).unwrap(),
+        "# Legacy Foo\n",
+        "rollback must restore adapter migration side effects"
+    );
+    assert!(
+        !dir.path().join(".claude/skills/foo/SKILL.md").exists(),
+        "new nested install must be removed on rollback"
+    );
+}
+
+#[test]
 fn install_fails_when_nested_target_path_is_blocked_without_update() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(dir.path().join("skills")).unwrap();
@@ -734,6 +876,52 @@ fn install_cleans_up_partial_flat_write_failures() {
     assert!(
         !dir.path().join(".claude/agents/beta.md").exists(),
         "newly written files must be cleaned up after partial failure"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn install_update_restores_existing_nested_dir_when_copy_fails() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempfile::tempdir().unwrap();
+    let source_dir = dir.path().join("skills/foo");
+    let dest_dir = dir.path().join(".claude/skills/foo");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::create_dir_all(&dest_dir).unwrap();
+    std::fs::write(source_dir.join("SKILL.md"), "# New Foo\n").unwrap();
+    symlink("missing-target.md", source_dir.join("dangling.md")).unwrap();
+    std::fs::write(dest_dir.join("SKILL.md"), "# Old Foo\n").unwrap();
+    std::fs::write(dest_dir.join("keep.md"), "# Keep\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         local  skill  foo  skills/foo\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path())
+        .args(["install", "--update"])
+        .timeout(std::time::Duration::from_secs(5))
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !output.status.success(),
+        "install --update should fail when source copy fails"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to install 'foo' to claude-code (local)"),
+        "install failure should be surfaced, got: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dest_dir.join("SKILL.md")).unwrap(),
+        "# Old Foo\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dest_dir.join("keep.md")).unwrap(),
+        "# Keep\n"
     );
 }
 

--- a/tests/interactive.rs
+++ b/tests/interactive.rs
@@ -27,6 +27,15 @@ fn init_cmd(dir: &std::path::Path) -> Command {
     cmd
 }
 
+fn status_cmd(dir: &std::path::Path) -> Command {
+    let mut cmd = Command::new(skillfile_bin());
+    cmd.arg("status")
+        .current_dir(dir)
+        .env("TERM", "xterm-256color")
+        .env("CLICOLOR_FORCE", "1");
+    cmd
+}
+
 // ---------------------------------------------------------------------------
 // PTY sanity check
 // ---------------------------------------------------------------------------
@@ -157,4 +166,24 @@ fn search_tui_enters_alternate_screen() {
     // Kill the process (keystrokes don't reach crossterm through rexpect PTY).
     session.send_control('c').expect("send SIGINT");
     session.exp_eof().ok();
+}
+
+#[test]
+fn status_renders_ansi_in_pty() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/foo.md"), "# Foo\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         local  skill  foo  skills/foo.md\n",
+    )
+    .unwrap();
+
+    let mut session = rexpect::session::spawn_command(status_cmd(dir.path()), Some(TIMEOUT_MS))
+        .expect("failed to spawn status in PTY");
+    session
+        .exp_string("\x1b[")
+        .expect("status should render ANSI escapes on a TTY");
+    session.exp_eof().expect("status should exit cleanly");
 }

--- a/tests/upstream.rs
+++ b/tests/upstream.rs
@@ -80,21 +80,32 @@ fn sf_retry(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
     .expect("command failed after all retry attempts")
 }
 
-/// Check whether a GitHub token is available (env var or `gh` CLI).
 fn has_github_token() -> bool {
-    if std::env::var("GITHUB_TOKEN").is_ok() || std::env::var("GH_TOKEN").is_ok() {
-        return true;
+    std::env::var("GITHUB_TOKEN").is_ok_and(|t| !t.trim().is_empty())
+        || std::env::var("GH_TOKEN").is_ok_and(|t| !t.trim().is_empty())
+        || has_usable_gh_cli_token()
+}
+
+fn has_usable_gh_cli_token() -> bool {
+    let status = std::process::Command::new("gh")
+        .args(["auth", "status", "--hostname", "github.com"])
+        .output();
+    if !status.is_ok_and(|o| o.status.success()) {
+        return false;
     }
+
     std::process::Command::new("gh")
         .args(["auth", "token"])
         .output()
-        .is_ok_and(|o| o.status.success() && !o.stdout.is_empty())
+        .is_ok_and(|o| o.status.success() && !String::from_utf8_lossy(&o.stdout).trim().is_empty())
 }
 
-/// Skip the test if no GitHub token is available. Returns true if token exists.
+/// Skip the test if no usable GitHub token is available. Returns true if token exists.
 fn require_github_token() -> bool {
     if !has_github_token() {
-        eprintln!("skipping: no GitHub token (set GITHUB_TOKEN, GH_TOKEN, or run `gh auth login`)");
+        eprintln!(
+            "skipping: no usable GitHub token (set GITHUB_TOKEN, GH_TOKEN, or run `gh auth login`)"
+        );
         return false;
     }
     true


### PR DESCRIPTION
**SUMMARY**
Prepare the `v1.6.0` release by tightening rollback behavior, removing duplicate `validate` diagnostics, and closing the QA gaps found in adversarial review.

**RATIONALE**
The staged changes touched install rollback, parser validation, and release packaging. The review pass found real edge cases in rollback recovery and several weak spots in the test suite, so the work needed to prove the shipped behavior instead of relying on helper logic or fragile assertions.

**CHANGES**
- Replaced `add`-specific rollback backup logic in `crates/cli/src/commands/add.rs` with shared `InstallSnapshot` handling from `crates/deploy/src/install.rs`.
- Added snapshot and restore coverage in `crates/deploy/src/install.rs` for patch files, legacy flat-file migration side effects, symlink preservation, scratch retention on restore failure, and patch-conflict rollback.
- Fixed Windows symlink restoration in `crates/deploy/src/install.rs` by preserving symlink kind when recreating dangling directory links.
- Promoted parser warnings to `validate` errors in `crates/cli/src/commands/validate.rs` while suppressing the duplicate-name warning that was being reported twice.
- Added a hidden debug command in `crates/cli/src/main.rs` so the functional suite can prove config-file token injection through the real CLI startup path.
- Expanded functional coverage in `tests/cli.rs` for config-token detection, duplicate-name reporting, parse-warning failures, and rollback of failed installs across adapter side effects.
- Added PTY coverage in `tests/interactive.rs` for ANSI rendering in `status`.
- Tightened `tests/upstream.rs` token gating so the live upstream suite skips only when env or `gh` credentials are absent.
- Updated workspace and crate version metadata in `Cargo.toml` and `Cargo.lock` to `1.6.0`.