### PR TITLE
Fix zsh autocomplete and cut `v1.6.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to skillfile are documented here.
 
 ---
 
+## v1.6.1 - 05-05-2026
+
+### Fixed
+
+- **Zsh autocomplete now works reliably** - `skillfile completions zsh` now generates a dynamic completion hook that calls back into `skillfile` at completion time, so commands like `info`, `remove`, `pin`, `unpin`, `diff`, and `resolve` can complete entry names from your `Skillfile`.
+- **Zsh setup guidance is clearer** - the recommended setup now uses `source <(skillfile completions zsh)` to avoid stale `compinit` / `.zcompdump` state after upgrades, with a documented fallback for file-based setups.
+
 ## v1.6.0 - 04-05-2026
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skillfile"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-core"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-deploy"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "dirs",
  "serde_json",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-sources"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "html-escape",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
@@ -15,9 +15,9 @@ categories = ["command-line-utilities", "development-tools"]
 
 [workspace.dependencies]
 # Internal crates
-skillfile-core = { path = "crates/core", version = "1.6.0" }
-skillfile-sources = { path = "crates/sources", version = "1.6.0" }
-skillfile-deploy = { path = "crates/deploy", version = "1.6.0" }
+skillfile-core = { path = "crates/core", version = "1.6.1" }
+skillfile-sources = { path = "crates/sources", version = "1.6.1" }
+skillfile-deploy = { path = "crates/deploy", version = "1.6.1" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -210,14 +210,28 @@ Generate completions for your shell, then source or install them:
 skillfile completions bash > ~/.local/share/bash-completion/completions/skillfile
 
 # Zsh
-skillfile completions zsh > ~/.zfunc/_skillfile
-# (add `fpath+=~/.zfunc` to .zshrc before compinit)
+# add this after your existing `compinit` in ~/.zshrc
+echo 'source <(skillfile completions zsh)' >> ~/.zshrc
 
 # Fish
 skillfile completions fish > ~/.config/fish/completions/skillfile.fish
 ```
 
-Tab completion covers all commands, flags, and entry names (for `info`, `remove`, `pin`, `unpin`, `diff`, `resolve`).
+For zsh, sourcing the generated script on shell startup is the most reliable option because it avoids stale `compinit` / `.zcompdump` state after upgrades.
+
+If you prefer a file-based zsh setup instead:
+
+```zsh
+skillfile completions zsh > ~/.zfunc/_skillfile
+# add this before `compinit` in ~/.zshrc:
+fpath=(~/.zfunc $fpath)
+autoload -Uz compinit
+compinit
+```
+
+If zsh still serves stale completions after switching methods, run `rm -f ~/.zcompdump && compinit` once.
+
+These scripts call back into `skillfile` at completion time, so tab completion covers commands, flags, and entry names (for `info`, `remove`, `pin`, `unpin`, `diff`, `resolve`).
 
 ## Security
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -55,6 +55,40 @@ fn cli_command() -> clap::Command {
     Cli::command().long_about(cli_long_about())
 }
 
+fn completion_env_shell(shell: clap_complete::Shell) -> &'static str {
+    match shell.to_string().as_str() {
+        "bash" => "bash",
+        "elvish" => "elvish",
+        "fish" => "fish",
+        "powershell" => "powershell",
+        "zsh" => "zsh",
+        other => panic!("unsupported completion shell: {other}"),
+    }
+}
+
+fn write_completion_registration(shell: clap_complete::Shell) -> Result<(), SkillfileError> {
+    let completer = std::env::current_exe()
+        .map_err(|e| SkillfileError::Install(format!("failed to locate skillfile binary: {e}")))?;
+    let output = std::process::Command::new(&completer)
+        .env("COMPLETE", completion_env_shell(shell))
+        .output()
+        .map_err(|e| {
+            SkillfileError::Install(format!("failed to generate shell completions: {e}"))
+        })?;
+
+    if output.status.success() {
+        use std::io::Write as _;
+        std::io::stdout()
+            .write_all(&output.stdout)
+            .map_err(SkillfileError::Io)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(SkillfileError::Install(format!(
+            "failed to generate shell completions: {stderr}"
+        )))
+    }
+}
+
 #[derive(Parser)]
 #[command(
     name = "skillfile",
