### PR TITLE
Fix fuzz target for GitLab source variant

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skillfile-core"
-version = "1.3.0"
+version = "1.6.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/fuzz/fuzz_targets/parse_manifest.rs
+++ b/fuzz/fuzz_targets/parse_manifest.rs
@@ -12,6 +12,31 @@ fn is_valid_name(name: &str) -> bool {
             .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')
 }
 
+fn assert_repo_source_invariants(
+    source_type: &str,
+    entry_name: &str,
+    owner_repo: &str,
+    path_in_repo: &str,
+    ref_: &str,
+) {
+    assert!(
+        !owner_repo.is_empty(),
+        "{source_type} entry '{entry_name}' has empty owner_repo",
+    );
+    assert!(
+        !path_in_repo.is_empty(),
+        "{source_type} entry '{entry_name}' has empty path_in_repo",
+    );
+    assert!(
+        !ref_.is_empty(),
+        "{source_type} entry '{entry_name}' has empty ref_",
+    );
+    assert!(
+        owner_repo.contains('/'),
+        "{source_type} entry '{entry_name}' owner_repo '{owner_repo}' missing '/'",
+    );
+}
+
 fuzz_target!(|data: &[u8]| {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("Skillfile");
@@ -47,29 +72,24 @@ fuzz_target!(|data: &[u8]| {
                 owner_repo,
                 path_in_repo,
                 ref_,
-            } => {
-                assert!(
-                    !owner_repo.is_empty(),
-                    "github entry '{}' has empty owner_repo",
-                    entry.name,
-                );
-                assert!(
-                    !path_in_repo.is_empty(),
-                    "github entry '{}' has empty path_in_repo",
-                    entry.name,
-                );
-                assert!(
-                    !ref_.is_empty(),
-                    "github entry '{}' has empty ref_",
-                    entry.name,
-                );
-                assert!(
-                    owner_repo.contains('/'),
-                    "github entry '{}' owner_repo '{}' missing '/'",
-                    entry.name,
-                    owner_repo,
-                );
-            }
+            } => assert_repo_source_invariants(
+                "github",
+                &entry.name,
+                owner_repo,
+                path_in_repo,
+                ref_,
+            ),
+            SourceFields::Gitlab {
+                owner_repo,
+                path_in_repo,
+                ref_,
+            } => assert_repo_source_invariants(
+                "gitlab",
+                &entry.name,
+                owner_repo,
+                path_in_repo,
+                ref_,
+            ),
             SourceFields::Local { path } => {
                 assert!(
                     !path.is_empty(),


### PR DESCRIPTION
**SUMMARY**
Update the `parse_manifest` fuzz target to handle the new `SourceFields::Gitlab` variant and keep its repo source checks shared. Refresh `fuzz/Cargo.lock` to match the current `skillfile-core` workspace version.

**RATIONALE**
The fuzzer stopped compiling after `bba3b02` added `Gitlab` support to `SourceFields`. Keeping the fuzz target exhaustive preserves parser regression coverage when source variants change.

**CHANGES**
- add `assert_repo_source_invariants()` in `fuzz/fuzz_targets/parse_manifest.rs`
- apply the shared repo invariant checks to both `SourceFields::Github` and `SourceFields::Gitlab`
- update the staged `fuzz/Cargo.lock` path dependency entry for `skillfile-core` from `1.3.0` to `1.6.4`