### PR TITLE
fix: Can not add skills in non-main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Run `skillfile add` for a guided wizard, or use the explicit CLI for any source:
 skillfile add                                            # wizard: GitHub, search, local, URL
 skillfile add github skill anthropics/skills            # discover all skills in a repo
 skillfile add github skill anthropics/skills slack-gif-creator  # add one specific skill
+skillfile add github skill nuxt/ui@v4 skills/           # add from a specific branch or tag
 skillfile add local skill skills/my-custom/SKILL.md      # track a local file
 skillfile add url skill https://example.com/skill.md     # add from a URL
 ```
@@ -163,6 +164,7 @@ install  gemini-cli   local
 # GitHub-hosted skills and agents
 github  skill  obra/superpowers  skills/requesting-code-review
 github  agent  reviewer  owner/repo  agents/reviewer.md  v2.0
+github  skill  nuxt/ui@v4  skills/SKILL.md
 
 # Local files
 local  skill  skills/git/commit.md
@@ -242,6 +244,7 @@ The lock file pins entries to exact commit SHAs. The same SHA always produces th
 Review what you install. The risk profile is the same as `git clone`.
 
 ## Development
+
 ```bash
 cargo test --workspace                     # unit + integration + upstream tests
 cargo test --test upstream                 # upstream API health tests (needs GITHUB_TOKEN)
@@ -254,12 +257,14 @@ cargo fmt --check                          # format check
 This project includes a `.pre-commit-config.yaml` that runs `cargo fmt --all` automatically before each commit, so formatting issues never reach CI.
 
 **First-time setup:**
+
 ```bash
 pip install pre-commit    # or: brew install pre-commit
 pre-commit install        # install the git hook (once per clone)
 ```
 
 To run manually:
+
 ```bash
 pre-commit run --all-files
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -71,16 +71,16 @@ local  <entity-type>  [name]  <path>
 ### GitHub
 
 ```
