### PR TITLE
Fix search path resolution for skills.sh results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to skillfile are documented here.
 
 ---
 
+## v1.6.2 - 11-05-2026
+
+### Fixed
+
+- **`skillfile search` now auto-resolves renamed and hyphenated skill paths more reliably** - choosing a result like `linkedin profile optimizer` from `skills.sh` now correctly maps the display name to the upstream repo path `skills/linkedin-profile-optimizer` instead of dropping into the manual `Path in repo:` prompt.
+- **Search-to-add is more resilient when local GitHub auth is broken** - GitHub path discovery now retries public GitHub requests without auth after `401` or auth-masked `404` responses, so an invalid cached `gh` token no longer breaks adding public skills from search results.
+
 ## v1.6.1 - 05-05-2026
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skillfile"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-core"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-deploy"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "dirs",
  "serde_json",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-sources"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "html-escape",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
@@ -15,9 +15,9 @@ categories = ["command-line-utilities", "development-tools"]
 
 [workspace.dependencies]
 # Internal crates
-skillfile-core = { path = "crates/core", version = "1.6.1" }
-skillfile-sources = { path = "crates/sources", version = "1.6.1" }
-skillfile-deploy = { path = "crates/deploy", version = "1.6.1" }
+skillfile-core = { path = "crates/core", version = "1.6.2" }
+skillfile-sources = { path = "crates/sources", version = "1.6.2" }
+skillfile-deploy = { path = "crates/deploy", version = "1.6.2" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/cli/src/commands/search.rs
+++ b/crates/cli/src/commands/search.rs
@@ -10,12 +10,12 @@ use std::path::Path;
 
 use skillfile_core::error::SkillfileError;
 use skillfile_core::output::Spinner;
-use skillfile_sources::http::UreqClient;
+use skillfile_sources::http::{HttpClient, UreqClient};
 use skillfile_sources::registry::{
     fetch_agentskill_github_meta, scrape_github_meta_from_page, search_all, search_registry,
     RegistryId, SearchOptions, SearchResponse,
 };
-use skillfile_sources::resolver::list_repo_skill_entries;
+use skillfile_sources::resolver::{fetch_github_file, list_repo_skill_entries, GithubFetch};
 
 use super::add::{cmd_add, entry_from_github, GithubEntryArgs};
 
@@ -190,7 +190,7 @@ fn interactive_select(resp: &SearchResponse, repo_root: &Path) -> Result<(), Ski
         println!("  path: {entry_path}");
         entry_path
     } else {
-        let Some(p) = resolve_skill_path(&owner_repo, &item.name)? else {
+        let Some(p) = resolve_skill_path(&owner_repo, &item.name, entity_type)? else {
             return Ok(());
         };
         p
@@ -233,13 +233,24 @@ fn entry_path_from_github_path(github_path: &str) -> String {
 fn resolve_skill_path(
     owner_repo: &str,
     skill_name: &str,
+    entity_type: &str,
 ) -> Result<Option<String>, SkillfileError> {
     let client = UreqClient::new();
     let spinner = Spinner::new(&format!("Listing files in {owner_repo}"));
-    let md_files = list_repo_skill_entries(&client, owner_repo);
+    let query = SearchPathQuery {
+        owner_repo,
+        skill_name,
+        entity_type,
+    };
+    let (candidates, resolved) = discover_skill_path(&client, &query);
     spinner.finish();
 
-    if md_files.is_empty() {
+    if let Some(path) = resolved {
+        println!("  path: {path}");
+        return Ok(Some(path));
+    }
+
+    if candidates.is_empty() {
         return prompt_result(
             inquire::Text::new("Path in repo:")
                 .with_default(".")
@@ -250,23 +261,54 @@ fn resolve_skill_path(
         );
     }
 
-    if md_files.len() == 1 {
-        println!("  file: {}", md_files[0]);
-        return Ok(Some(md_files[0].clone()));
+    if candidates.len() == 1 {
+        println!("  file: {}", candidates[0]);
+        return Ok(Some(candidates[0].clone()));
     }
 
-    // Score entries against the skill name to narrow down candidates.
-    let ranked = rank_by_name(&md_files, skill_name);
+    prompt_result(inquire::Select::new("Select file:", candidates).prompt())
+}
 
-    // If the top match is exact, auto-select it.
-    if let Some((path, score)) = ranked.first() {
-        if *score == MatchScore::Exact {
-            println!("  path: {path}");
-            return Ok(Some(path.clone()));
+struct SearchPathQuery<'a> {
+    owner_repo: &'a str,
+    skill_name: &'a str,
+    entity_type: &'a str,
+}
+
+fn discover_skill_path(
+    client: &dyn HttpClient,
+    query: &SearchPathQuery<'_>,
+) -> (Vec<String>, Option<String>) {
+    let mut md_files = list_repo_skill_entries(client, query.owner_repo);
+
+    if md_files.is_empty() {
+        let (canonical_files, canonical_path) =
+            try_canonical_resolution(client, query.owner_repo, query.skill_name);
+        if let Some(path) = canonical_path {
+            return (Vec::new(), Some(path));
+        }
+        if !canonical_files.is_empty() {
+            md_files = canonical_files;
+        } else if let Some(path) =
+            probe_common_skill_paths(client, query.owner_repo, query.skill_name)
+        {
+            return (Vec::new(), Some(path));
+        } else {
+            return (Vec::new(), None);
         }
     }
 
-    // Show only files that matched the name. If nothing matched, show all.
+    if md_files.len() == 1 {
+        return (Vec::new(), Some(md_files[0].clone()));
+    }
+
+    let ranked = rank_by_name_for_entity(&md_files, query.skill_name, query.entity_type);
+    if let Some((path, score)) = ranked.first() {
+        if *score == MatchScore::Exact {
+            return (Vec::new(), Some(path.clone()));
+        }
+    }
+
     let candidates: Vec<String> = ranked.iter().map(|(p, _)| p.clone()).collect();
     let list = if candidates.is_empty() {
         md_files
@@ -274,7 +316,7 @@ fn resolve_skill_path(
         candidates
     };
 
-    prompt_result(inquire::Select::new("Select file:", list).prompt())
+    (list, None)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -283,25 +325,21 @@ enum MatchScore {
     Contains,
 }
 
-/// Rank entry paths by how well they match the skill name. Returns only
-/// entries that match, sorted best-first.
-///
-/// Entry paths may be directories (`skills/kubernetes-specialist`),
-/// single files (`agents/reviewer.md`), or `.` (root SKILL.md).
-fn rank_by_name(entries: &[String], skill_name: &str) -> Vec<(String, MatchScore)> {
-    let name_lower = skill_name.to_ascii_lowercase();
+fn rank_by_name_for_entity(
+    entries: &[String],
+    skill_name: &str,
+    entity_type: &str,
+) -> Vec<(String, MatchScore)> {
+    let name_key = normalize_skill_key(skill_name);
     let mut scored: Vec<(String, MatchScore)> = entries
         .iter()
         .filter_map(|path| {
-            let path_lower = path.to_ascii_lowercase();
-            // For "skills/kubernetes-specialist" → "kubernetes-specialist"
-            // For "agents/reviewer.md" → "reviewer" (strip .md)
-            let tail = path_lower.rsplit('/').next().unwrap_or(&path_lower);
-            let key = tail.strip_suffix(".md").unwrap_or(tail);
+            let key = entry_name_key(path);
+            let path_key = normalize_skill_key(path);
 
-            if key == name_lower {
+            if key == name_key {
                 Some((path.clone(), MatchScore::Exact))
-            } else if path_lower.contains(&name_lower) {
+            } else if path_key.contains(&name_key) {
                 Some((path.clone(), MatchScore::Contains))
             } else {
                 None
@@ -309,8 +347,210 @@ fn rank_by_name(entries: &[String], skill_name: &str) -> Vec<(String, MatchScore
         })
         .collect();
 
-    scored.sort_by_key(|(_, score)| *score);
+    scored.sort_by_key(|(path, score)| (*score, path_preference(path, entity_type), path.clone()));
     scored
+}
+
+fn path_preference(path: &str, entity_type: &str) -> u8 {
+    let preferred_prefix = match entity_type {
+        "agent" => "agents/",
+        _ => "skills/",
+    };
+    if path.starts_with(preferred_prefix) {
+        0
+    } else if path.starts_with('.') {
+        2
+    } else {
+        1
+    }
+}
+
+fn entry_name_key(path: &str) -> String {
+    let tail = path.rsplit('/').next().unwrap_or(path);
+    let key = tail.strip_suffix(".md").unwrap_or(tail);
+    normalize_skill_key(key)
+}
+
+fn normalize_skill_key(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut last_was_sep = false;
+
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            last_was_sep = false;
+        } else if !out.is_empty() && !last_was_sep {
+            out.push('-');
+            last_was_sep = true;
+        }
+    }
+
+    if out.ends_with('-') {
+        out.pop();
+    }
+
+    out
+}
+
+fn probe_common_skill_paths(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+    skill_name: &str,
+) -> Option<String> {
+    let slug = normalize_skill_key(skill_name);
+    if slug.is_empty() {
+        return None;
+    }
+
+    for ref_ in ["main", "master"] {
+        let gh = GithubFetch {
+            client,
+            owner_repo,
+            ref_,
+        };
+
+        if let Some(candidate) = common_skill_file_candidates(&slug)
+            .into_iter()
+            .find(|candidate| fetch_github_file(&gh, candidate).is_ok())
+        {
+            return Some(entry_path_from_github_path(&candidate));
+        }
+    }
+
+    None
+}
+
+fn common_skill_file_candidates(slug: &str) -> [String; 5] {
+    [
+        format!("skills/{slug}/SKILL.md"),
+        format!("{slug}/SKILL.md"),
+        format!("skills/{slug}.md"),
+        format!("{slug}.md"),
+        "SKILL.md".to_string(),
+    ]
+}
+
+fn canonical_owner_repo(client: &dyn HttpClient, owner_repo: &str) -> Option<String> {
+    let url = format!("https://api.github.com/repos/{owner_repo}");
+    let text = client.get_json(&url).ok()??;
+    let data: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let full_name = data["full_name"].as_str()?;
+    Some(full_name.to_string())
+}
+
+fn try_canonical_resolution(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+    skill_name: &str,
+) -> (Vec<String>, Option<String>) {
+    let Some(canonical) = canonical_owner_repo(client, owner_repo) else {
+        return (Vec::new(), None);
+    };
+    let md_files = list_repo_skill_entries(client, &canonical);
+    let path = if md_files.is_empty() {
+        probe_common_skill_paths(client, &canonical, skill_name)
+    } else {
+        None
+    };
+    (md_files, path)
+}
+
+#[cfg(debug_assertions)]
+pub fn run_search_path_resolution_regression() -> Result<(), SkillfileError> {
+    let client = FakeSearchPathClient::new();
+    let query = SearchPathQuery {
+        owner_repo: "paramchoudhary/resumeskills",
+        skill_name: "linkedin profile optimizer",
+        entity_type: "skill",
+    };
+    let (_, resolved) = discover_skill_path(&client, &query);
+    emit_regression_resolution(resolved.as_deref())
+}
+
+#[cfg(debug_assertions)]
+fn emit_regression_resolution(resolved: Option<&str>) -> Result<(), SkillfileError> {
+    match resolved {
+        Some("skills/linkedin-profile-optimizer") => {
+            println!("skills/linkedin-profile-optimizer");
+            Ok(())
+        }
+        Some(other) => Err(SkillfileError::Install(format!(
+            "resolved wrong path: {other}"
+        ))),
+        None => Err(SkillfileError::Install(
+            "failed to auto-resolve search path".into(),
+        )),
+    }
+}
+
+#[cfg(debug_assertions)]
+struct FakeSearchPathClient {
+    json: std::collections::HashMap<String, Option<String>>,
+}
+
+#[cfg(debug_assertions)]
+impl FakeSearchPathClient {
+    fn new() -> Self {
+        Self {
+            json: regression_fixture_json(),
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+impl HttpClient for FakeSearchPathClient {
+    fn get_bytes(&self, _url: &str) -> Result<Vec<u8>, SkillfileError> {
+        Err(SkillfileError::Network("unexpected raw fetch".into()))
+    }
+
+    fn get_json(&self, url: &str) -> Result<Option<String>, SkillfileError> {
+        Ok(self.json.get(url).cloned().flatten())
+    }
+
+    fn post_json(&self, _url: &str, _body: &str) -> Result<Vec<u8>, SkillfileError> {
+        Err(SkillfileError::Network("unexpected post".into()))
+    }
+}
+
+#[cfg(debug_assertions)]
+fn regression_fixture_json() -> std::collections::HashMap<String, Option<String>> {
+    use std::collections::HashMap;
+
+    let mut json = HashMap::new();
+    json.insert(
+        "https://api.github.com/repos/paramchoudhary/resumeskills/git/trees/main?recursive=1"
+            .to_string(),
+        None,
+    );
+    json.insert(
+        "https://api.github.com/repos/paramchoudhary/resumeskills/git/trees/master?recursive=1"
+            .to_string(),
+        None,
+    );
+    json.insert(
+        "https://api.github.com/repos/paramchoudhary/resumeskills".to_string(),
+        Some(
+            serde_json::json!({
+                "full_name": "Paramchoudhary/ResumeSkills"
+            })
+            .to_string(),
+        ),
+    );
+    json.insert(
+        "https://api.github.com/repos/Paramchoudhary/ResumeSkills/git/trees/main?recursive=1"
+            .to_string(),
+        Some(
+            serde_json::json!({
+                "tree": [
+                    {"type": "blob", "path": ".agents/skills/linkedin-profile-optimizer/SKILL.md"},
+                    {"type": "blob", "path": ".claude/skills/linkedin-profile-optimizer/SKILL.md"},
+                    {"type": "blob", "path": "skills/linkedin-profile-optimizer/SKILL.md"}
+                ]
+            })
+            .to_string(),
+        ),
+    );
+    json
 }
 
 /// Convert an `inquire` prompt result into `Ok(Some(value))` on success,
@@ -413,6 +653,69 @@ mod tests {
     use skillfile_sources::registry::SearchResult;
 
     #[test]
+    fn normalize_skill_key_collapses_separators() {
+        assert_eq!(
+            normalize_skill_key("LinkedIn Profile_Optimizer"),
+            "linkedin-profile-optimizer"
+        );
+    }
+
+    #[test]
+    fn rank_by_name_matches_space_separated_skill_name_to_hyphenated_path() {
+        let entries = vec![
+            "skills/linkedin-profile-optimizer".to_string(),
+            "skills/resume-tailor".to_string(),
+        ];
+
+        let ranked = rank_by_name_for_entity(&entries, "linkedin profile optimizer", "skill");
+
+        assert_eq!(
+            ranked.first(),
+            Some(&(
+                "skills/linkedin-profile-optimizer".to_string(),
+                MatchScore::Exact,
+            ))
+        );
+    }
+
+    #[test]
+    fn rank_by_name_prefers_skills_dir_over_hidden_mirrors_for_skill() {
+        let entries = vec![
+            ".agents/skills/linkedin-profile-optimizer".to_string(),
+            "skills/linkedin-profile-optimizer".to_string(),
+        ];
+
+        let ranked = rank_by_name_for_entity(&entries, "linkedin profile optimizer", "skill");
+
+        assert_eq!(
+            ranked.first(),
+            Some(&(
+                "skills/linkedin-profile-optimizer".to_string(),
+                MatchScore::Exact,
+            ))
+        );
+    }
+
+    #[test]
+    fn common_skill_file_candidates_cover_standard_layouts() {
+        let candidates = common_skill_file_candidates("linkedin-profile-optimizer");
+
+        assert_eq!(candidates[0], "skills/linkedin-profile-optimizer/SKILL.md");
+        assert_eq!(candidates[4], "SKILL.md");
+    }
+
+    #[test]
+    fn canonical_owner_repo_parses_full_name() {
+        let json = serde_json::json!({
+            "full_name": "Paramchoudhary/ResumeSkills"
+        });
+        assert_eq!(
+            json["full_name"].as_str(),
+            Some("Paramchoudhary/ResumeSkills")
+        );
+    }
+
+    #[test]
     fn prompt_result_ok_returns_some() {
         let result: Result<String, inquire::InquireError> = Ok("test".to_string());
         let value = prompt_result(result).unwrap();
@@ -502,7 +805,7 @@ mod tests {
     fn rank_exact_dir_entry() {
         // Directory entry: last segment matches skill name exactly.
         let entries = paths(&["skills/kubernetes-specialist", "skills/docker-helper"]);
-        let ranked = rank_by_name(&entries, "kubernetes-specialist");
+        let ranked = rank_by_name_for_entity(&entries, "kubernetes-specialist", "skill");
         assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].0, "skills/kubernetes-specialist");
         assert_eq!(ranked[0].1, MatchScore::Exact);
@@ -512,7 +815,7 @@ mod tests {
     fn rank_exact_single_file() {
         // Single-file entry: stem (without .md) matches skill name.
         let entries = paths(&["skills/kubernetes-specialist.md", "skills/docker-helper.md"]);
-        let ranked = rank_by_name(&entries, "kubernetes-specialist");
+        let ranked = rank_by_name_for_entity(&entries, "kubernetes-specialist", "skill");
         assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].0, "skills/kubernetes-specialist.md");
         assert_eq!(ranked[0].1, MatchScore::Exact);
@@ -521,7 +824,7 @@ mod tests {
     #[test]
     fn rank_exact_case_insensitive() {
         let entries = paths(&["skills/Kubernetes-Specialist", "skills/other"]);
-        let ranked = rank_by_name(&entries, "kubernetes-specialist");
+        let ranked = rank_by_name_for_entity(&entries, "kubernetes-specialist", "skill");
         assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].1, MatchScore::Exact);
     }
@@ -529,7 +832,7 @@ mod tests {
     #[test]
     fn rank_contains_match() {
         let entries = paths(&["skills/advanced-kubernetes-specialist-v2", "skills/docker"]);
-        let ranked = rank_by_name(&entries, "kubernetes-specialist");
+        let ranked = rank_by_name_for_entity(&entries, "kubernetes-specialist", "skill");
         assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].0, "skills/advanced-kubernetes-specialist-v2");
         assert_eq!(ranked[0].1, MatchScore::Contains);
@@ -541,7 +844,7 @@ mod tests {
             "skills/extra-kubernetes-specialist-stuff",
             "skills/kubernetes-specialist",
         ]);
-        let ranked = rank_by_name(&entries, "kubernetes-specialist");
+        let ranked = rank_by_name_for_entity(&entries, "kubernetes-specialist", "skill");
         assert_eq!(ranked.len(), 2);
         assert_eq!(ranked[0].1, MatchScore::Exact);
         assert_eq!(ranked[0].0, "skills/kubernetes-specialist");
@@ -551,7 +854,7 @@ mod tests {
     #[test]
     fn rank_no_matches_returns_empty() {
         let entries = paths(&["skills/docker", "skills/python", "skills/rust.md"]);
-        let ranked = rank_by_name(&entries, "kubernetes-specialist");
+        let ranked = rank_by_name_for_entity(&entries, "kubernetes-specialist", "skill");
         assert!(ranked.is_empty());
     }
 
@@ -559,13 +862,13 @@ mod tests {
     fn rank_dot_entry_never_matches() {
         // "." is the root SKILL.md — should not match a specific name.
         let entries = paths(&["."]);
-        let ranked = rank_by_name(&entries, "some-skill");
+        let ranked = rank_by_name_for_entity(&entries, "some-skill", "skill");
         assert!(ranked.is_empty());
     }
 
     #[test]
     fn rank_empty_entries_returns_empty() {
-        let ranked = rank_by_name(&[], "anything");
+        let ranked = rank_by_name_for_entity(&[], "anything", "skill");
         assert!(ranked.is_empty());
     }
 
@@ -573,7 +876,7 @@ mod tests {
     fn rank_contains_matches_parent_dir() {
         // Name appears in a parent dir segment.
         let entries = paths(&["kubernetes-specialist/references", "unrelated/thing.md"]);
-        let ranked = rank_by_name(&entries, "kubernetes-specialist");
+        let ranked = rank_by_name_for_entity(&entries, "kubernetes-specialist", "skill");
         assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].1, MatchScore::Contains);
     }
@@ -587,7 +890,7 @@ mod tests {
             "skills/python-pro",
             "skills/code-reviewer.md",
         ]);
-        let ranked = rank_by_name(&entries, "kubernetes-specialist");
+        let ranked = rank_by_name_for_entity(&entries, "kubernetes-specialist", "skill");
         assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].0, "skills/kubernetes-specialist");
         assert_eq!(ranked[0].1, MatchScore::Exact);

--- a/crates/cli/src/commands/search.rs
+++ b/crates/cli/src/commands/search.rs
@@ -650,7 +650,53 @@ pub fn print_json(w: &mut dyn Write, resp: &SearchResponse) -> Result<(), Skillf
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
     use skillfile_sources::registry::SearchResult;
+
+    struct SearchPathClient {
+        json: HashMap<String, Option<String>>,
+        bytes: HashMap<String, Vec<u8>>,
+    }
+
+    impl SearchPathClient {
+        fn new() -> Self {
+            Self {
+                json: HashMap::new(),
+                bytes: HashMap::new(),
+            }
+        }
+
+        fn with_json(mut self, url: &str, body: Option<serde_json::Value>) -> Self {
+            self.json
+                .insert(url.to_string(), body.map(|value| value.to_string()));
+            self
+        }
+
+        fn with_bytes(mut self, url: &str, body: &[u8]) -> Self {
+            self.bytes.insert(url.to_string(), body.to_vec());
+            self
+        }
+    }
+
+    impl HttpClient for SearchPathClient {
+        fn get_bytes(&self, url: &str) -> Result<Vec<u8>, SkillfileError> {
+            match self.bytes.get(url) {
+                Some(bytes) => Ok(bytes.clone()),
+                None => Err(SkillfileError::Network(format!(
+                    "unexpected raw fetch in test: {url}"
+                ))),
+            }
+        }
+
+        fn get_json(&self, url: &str) -> Result<Option<String>, SkillfileError> {
+            Ok(self.json.get(url).cloned().flatten())
+        }
+
+        fn post_json(&self, _url: &str, _body: &str) -> Result<Vec<u8>, SkillfileError> {
+            Err(SkillfileError::Network("unexpected post".into()))
+        }
+    }
 
     #[test]
     fn normalize_skill_key_collapses_separators() {
@@ -697,6 +743,21 @@ mod tests {
     }
 
     #[test]
+    fn rank_by_name_prefers_agents_dir_over_hidden_mirrors_for_agent() {
+        let entries = vec![
+            ".claude/agents/code-reviewer.md".to_string(),
+            "agents/code-reviewer.md".to_string(),
+        ];
+
+        let ranked = rank_by_name_for_entity(&entries, "code reviewer", "agent");
+
+        assert_eq!(
+            ranked.first(),
+            Some(&("agents/code-reviewer.md".to_string(), MatchScore::Exact))
+        );
+    }
+
+    #[test]
     fn common_skill_file_candidates_cover_standard_layouts() {
         let candidates = common_skill_file_candidates("linkedin-profile-optimizer");
 
@@ -706,12 +767,131 @@ mod tests {
 
     #[test]
     fn canonical_owner_repo_parses_full_name() {
-        let json = serde_json::json!({
-            "full_name": "Paramchoudhary/ResumeSkills"
-        });
+        let client = SearchPathClient::new().with_json(
+            "https://api.github.com/repos/paramchoudhary/resumeskills",
+            Some(serde_json::json!({
+                "full_name": "Paramchoudhary/ResumeSkills"
+            })),
+        );
+
         assert_eq!(
-            json["full_name"].as_str(),
+            canonical_owner_repo(&client, "paramchoudhary/resumeskills").as_deref(),
             Some("Paramchoudhary/ResumeSkills")
+        );
+    }
+
+    #[test]
+    fn discover_skill_path_uses_canonical_repo_when_original_name_is_stale() {
+        let client = SearchPathClient::new()
+            .with_json(
+                "https://api.github.com/repos/paramchoudhary/resumeskills/git/trees/main?recursive=1",
+                None,
+            )
+            .with_json(
+                "https://api.github.com/repos/paramchoudhary/resumeskills/git/trees/master?recursive=1",
+                None,
+            )
+            .with_json(
+                "https://api.github.com/repos/paramchoudhary/resumeskills",
+                Some(serde_json::json!({
+                    "full_name": "Paramchoudhary/ResumeSkills"
+                })),
+            )
+            .with_json(
+                "https://api.github.com/repos/Paramchoudhary/ResumeSkills/git/trees/main?recursive=1",
+                Some(serde_json::json!({
+                    "tree": [
+                        {"type": "blob", "path": ".agents/skills/linkedin-profile-optimizer/SKILL.md"},
+                        {"type": "blob", "path": "skills/linkedin-profile-optimizer/SKILL.md"}
+                    ]
+                })),
+            );
+        let query = SearchPathQuery {
+            owner_repo: "paramchoudhary/resumeskills",
+            skill_name: "linkedin profile optimizer",
+            entity_type: "skill",
+        };
+
+        let (candidates, resolved) = discover_skill_path(&client, &query);
+
+        assert!(candidates.is_empty());
+        assert_eq!(
+            resolved.as_deref(),
+            Some("skills/linkedin-profile-optimizer")
+        );
+    }
+
+    #[test]
+    fn discover_skill_path_probes_common_layout_when_tree_api_returns_empty() {
+        let client = SearchPathClient::new()
+            .with_json(
+                "https://api.github.com/repos/paramchoudhary/resumeskills/git/trees/main?recursive=1",
+                None,
+            )
+            .with_json(
+                "https://api.github.com/repos/paramchoudhary/resumeskills/git/trees/master?recursive=1",
+                None,
+            )
+            .with_json(
+                "https://api.github.com/repos/paramchoudhary/resumeskills",
+                Some(serde_json::json!({
+                    "full_name": "Paramchoudhary/ResumeSkills"
+                })),
+            )
+            .with_json(
+                "https://api.github.com/repos/Paramchoudhary/ResumeSkills/git/trees/main?recursive=1",
+                None,
+            )
+            .with_json(
+                "https://api.github.com/repos/Paramchoudhary/ResumeSkills/git/trees/master?recursive=1",
+                None,
+            )
+            .with_bytes(
+                "https://raw.githubusercontent.com/paramchoudhary/resumeskills/main/skills/linkedin-profile-optimizer/SKILL.md",
+                b"# skill",
+            );
+        let query = SearchPathQuery {
+            owner_repo: "paramchoudhary/resumeskills",
+            skill_name: "linkedin profile optimizer",
+            entity_type: "skill",
+        };
+
+        let (candidates, resolved) = discover_skill_path(&client, &query);
+
+        assert!(candidates.is_empty());
+        assert_eq!(
+            resolved.as_deref(),
+            Some("skills/linkedin-profile-optimizer")
+        );
+    }
+
+    #[test]
+    fn discover_skill_path_returns_filtered_candidates_without_exact_match() {
+        let client = SearchPathClient::new().with_json(
+            "https://api.github.com/repos/example/repo/git/trees/main?recursive=1",
+            Some(serde_json::json!({
+                "tree": [
+                    {"type": "blob", "path": "skills/linkedin-profile-helper/SKILL.md"},
+                    {"type": "blob", "path": "skills/linkedin-profile-writer/SKILL.md"},
+                    {"type": "blob", "path": "skills/resume-tailor/SKILL.md"}
+                ]
+            })),
+        );
+        let query = SearchPathQuery {
+            owner_repo: "example/repo",
+            skill_name: "linkedin profile",
+            entity_type: "skill",
+        };
+
+        let (candidates, resolved) = discover_skill_path(&client, &query);
+
+        assert!(resolved.is_none());
+        assert_eq!(
+            candidates,
+            vec![
+                "skills/linkedin-profile-helper".to_string(),
+                "skills/linkedin-profile-writer".to_string(),
+            ]
         );
     }
 
@@ -894,6 +1074,20 @@ mod tests {
         assert_eq!(ranked.len(), 1);
         assert_eq!(ranked[0].0, "skills/kubernetes-specialist");
         assert_eq!(ranked[0].1, MatchScore::Exact);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn emit_regression_resolution_errors_on_wrong_path() {
+        let err = emit_regression_resolution(Some("skills/wrong")).unwrap_err();
+        assert!(err.to_string().contains("resolved wrong path"));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn emit_regression_resolution_errors_when_path_is_missing() {
+        let err = emit_regression_resolution(None).unwrap_err();
+        assert!(err.to_string().contains("failed to auto-resolve"));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -354,6 +354,10 @@ Examples:
     #[command(name = "__github-auth-test", hide = true)]
     GithubAuthTest,
 
+    #[cfg(debug_assertions)]
+    #[command(name = "__search-path-resolution-test", hide = true)]
+    SearchPathResolutionTest,
+
     // -- Validation (display_order 30-39) -------------------------------------
     /// Check the Skillfile for errors
     #[command(display_order = 30)]
@@ -643,6 +647,10 @@ fn run_source_commands(repo_root: &Path, cmd: Command) -> Result<(), SkillfileEr
         Command::SearchTuiTest => run_search_tui_test(),
         #[cfg(debug_assertions)]
         Command::GithubAuthTest => run_github_auth_test(),
+        #[cfg(debug_assertions)]
+        Command::SearchPathResolutionTest => {
+            commands::search::run_search_path_resolution_regression()
+        }
         _ => Ok(()), // covered by run_content_commands
     }
 }

--- a/crates/sources/src/http.rs
+++ b/crates/sources/src/http.rs
@@ -161,6 +161,31 @@ fn read_response_text(body: &mut ureq::Body, url: &str) -> Result<String, Skillf
         .map_err(|e| SkillfileError::Network(format!("failed to read response from {url}: {e}")))
 }
 
+enum HttpAttemptError {
+    Status { code: u16, error: SkillfileError },
+    Other(SkillfileError),
+}
+
+impl HttpAttemptError {
+    fn code(&self) -> Option<u16> {
+        match self {
+            Self::Status { code, .. } => Some(*code),
+            Self::Other(_) => None,
+        }
+    }
+
+    fn into_skillfile(self) -> SkillfileError {
+        match self {
+            Self::Status { error, .. } | Self::Other(error) => error,
+        }
+    }
+}
+
+enum JsonAttempt {
+    Found(String),
+    Missing { code: u16 },
+}
+
 /// Production HTTP client backed by `ureq::Agent`.
 ///
 /// Attaches `User-Agent` to every request. GitHub `Authorization` header
@@ -183,11 +208,19 @@ impl UreqClient {
         }
     }
 
-    fn build_get(&self, url: &str) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
+    fn build_get_inner(
+        &self,
+        url: &str,
+        with_auth: bool,
+    ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
         let mut req = self.agent.get(url).header("User-Agent", "skillfile/1.0");
-        if let Some(token) = github_token().for_url(url) {
-            req = req.header("Authorization", &format!("Bearer {token}"));
+        if !with_auth {
+            return req;
         }
+        let Some(token) = github_token().for_url(url) else {
+            return req;
+        };
+        req = req.header("Authorization", &format!("Bearer {token}"));
         req
     }
 
@@ -197,6 +230,66 @@ impl UreqClient {
             req = req.header("Authorization", &format!("Bearer {token}"));
         }
         req
+    }
+
+    fn get_bytes_inner(&self, url: &str, with_auth: bool) -> Result<Vec<u8>, HttpAttemptError> {
+        let mut response = self
+            .build_get_inner(url, with_auth)
+            .call()
+            .map_err(|e| match &e {
+                ureq::Error::StatusCode(404) => HttpAttemptError::Status {
+                    code: 404,
+                    error: SkillfileError::Network(format!(
+                        "HTTP 404: {url} not found — check that the path exists in the upstream repo"
+                    )),
+                },
+                ureq::Error::StatusCode(code) => HttpAttemptError::Status {
+                    code: *code,
+                    error: SkillfileError::Network(format!("HTTP {code} fetching {url}")),
+                },
+                _ => HttpAttemptError::Other(SkillfileError::Network(format!(
+                    "{e} fetching {url}"
+                ))),
+            })?;
+        response.body_mut().read_to_vec().map_err(|e| {
+            HttpAttemptError::Other(SkillfileError::Network(format!(
+                "failed to read response from {url}: {e}"
+            )))
+        })
+    }
+
+    fn get_json_inner(&self, url: &str, with_auth: bool) -> Result<JsonAttempt, HttpAttemptError> {
+        let result = self
+            .build_get_inner(url, with_auth)
+            .header("Accept", "application/vnd.github.v3+json")
+            .call();
+
+        match result {
+            Ok(mut response) => read_response_text(response.body_mut(), url)
+                .map(JsonAttempt::Found)
+                .map_err(HttpAttemptError::Other),
+            Err(ureq::Error::StatusCode(code)) if code == 404 || code == 422 => {
+                Ok(JsonAttempt::Missing { code })
+            }
+            Err(ureq::Error::StatusCode(403)) => Err(HttpAttemptError::Status {
+                code: 403,
+                error: SkillfileError::Network(format!(
+                    "HTTP 403 fetching {url} — you may be rate-limited. \
+                     Set GITHUB_TOKEN or run `gh auth login` to authenticate."
+                )),
+            }),
+            Err(ureq::Error::StatusCode(code)) => Err(HttpAttemptError::Status {
+                code,
+                error: SkillfileError::Network(format!("HTTP {code} fetching {url}")),
+            }),
+            Err(e) => Err(HttpAttemptError::Other(SkillfileError::Network(format!(
+                "{e} fetching {url}"
+            )))),
+        }
+    }
+
+    fn should_retry_unauth(url: &str, code: u16, had_auth: bool) -> bool {
+        had_auth && is_github_url(url) && matches!(code, 401 | 404)
     }
 }
 
@@ -208,37 +301,40 @@ impl Default for UreqClient {
 
 impl HttpClient for UreqClient {
     fn get_bytes(&self, url: &str) -> Result<Vec<u8>, SkillfileError> {
-        let mut response = self.build_get(url).call().map_err(|e| match &e {
-            ureq::Error::StatusCode(404) => SkillfileError::Network(format!(
-                "HTTP 404: {url} not found — check that the path exists in the upstream repo"
-            )),
-            ureq::Error::StatusCode(code) => {
-                SkillfileError::Network(format!("HTTP {code} fetching {url}"))
-            }
-            _ => SkillfileError::Network(format!("{e} fetching {url}")),
-        })?;
-        response.body_mut().read_to_vec().map_err(|e| {
-            SkillfileError::Network(format!("failed to read response from {url}: {e}"))
-        })
+        let had_auth = github_token().for_url(url).is_some();
+        let first = self.get_bytes_inner(url, true);
+        let should_retry = first
+            .as_ref()
+            .err()
+            .and_then(HttpAttemptError::code)
+            .is_some_and(|code| Self::should_retry_unauth(url, code, had_auth));
+        if should_retry {
+            return self
+                .get_bytes_inner(url, false)
+                .map_err(HttpAttemptError::into_skillfile);
+        }
+        first.map_err(HttpAttemptError::into_skillfile)
     }
 
     fn get_json(&self, url: &str) -> Result<Option<String>, SkillfileError> {
-        let result = self
-            .build_get(url)
-            .header("Accept", "application/vnd.github.v3+json")
-            .call();
-
-        match result {
-            Ok(mut response) => read_response_text(response.body_mut(), url).map(Some),
-            // 404/422 = ref or repo doesn't exist (tentative lookup, not fatal).
-            // 403 = rate-limited or forbidden; 401 = bad token — surface these.
-            Err(ureq::Error::StatusCode(code)) if code == 404 || code == 422 => Ok(None),
-            Err(ureq::Error::StatusCode(403)) => Err(SkillfileError::Network(format!(
-                "HTTP 403 fetching {url} — you may be rate-limited. \
-                 Set GITHUB_TOKEN or run `gh auth login` to authenticate."
-            ))),
-            Err(e) => Err(SkillfileError::Network(format!("{e} fetching {url}"))),
+        let had_auth = github_token().for_url(url).is_some();
+        let first = self.get_json_inner(url, true);
+        let should_retry = match &first {
+            Ok(JsonAttempt::Missing { code }) => Self::should_retry_unauth(url, *code, had_auth),
+            Err(error) => error
+                .code()
+                .is_some_and(|code| Self::should_retry_unauth(url, code, had_auth)),
+            Ok(JsonAttempt::Found(_)) => false,
+        };
+        if should_retry {
+            return self
+                .get_json_inner(url, false)
+                .map_err(HttpAttemptError::into_skillfile)
+                .map(json_attempt_into_option);
         }
+        first
+            .map_err(HttpAttemptError::into_skillfile)
+            .map(json_attempt_into_option)
     }
 
     fn post_json(&self, url: &str, body: &str) -> Result<Vec<u8>, SkillfileError> {
@@ -275,6 +371,13 @@ impl HttpClient for UreqClient {
         response.body_mut().read_to_vec().map_err(|e| {
             SkillfileError::Network(format!("failed to read response from {url}: {e}"))
         })
+    }
+}
+
+fn json_attempt_into_option(result: JsonAttempt) -> Option<String> {
+    match result {
+        JsonAttempt::Found(text) => Some(text),
+        JsonAttempt::Missing { .. } => None,
     }
 }
 
@@ -396,5 +499,29 @@ mod tests {
     #[test]
     fn http_github_url_is_github() {
         assert!(is_github_url("http://api.github.com/repos/owner/repo"));
+    }
+
+    #[test]
+    fn retry_unauth_on_github_auth_failure_or_masked_not_found() {
+        assert!(UreqClient::should_retry_unauth(
+            "https://api.github.com/repos/owner/repo",
+            401,
+            true
+        ));
+        assert!(UreqClient::should_retry_unauth(
+            "https://raw.githubusercontent.com/owner/repo/main/SKILL.md",
+            404,
+            true
+        ));
+        assert!(!UreqClient::should_retry_unauth(
+            "https://skills.sh/api/search?q=test",
+            404,
+            true
+        ));
+        assert!(!UreqClient::should_retry_unauth(
+            "https://api.github.com/repos/owner/repo",
+            401,
+            false
+        ));
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -118,6 +118,19 @@ fn github_auth_test_detects_config_file_token() {
         .stdout(predicate::str::contains("available"));
 }
 
+#[test]
+fn search_path_resolution_regression_avoids_manual_repo_prompt() {
+    skillfile_cmd()
+        .arg("__search-path-resolution-test")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "skills/linkedin-profile-optimizer",
+        ))
+        .stdout(predicate::str::contains(".agents/skills").not())
+        .stderr(predicate::str::contains("Path in repo").not());
+}
+
 // ---------------------------------------------------------------------------
 // init
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**SUMMARY**
Improve `search` path resolution so `skills.sh` results map cleanly to GitHub repo paths and do not fall back to the manual `Path in repo:` prompt for known layouts.

**RATIONALE**
`skillfile search linkedin` could still fail on public skills when the registry returned a display name instead of the upstream path, or when a broken local GitHub token caused public GitHub lookups to fail. This needed a stable regression test and a more robust resolver path.

**CHANGES**
- Update `crates/cli/src/commands/search.rs` to normalize skill names, prefer canonical `skills/` paths over hidden mirrors, and probe common `SKILL.md` layouts before prompting
- Add a debug-only regression harness in `crates/cli/src/main.rs` for deterministic binary-level coverage of the broken search flow
- Refactor `crates/sources/src/http.rs` to retry eligible GitHub requests without auth using structured status handling instead of parsing status codes from error strings
- Add functional coverage in `tests/cli.rs` for the `search linkedin` regression
- Bump workspace crate versions to `1.6.2` in `Cargo.toml` and `Cargo.lock`
- Add the `v1.6.2` release entry to `CHANGELOG.md`