@@ -508,15 +542,7 @@ fn run_install(repo_root: &Path, dry_run: bool, update: bool) -> Result<(), Skil
 
 fn run_content_commands(repo_root: &Path, cmd: Command) -> Result<(), SkillfileError> {
     match cmd {
-        Command::Completions { shell } => {
-            clap_complete::generate(
-                shell,
-                &mut Cli::command(),
-                "skillfile",
-                &mut std::io::stdout(),
-            );
-            Ok(())
-        }
+        Command::Completions { shell } => write_completion_registration(shell),
         Command::Validate => commands::validate::cmd_validate(repo_root),
         Command::Info { name } => commands::info::cmd_info(&name, repo_root),
         Command::Format { dry_run } => commands::format::cmd_format(repo_root, dry_run),
@@ -670,6 +696,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::ValueEnum;
 
     fn completions_non_empty(shell: clap_complete::Shell) {
         let mut buf = Vec::new();
@@ -707,5 +734,12 @@ mod tests {
     #[test]
     fn completions_powershell() {
         completions_non_empty(clap_complete::Shell::PowerShell);
+    }
+
+    #[test]
+    fn completion_env_shell_names_match_clap() {
+        for shell in clap_complete::Shell::value_variants() {
+            assert_eq!(completion_env_shell(*shell), shell.to_string());
+        }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,6 +3,7 @@ mod update_check;
 use skillfile::commands;
 use skillfile::config;
 
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -103,16 +104,16 @@ fn completion_registration_completer() -> Result<PathBuf, SkillfileError> {
     };
     let candidate = profile_dir.join("skillfile");
 
-    Ok(candidate
-        .exists()
-        .then_some(candidate)
-        .unwrap_or(current_exe))
+    Ok(if candidate.exists() {
+        candidate
+    } else {
+        current_exe
+    })
 }
 
 fn write_completion_registration(shell: clap_complete::Shell) -> Result<(), SkillfileError> {
     let completer = completion_registration_completer()?;
     let output = completion_registration_output(&completer, completion_env_shell(shell))?;
-    use std::io::Write as _;
     std::io::stdout()
         .write_all(&output)
         .map_err(SkillfileError::Io)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -66,27 +66,56 @@ fn completion_env_shell(shell: clap_complete::Shell) -> &'static str {
     }
 }
 
-fn write_completion_registration(shell: clap_complete::Shell) -> Result<(), SkillfileError> {
-    let completer = std::env::current_exe()
-        .map_err(|e| SkillfileError::Install(format!("failed to locate skillfile binary: {e}")))?;
-    let output = std::process::Command::new(&completer)
-        .env("COMPLETE", completion_env_shell(shell))
+fn completion_registration_output(
+    completer: &Path,
+    shell_name: &str,
+) -> Result<Vec<u8>, SkillfileError> {
+    let output = std::process::Command::new(completer)
+        .env("COMPLETE", shell_name)
         .output()
         .map_err(|e| {
             SkillfileError::Install(format!("failed to generate shell completions: {e}"))
         })?;
 
     if output.status.success() {
-        use std::io::Write as _;
-        std::io::stdout()
-            .write_all(&output.stdout)
-            .map_err(SkillfileError::Io)
+        Ok(output.stdout)
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         Err(SkillfileError::Install(format!(
             "failed to generate shell completions: {stderr}"
         )))
     }
+}
+
+fn completion_registration_completer() -> Result<PathBuf, SkillfileError> {
+    let current_exe = std::env::current_exe()
+        .map_err(|e| SkillfileError::Install(format!("failed to locate skillfile binary: {e}")))?;
+
+    if current_exe
+        .file_name()
+        .is_some_and(|name| name == std::ffi::OsStr::new("skillfile"))
+    {
+        return Ok(current_exe);
+    }
+
+    let Some(profile_dir) = current_exe.parent().and_then(|p| p.parent()) else {
+        return Ok(current_exe);
+    };
+    let candidate = profile_dir.join("skillfile");
+
+    Ok(candidate
+        .exists()
+        .then_some(candidate)
+        .unwrap_or(current_exe))
+}
+
+fn write_completion_registration(shell: clap_complete::Shell) -> Result<(), SkillfileError> {
+    let completer = completion_registration_completer()?;
+    let output = completion_registration_output(&completer, completion_env_shell(shell))?;
+    use std::io::Write as _;
+    std::io::stdout()
+        .write_all(&output)
+        .map_err(SkillfileError::Io)
 }
 
 #[derive(Parser)]
@@ -697,6 +726,25 @@ fn main() {
 mod tests {
     use super::*;
     use clap::ValueEnum;
+    use std::path::{Path, PathBuf};
+
+    fn skillfile_bin_from_test_dir() -> Option<PathBuf> {
+        let test_exe = std::env::current_exe().ok()?;
+        let profile_dir = test_exe.parent().and_then(|p| p.parent())?;
+        let candidate = profile_dir.join("skillfile");
+        candidate.exists().then_some(candidate)
+    }
+
+    fn skillfile_bin() -> PathBuf {
+        skillfile_bin_from_test_dir().unwrap_or_else(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("cli crate should live under workspace root")
+                .parent()
+                .expect("workspace root should have a parent")
+                .join("target/debug/skillfile")
+        })
+    }
 
     fn completions_non_empty(shell: clap_complete::Shell) {
         let mut buf = Vec::new();
@@ -741,5 +789,37 @@ mod tests {
         for shell in clap_complete::Shell::value_variants() {
             assert_eq!(completion_env_shell(*shell), shell.to_string());
         }
+    }
+
+    #[test]
+    fn completion_registration_output_returns_dynamic_zsh_script() {
+        let output = completion_registration_output(&skillfile_bin(), "zsh")
+            .expect("zsh registration should succeed");
+        let output = String::from_utf8(output).expect("completion output should be utf-8");
+        assert!(output.contains("_clap_dynamic_completer_skillfile"));
+        assert!(output.contains("COMPLETE=\"zsh\""));
+    }
+
+    #[test]
+    fn completion_registration_output_reports_unknown_shell() {
+        let err = completion_registration_output(&skillfile_bin(), "bogus")
+            .expect_err("unknown shell should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("failed to generate shell completions"));
+        assert!(msg.contains("unknown shell `bogus`"));
+    }
+
+    #[test]
+    fn completion_registration_output_reports_spawn_failure() {
+        let err = completion_registration_output(Path::new("/definitely/missing-skillfile"), "zsh")
+            .expect_err("missing completer should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("failed to generate shell completions"));
+    }
+
+    #[test]
+    fn write_completion_registration_uses_real_binary_in_tests() {
+        write_completion_registration(clap_complete::Shell::Zsh)
+            .expect("zsh registration should write to stdout");
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -61,6 +61,38 @@ fn version_flag_exits_zero() {
 }
 
 #[test]
+fn completions_zsh_outputs_dynamic_registration() {
+    skillfile_cmd()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "_clap_dynamic_completer_skillfile",
+        ))
+        .stdout(predicate::str::contains("COMPLETE=\"zsh\""));
+}
+
+#[test]
+fn complete_env_zsh_suggests_entry_names() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "local  skill  browser  skills/browser.md\n\
+         local  agent  reviewer  agents/reviewer.md\n",
+    )
+    .unwrap();
+
+    sf(dir.path())
+        .args(["--", "skillfile", "remove"])
+        .env("COMPLETE", "zsh")
+        .env("_CLAP_COMPLETE_INDEX", "2")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("browser"))
+        .stdout(predicate::str::contains("reviewer"));
+}
+
+#[test]
 fn no_args_exits_nonzero() {
     skillfile_cmd()
         .assert()


### PR DESCRIPTION
**SUMMARY**
Restore working zsh autocomplete for `skillfile` and prepare the `v1.6.1` patch release.

**RATIONALE**
`v1.6.0` shipped a static zsh completion script while the CLI's entry name candidates were wired through Clap's dynamic completion path. Users got broken autocomplete for commands like `remove` despite the documented behavior, so the fix needs both a CLI patch and a patch version bump.

**CHANGES**
- switch `Command::Completions` in `crates/cli/src/main.rs` to emit the dynamic completion registration script by invoking the current binary with `COMPLETE=<shell>`
- add coverage in `tests/cli.rs` for generated zsh completions and runtime entry name suggestions from `Skillfile`
- bump workspace and internal crate versions in `Cargo.toml` from `1.6.0` to `1.6.1`