-github  <entity-type>  [name]  <owner/repo>  <path-in-repo>  [ref]
+github  <entity-type>  [name]  <owner/repo[@ref]>  <path-in-repo>  [ref]
 ```
 
 | Field | Description |
 |---|---|
 | `entity-type` | `skill` or `agent` |
 | `name` | Optional logical name. If omitted, inferred from the filename stem of `path-in-repo`. |
-| `owner/repo` | GitHub repository identifier (e.g. `VoltAgent/awesome-claude-code-subagents`) |
+| `owner/repo[@ref]` | GitHub repository identifier, optionally with `@ref` suffix to specify branch, tag, or SHA (e.g. `nuxt/ui@v4`, `anthropics/skills@main`). The `@ref` syntax takes priority over the positional `[ref]` field. |
 | `path-in-repo` | Path to the `.md` file within the repo. Use `.` if SKILL.md is at the repo root. |
-| `ref` | Branch, tag, or commit SHA. Defaults to `main` if omitted. |
+| `ref` | Branch, tag, or commit SHA. Defaults to `main` if omitted. Ignored when `@ref` is present in `owner/repo`. |
 
 ### URL
 

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -13,6 +13,16 @@ use skillfile_deploy::install::{
 use skillfile_sources::strategy::format_parts;
 use skillfile_sources::sync::{sync_entry, vendor_dir_for, SyncContext};
 
+/// Parse `owner/repo[@ref]` into `(owner_repo, ref_)`.
+fn parse_owner_repo_ref(input: &str) -> (String, Option<String>) {
+    match input.split_once('@') {
+        Some((repo, ref_)) if !repo.is_empty() && !ref_.is_empty() => {
+            (repo.to_string(), Some(ref_.to_string()))
+        }
+        _ => (input.to_string(), None),
+    }
+}
+
 fn format_line(entry: &Entry) -> String {
     let mut parts = vec![
         entry.source_type().to_string(),
@@ -145,7 +155,8 @@ pub fn cmd_add_bulk(args: &BulkAddArgs<'_>, repo_root: &Path) -> Result<(), Skil
         args.entity_type, args.owner_repo
     ));
     let client = skillfile_sources::http::UreqClient::new();
-    let entries = list_repo_skill_entries_under(&client, args.owner_repo, args.base_path);
+    let entries =
+        list_repo_skill_entries_under(&client, args.owner_repo, args.base_path, args.ref_);
     spinner.finish();
 
     if entries.is_empty() {
@@ -467,7 +478,7 @@ fn validate_github_repo(owner_repo: &str) -> Result<(), SkillfileError> {
 fn discover_top_level_dirs(owner_repo: &str) -> Vec<String> {
     use skillfile_sources::resolver::list_repo_skill_entries_under;
     let client = skillfile_sources::http::UreqClient::new();
-    let entries = list_repo_skill_entries_under(&client, owner_repo, ".");
+    let entries = list_repo_skill_entries_under(&client, owner_repo, ".", None);
     let mut dirs: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for entry in &entries {
         if let Some(first_seg) = entry.split('/').next() {
@@ -481,20 +492,22 @@ fn discover_top_level_dirs(owner_repo: &str) -> Vec<String> {
 fn wizard_github(repo_root: &Path) -> Result<(), SkillfileError> {
     use skillfile_core::output::Spinner;
 
-    let owner_repo: String = cliclack::input("GitHub repository (owner/repo)")
-        .placeholder("e.g. anthropics/skills")
+    let owner_repo_input: String = cliclack::input("GitHub repository (owner/repo)")
+        .placeholder("e.g. anthropics/skills or nuxt/ui@v4")
         .validate(|v: &String| {
             if v.contains('/') && v.len() > 2 {
                 Ok(())
             } else {
-                Err("Expected format: owner/repo")
+                Err("Expected format: owner/repo or owner/repo@ref")
             }
         })
         .interact()?;
 
+    let (parsed_repo, parsed_ref) = parse_owner_repo_ref(&owner_repo_input);
+
     // Validate repo exists before asking more questions.
-    let spinner = Spinner::new(&format!("Checking {owner_repo}..."));
-    let valid = validate_github_repo(&owner_repo);
+    let spinner = Spinner::new(&format!("Checking {parsed_repo}..."));
+    let valid = validate_github_repo(&parsed_repo);
     spinner.finish();
     valid?;
 
@@ -504,7 +517,7 @@ fn wizard_github(repo_root: &Path) -> Result<(), SkillfileError> {
 
     // Discover top-level dirs for the path hint.
     let spinner = Spinner::new("Scanning repository...");
-    let top_dirs = discover_top_level_dirs(&owner_repo);
+    let top_dirs = discover_top_level_dirs(&parsed_repo);
     spinner.finish();
 
     let path_hint = if top_dirs.is_empty() {
@@ -521,9 +534,9 @@ fn wizard_github(repo_root: &Path) -> Result<(), SkillfileError> {
     cmd_add_bulk(
         &BulkAddArgs {
             entity_type,
-            owner_repo: &owner_repo,
+            owner_repo: &parsed_repo,
             base_path: &base_path,
-            ref_: None,
+            ref_: parsed_ref.as_deref(),
             no_interactive: false,
         },
         repo_root,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -470,8 +470,8 @@ enum AddSource {
         /// Entity type: skill or agent
         #[arg(value_name = "TYPE", value_parser = parse_entity_type)]
         entity_type: String,
-        /// GitHub repository (e.g. owner/repo)
-        #[arg(value_name = "OWNER/REPO")]
+        /// GitHub repository (e.g. owner/repo or owner/repo@ref)
+        #[arg(value_name = "OWNER/REPO[@REF]")]
         owner_repo: String,
         /// Path within the repo (omit to discover all entries)
         #[arg(value_name = "PATH")]
@@ -521,6 +521,21 @@ fn is_discovery_path(path: &str) -> bool {
             .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
 }
 
+/// Parse `owner/repo[@ref]` into `(owner_repo, ref_)`.
+///
+/// Supports:
+/// - `owner/repo` → `("owner/repo", None)`
+/// - `owner/repo@v4` → `("owner/repo", Some("v4"))`
+/// - `owner/repo@main` → `("owner/repo", Some("main"))`
+fn parse_owner_repo_ref(input: &str) -> (String, Option<String>) {
+    match input.split_once('@') {
+        Some((repo, ref_)) if !repo.is_empty() && !ref_.is_empty() => {
+            (repo.to_string(), Some(ref_.to_string()))
+        }
+        _ => (input.to_string(), None),
+    }
+}
+
 fn handle_add(source: AddSource, repo_root: &std::path::Path) -> Result<(), SkillfileError> {
     let entry = match source {
         AddSource::Github {
@@ -532,12 +547,14 @@ fn handle_add(source: AddSource, repo_root: &std::path::Path) -> Result<(), Skil
             no_interactive,
         } if is_discovery_path(path.as_deref().unwrap_or(".")) => {
             let base_path = path.as_deref().unwrap_or(".");
+            let (parsed_repo, parsed_ref) = parse_owner_repo_ref(&owner_repo);
+            let effective_ref = ref_.or(parsed_ref);
             return commands::add::cmd_add_bulk(
                 &commands::add::BulkAddArgs {
                     entity_type: &entity_type,
-                    owner_repo: &owner_repo,
+                    owner_repo: &parsed_repo,
                     base_path,
-                    ref_: ref_.as_deref(),
+                    ref_: effective_ref.as_deref(),
                     no_interactive,
                 },
                 repo_root,
@@ -550,13 +567,17 @@ fn handle_add(source: AddSource, repo_root: &std::path::Path) -> Result<(), Skil
             ref_,
             name,
             no_interactive: _,
-        } => commands::add::entry_from_github(&commands::add::GithubEntryArgs {
-            entity_type: &entity_type,
-            owner_repo: &owner_repo,
-            path: path.as_deref().unwrap_or("."),
-            ref_: ref_.as_deref(),
-            name: name.as_deref(),
-        }),
+        } => {
+            let (parsed_repo, parsed_ref) = parse_owner_repo_ref(&owner_repo);
+            let effective_ref = ref_.or(parsed_ref);
+            commands::add::entry_from_github(&commands::add::GithubEntryArgs {
+                entity_type: &entity_type,
+                owner_repo: &parsed_repo,
+                path: path.as_deref().unwrap_or("."),
+                ref_: effective_ref.as_deref(),
+                name: name.as_deref(),
+            })
+        }
         AddSource::Local {
             entity_type,
             path,

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -78,6 +78,30 @@ fn strip_inline_comment(parts: Vec<String>) -> Vec<String> {
     }
 }
 
+/// Parse `owner/repo[@ref]` into `(owner_repo, ref_)`.
+///
+/// Supports:
+/// - `owner/repo` → `("owner/repo", None)`
+/// - `owner/repo@v4` → `("owner/repo", Some("v4"))`
+/// - `owner/repo@main` → `("owner/repo", Some("main"))`
+fn parse_owner_repo_ref(input: &str) -> (String, Option<String>) {
+    match input.split_once('@') {
+        Some((repo, ref_)) if !repo.is_empty() && !ref_.is_empty() => {
+            (repo.to_string(), Some(ref_.to_string()))
+        }
+        _ => (input.to_string(), None),
+    }
+}
+
+/// Resolve the effective ref from the `@`-syntax parsed ref and an explicit positional ref.
+///
+/// Priority: `owner/repo@ref` > explicit positional ref > `DEFAULT_REF`.
+fn resolve_ref(at_ref: Option<String>, positional_ref: Option<&str>) -> String {
+    at_ref
+        .or_else(|| positional_ref.map(String::from))
+        .unwrap_or_else(|| DEFAULT_REF.to_string())
+}
+
 /// Parse a github entry line. parts[0]=source_type, parts[1]=entity_type, etc.
 fn parse_github_entry(
     parts: &[String],
@@ -94,8 +118,9 @@ fn parse_github_entry(
             ));
             return (None, warnings);
         }
-        let ref_ = parts.get(4).map_or(DEFAULT_REF, String::as_str);
-        (infer_name(&parts[3]), &parts[2], &parts[3], ref_)
+        let (parsed_repo, parsed_ref) = parse_owner_repo_ref(&parts[2]);
+        let ref_ = resolve_ref(parsed_ref, parts.get(4).map(String::as_str));
+        (infer_name(&parts[3]), parsed_repo, &parts[3], ref_)
     } else {
         if parts.len() < 5 {
             warnings.push(format!(
@@ -106,22 +131,23 @@ fn parse_github_entry(
         if !parts[3].contains('/') {
             warnings.push(format!(
                 "warning: line {lineno}: invalid owner/repo '{}' \
-                 — expected 'owner/repo' format",
+                 — expected 'owner/repo' or 'owner/repo@ref' format",
                 parts[3],
             ));
             return (None, warnings);
         }
-        let ref_ = parts.get(5).map_or(DEFAULT_REF, String::as_str);
-        (parts[2].clone(), &parts[3], &parts[4], ref_)
+        let (parsed_repo, parsed_ref) = parse_owner_repo_ref(&parts[3]);
+        let ref_ = resolve_ref(parsed_ref, parts.get(5).map(String::as_str));
+        (parts[2].clone(), parsed_repo, &parts[4], ref_)
     };
 
     let entry = Entry {
         entity_type,
         name,
         source: SourceFields::Github {
-            owner_repo: owner_repo.clone(),
+            owner_repo,
             path_in_repo: path_in_repo.clone(),
-            ref_: ref_.to_owned(),
+            ref_,
         },
     };
     (Some(entry), warnings)
@@ -549,6 +575,74 @@ mod tests {
         );
         let r = parse_manifest(&p).unwrap();
         assert_eq!(r.manifest.entries[0].ref_(), "main");
+    }
+
+    // -------------------------------------------------------------------
+    // @-syntax ref (owner/repo@ref)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn github_entry_at_ref_inferred_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(dir.path(), "github  skill  nuxt/ui@v4  path/to/SKILL.md");
+        let r = parse_manifest(&p).unwrap();
+        assert_eq!(r.manifest.entries.len(), 1);
+        let e = &r.manifest.entries[0];
+        assert_eq!(e.name, "SKILL");
+        assert_eq!(e.owner_repo(), "nuxt/ui");
+        assert_eq!(e.ref_(), "v4");
+    }
+
+    #[test]
+    fn github_entry_at_ref_explicit_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(
+            dir.path(),
+            "github  skill  my-skill  nuxt/ui@v4  path/to/SKILL.md",
+        );
+        let r = parse_manifest(&p).unwrap();
+        assert_eq!(r.manifest.entries.len(), 1);
+        let e = &r.manifest.entries[0];
+        assert_eq!(e.name, "my-skill");
+        assert_eq!(e.owner_repo(), "nuxt/ui");
+        assert_eq!(e.ref_(), "v4");
+    }
+
+    #[test]
+    fn github_entry_at_ref_with_main() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(
+            dir.path(),
+            "github  skill  owner/repo@main  path/to/SKILL.md",
+        );
+        let r = parse_manifest(&p).unwrap();
+        assert_eq!(r.manifest.entries[0].owner_repo(), "owner/repo");
+        assert_eq!(r.manifest.entries[0].ref_(), "main");
+    }
+
+    #[test]
+    fn github_entry_at_ref_with_sha() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(
+            dir.path(),
+            "github  skill  owner/repo@abc123def456  path/to/SKILL.md",
+        );
+        let r = parse_manifest(&p).unwrap();
+        assert_eq!(r.manifest.entries[0].owner_repo(), "owner/repo");
+        assert_eq!(r.manifest.entries[0].ref_(), "abc123def456");
+    }
+
+    #[test]
+    fn github_entry_at_ref_takes_priority_over_positional() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(
+            dir.path(),
+            "github  skill  nuxt/ui@v4  path/to/SKILL.md  v3",
+        );
+        let r = parse_manifest(&p).unwrap();
+        let e = &r.manifest.entries[0];
+        assert_eq!(e.owner_repo(), "nuxt/ui");
+        assert_eq!(e.ref_(), "v4");
     }
 
     // -------------------------------------------------------------------

--- a/crates/sources/src/resolver.rs
+++ b/crates/sources/src/resolver.rs
@@ -61,6 +61,16 @@ fn check_repo_renamed(client: &dyn HttpClient, owner_repo: &str) -> Option<Strin
     }
 }
 
+/// Fetch the `default_branch` field from the GitHub repo API.
+///
+/// Returns `None` if the API call fails or the field is missing.
+fn fetch_default_branch(client: &dyn HttpClient, owner_repo: &str) -> Option<String> {
+    let url = format!("https://api.github.com/repos/{owner_repo}");
+    let text = client.get_json(&url).ok()??;
+    let data: serde_json::Value = serde_json::from_str(&text).ok()?;
+    data["default_branch"].as_str().map(ToString::to_string)
+}
+
 /// Try to resolve a git ref to a commit SHA. Returns `None` on 4xx.
 fn try_resolve_sha(
     client: &dyn HttpClient,
@@ -83,6 +93,8 @@ fn try_resolve_sha(
 /// Resolve a branch/tag/SHA ref to a full commit SHA via GitHub API.
 ///
 /// When ref is `main` and the repo uses `master`, falls back automatically.
+/// When all hardcoded fallbacks fail, queries the repo's `default_branch`
+/// field via the GitHub API as a last resort.
 pub fn resolve_github_sha(
     client: &dyn HttpClient,
     owner_repo: &str,
@@ -100,6 +112,18 @@ pub fn resolve_github_sha(
     if let Some(fb) = fallback {
         if let Some(sha) = try_resolve_sha(client, owner_repo, fb)? {
             return Ok(sha);
+        }
+    }
+    // Last resort: query the repo's actual default_branch from the GitHub API.
+    // This handles repos whose default branch is neither `main` nor `master`
+    // (e.g. `v4`, `develop`, etc.).
+    if ref_ == "main" || ref_ == "master" {
+        if let Some(db) = fetch_default_branch(client, owner_repo) {
+            if db != "main" && db != "master" {
+                if let Some(sha) = try_resolve_sha(client, owner_repo, &db)? {
+                    return Ok(sha);
+                }
+            }
         }
     }
     // Before giving up, check if the repo was renamed. ureq follows 301
@@ -293,13 +317,25 @@ pub fn list_repo_skill_entries(client: &dyn HttpClient, owner_repo: &str) -> Vec
 /// search the entire repo (equivalent to `list_repo_skill_entries`).
 ///
 /// The returned paths are repo-relative (e.g. `skills/browser`, not `browser`).
+///
+/// When `ref_` is `None`, tries `main`, `master`, and the repo's
+/// `default_branch` in order.
 pub fn list_repo_skill_entries_under(
     client: &dyn HttpClient,
     owner_repo: &str,
     base_path: &str,
+    ref_: Option<&str>,
 ) -> Vec<String> {
-    let all_files = list_md_files_with_ref(client, owner_repo, "main")
-        .or_else(|| list_md_files_with_ref(client, owner_repo, "master"));
+    let all_files = if let Some(r) = ref_ {
+        list_md_files_with_ref(client, owner_repo, r)
+    } else {
+        list_md_files_with_ref(client, owner_repo, "main")
+            .or_else(|| list_md_files_with_ref(client, owner_repo, "master"))
+            .or_else(|| {
+                let db = fetch_default_branch(client, owner_repo)?;
+                list_md_files_with_ref(client, owner_repo, &db)
+            })
+    };
 
     let Some(files) = all_files else {
         return Vec::new();
@@ -1789,7 +1825,7 @@ mod tests {
         ]);
         client.add_json(&tree_url("org/repo", "main"), &json);
 
-        let entries = list_repo_skill_entries_under(&client, "org/repo", "skills/");
+        let entries = list_repo_skill_entries_under(&client, "org/repo", "skills/", None);
         assert!(entries.contains(&"skills/browser".to_string()));
         assert!(entries.contains(&"skills/git.md".to_string()));
         assert!(!entries.contains(&"agents/reviewer.md".to_string()));
@@ -1802,7 +1838,7 @@ mod tests {
         let json = tree_json(&[("skills/git.md", "blob"), ("agents/reviewer.md", "blob")]);
         client.add_json(&tree_url("org/repo", "main"), &json);
 
-        let entries = list_repo_skill_entries_under(&client, "org/repo", ".");
+        let entries = list_repo_skill_entries_under(&client, "org/repo", ".", None);
         assert!(entries.contains(&"skills/git.md".to_string()));
         assert!(entries.contains(&"agents/reviewer.md".to_string()));
         assert_eq!(entries.len(), 2);
@@ -1814,7 +1850,7 @@ mod tests {
         let json = tree_json(&[("skills/git.md", "blob")]);
         client.add_json(&tree_url("org/repo", "main"), &json);
 
-        let entries = list_repo_skill_entries_under(&client, "org/repo", "nonexistent/");
+        let entries = list_repo_skill_entries_under(&client, "org/repo", "nonexistent/", None);
         assert!(entries.is_empty());
     }
 
@@ -1824,7 +1860,7 @@ mod tests {
         client.add_json_err(&tree_url("org/repo", "main"), "timeout");
         client.add_json_err(&tree_url("org/repo", "master"), "timeout");
 
-        let entries = list_repo_skill_entries_under(&client, "org/repo", "skills/");
+        let entries = list_repo_skill_entries_under(&client, "org/repo", "skills/", None);
         assert!(entries.is_empty());
     }
 
@@ -1838,7 +1874,7 @@ mod tests {
         ]);
         client.add_json(&tree_url("org/repo", "main"), &json);
 
-        let entries = list_repo_skill_entries_under(&client, "org/repo", "skills");
+        let entries = list_repo_skill_entries_under(&client, "org/repo", "skills", None);
         assert!(entries.contains(&"skills/browser".to_string()));
         assert!(entries.contains(&"skills/git.md".to_string()));
         assert_eq!(entries.len(), 2);

--- a/tests/upstream.rs
+++ b/tests/upstream.rs
@@ -531,6 +531,7 @@ fn add_discovery_scoped_flat_repo() {
             &client,
             "jeffallan/claude-skills",
             "skills/",
+            None,
         );
         if result.is_empty() {
             Err("no entries returned")
@@ -573,6 +574,7 @@ fn add_discovery_scoped_nested_repo() {
             &client,
             "aiskillstore/marketplace",
             "skills/",
+            None,
         );
         if result.is_empty() {
             Err("no entries returned")


### PR DESCRIPTION
fix #106 
1. add branch name parse owner/repo[@ref]
2. add fetch default branch name with github api

Announcement: I'm not expert in Rust, code generated by AI, and tested with some cases by me.