### PR TITLE
Harden GitLab sync resolution and caching

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -21,7 +21,7 @@ A Skillfile consists of lines, each of which is one of:
 - **Blank line** — ignored
 - **Comment line** — starts with `#` (after optional whitespace), ignored
 - **`install` line** — declares a deployment target
-- **Entry line** — declares a skill or agent to manage (`local`, `github`, or `url`)
+- **Entry line** — declares a skill or agent to manage (`local`, `github`, `gitlab`, or `url`)
 
 ### Inline Comments
 
@@ -82,6 +82,22 @@ github  <entity-type>  [name]  <owner/repo[@ref]>  <path-in-repo>  [ref]
 | `path-in-repo` | Path to the `.md` file within the repo. Use `.` if SKILL.md is at the repo root. |
 | `ref` | Branch, tag, or commit SHA. Defaults to `main` if omitted. Ignored when `@ref` is present in `owner/repo`. |
 
+### GitLab
+
+```
+gitlab  <entity-type>  [name]  <group/project>  <path-in-repo>  [ref]
+```
+
+| Field | Description |
+|---|---|
+| `entity-type` | `skill` or `agent` |
+| `name` | Optional logical name. If omitted, inferred from the filename stem of `path-in-repo`. |
+| `group/project` | GitLab project path. Subgroups are allowed (for example `group/subgroup/project`). |
+| `path-in-repo` | Path to the `.md` file within the project. Use `.` if `SKILL.md` is at the project root. |
+| `ref` | Branch, tag, or commit SHA. Defaults to `main` if omitted. |
+
+GitLab host selection is configured out-of-band via `GITLAB_HOST` or user config, not in the manifest line itself.
+
 ### URL
 
 ```
@@ -108,7 +124,7 @@ When the `name` field is omitted, it is inferred from the source path:
 2. Strip the `.md` extension if present
 3. The result is the name
 
-For GitHub entries, a field containing `/` is treated as `owner/repo`, not as a name. This disambiguates the positional fields.
+For GitHub and GitLab entries, a field containing `/` is treated as the repository or project path, not as a name. This disambiguates the positional fields.
 
 ### Uniqueness
 

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -247,12 +247,16 @@ pub fn write_gitlab_config_token(token: &str) -> Result<(), std::io::Error> {
             "could not determine config directory",
         )
     })?;
+    write_gitlab_config_token_to(token, &path)
+}
+
+fn write_gitlab_config_token_to(token: &str, path: &Path) -> Result<(), std::io::Error> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let mut config = read_config_from(&path);
+    let mut config = read_config_from(path);
     config.gitlab_token = Some(token.to_string());
-    write_config_to(&config, &path)
+    write_config_to(&config, path)
 }
 
 /// If the manifest has no install targets, fill them from the user config.
@@ -600,9 +604,7 @@ mod tests {
         }];
         write_user_targets_to(&targets, &path).unwrap();
 
-        let mut config = read_config_from(&path);
-        config.gitlab_token = Some("glpat-preserved".to_string());
-        write_config_to(&config, &path).unwrap();
+        write_gitlab_config_token_to("glpat-preserved", &path).unwrap();
 
         let result = read_config_from(&path);
         assert_eq!(result.gitlab_token.as_deref(), Some("glpat-preserved"));

--- a/crates/sources/src/resolver.rs
+++ b/crates/sources/src/resolver.rs
@@ -18,6 +18,10 @@ fn encode_url_path(path: &str) -> String {
         .join("/")
 }
 
+fn encode_query_value(value: &str) -> String {
+    encode_path_segment(value)
+}
+
 /// Percent-encode a single path segment (RFC 3986 unreserved characters
 /// pass through, everything else becomes %XX).
 fn encode_path_segment(segment: &str) -> String {
@@ -157,7 +161,47 @@ pub fn resolve_github_sha(
 
 fn gitlab_api_commit_url(host: &str, owner_repo: &str, ref_: &str) -> String {
     let encoded = owner_repo.replace('/', "%2F");
-    format!("https://{host}/api/v4/projects/{encoded}/repository/commits/{ref_}")
+    let encoded_ref = encode_query_value(ref_);
+    format!("https://{host}/api/v4/projects/{encoded}/repository/commits/{encoded_ref}")
+}
+
+fn gitlab_project_url(host: &str, owner_repo: &str) -> String {
+    let encoded = owner_repo.replace('/', "%2F");
+    format!("https://{host}/api/v4/projects/{encoded}")
+}
+
+fn fetch_gitlab_default_branch(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+    host: &str,
+) -> Option<String> {
+    let url = gitlab_project_url(host, owner_repo);
+    let text = client.get_json(&url).ok()??;
+    let data: serde_json::Value = serde_json::from_str(&text).ok()?;
+    data["default_branch"].as_str().map(ToString::to_string)
+}
+
+fn non_legacy_gitlab_default_branch(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+    host: &str,
+) -> Option<String> {
+    let branch = fetch_gitlab_default_branch(client, owner_repo, host)?;
+    if branch == "main" || branch == "master" {
+        return None;
+    }
+    Some(branch)
+}
+
+fn resolve_gitlab_default_branch_sha(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+    host: &str,
+) -> Result<Option<String>, SkillfileError> {
+    let Some(default_branch) = non_legacy_gitlab_default_branch(client, owner_repo, host) else {
+        return Ok(None);
+    };
+    try_resolve_gitlab_sha(client, owner_repo, &default_branch, host)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -190,14 +234,11 @@ pub fn resolve_gitlab_sha(
     if let Some(sha) = try_resolve_gitlab_sha(client, owner_repo, ref_, host)? {
         return Ok(sha);
     }
-    // Fall back: main <-> master
-    let fallback = match ref_ {
-        "main" => Some("master"),
-        "master" => Some("main"),
-        _ => None,
-    };
-    if let Some(fb) = fallback {
+    if let Some(fb) = fallback_branch(ref_) {
         if let Some(sha) = try_resolve_gitlab_sha(client, owner_repo, fb, host)? {
+            return Ok(sha);
+        }
+        if let Some(sha) = resolve_gitlab_default_branch_sha(client, owner_repo, host)? {
             return Ok(sha);
         }
     }
@@ -244,10 +285,40 @@ pub struct GitlabFetch<'a> {
 fn gitlab_file_url(gl: &GitlabFetch<'_>, path: &str) -> String {
     let encoded_project = gl.owner_repo.replace('/', "%2F");
     let encoded_path = encode_url_path(path).replace('/', "%2F");
-    let (host, ref_) = (gl.host, gl.ref_);
+    let encoded_ref = encode_query_value(gl.ref_);
+    let host = gl.host;
     format!(
-        "https://{host}/api/v4/projects/{encoded_project}/repository/files/{encoded_path}/raw?ref={ref_}"
+        "https://{host}/api/v4/projects/{encoded_project}/repository/files/{encoded_path}/raw?ref={encoded_ref}"
     )
+}
+
+const GITLAB_TREE_PAGE_SIZE: usize = 100;
+
+fn gitlab_tree_url(gl: &GitlabFetch<'_>, base_path: &str, page: usize) -> String {
+    let encoded_project = gl.owner_repo.replace('/', "%2F");
+    let encoded_ref = encode_query_value(gl.ref_);
+    let encoded_path = encode_query_value(base_path);
+    format!(
+        "https://{}/api/v4/projects/{encoded_project}/repository/tree?ref={encoded_ref}&recursive=true&per_page={GITLAB_TREE_PAGE_SIZE}&page={page}&path={encoded_path}",
+        gl.host
+    )
+}
+
+fn gitlab_tree_blob_entry(
+    item: &serde_json::Value,
+    prefix: &str,
+    gl: &GitlabFetch<'_>,
+) -> Option<DirEntry> {
+    if item["type"].as_str() != Some("blob") {
+        return None;
+    }
+    let path = item["path"].as_str()?;
+    let relative_path = path.strip_prefix(prefix)?.to_string();
+    let download_url = gitlab_file_url(gl, path);
+    Some(DirEntry {
+        relative_path,
+        download_url,
+    })
 }
 
 pub fn fetch_gitlab_file(
@@ -267,38 +338,39 @@ pub(crate) fn list_gitlab_dir_recursive(
     gl: &GitlabFetch<'_>,
     base_path: &str,
 ) -> Result<Vec<DirEntry>, SkillfileError> {
-    let encoded = gl.owner_repo.replace('/', "%2F");
     let trimmed = base_path.trim_end_matches('/');
-    // Use GitLab's `path` parameter to scope the tree to the target directory,
-    // avoiding pagination issues on large repos.
-    let encoded_path = encode_url_path(trimmed);
-    let url = format!(
-        "https://{}/api/v4/projects/{}/repository/tree?ref={}&recursive=true&per_page=100&path={}",
-        gl.host, encoded, gl.ref_, encoded_path
-    );
-    let Some(text) = gl.client.get_json(&url)? else {
-        return Ok(Vec::new());
-    };
-    // GitLab returns a flat JSON array, not {"tree": [...]} like GitHub.
-    // With the `path` parameter, returned paths are still repo-absolute.
-    let items: Vec<serde_json::Value> = serde_json::from_str(&text)
-        .map_err(|e| SkillfileError::Network(format!("invalid GitLab tree JSON: {e}")))?;
-
     let prefix = format!("{trimmed}/");
+    let mut entries = Vec::new();
+    let mut page = 1;
 
-    let entries = items
-        .iter()
-        .filter(|item| item["type"].as_str() == Some("blob"))
-        .filter_map(|item| {
-            let path = item["path"].as_str()?;
-            let relative_path = path.strip_prefix(&prefix)?.to_string();
-            let download_url = gitlab_file_url(gl, path);
-            Some(DirEntry {
-                relative_path,
-                download_url,
-            })
-        })
-        .collect();
+    loop {
+        // Use GitLab's `path` parameter to scope the tree to the target
+        // directory, then page until fewer than GITLAB_TREE_PAGE_SIZE results
+        // are returned.
+        let url = gitlab_tree_url(gl, trimmed, page);
+        let Some(text) = gl.client.get_json(&url)? else {
+            break;
+        };
+        // GitLab returns a flat JSON array, not {"tree": [...]} like GitHub.
+        // With the `path` parameter, returned paths are still repo-absolute.
+        let items: Vec<serde_json::Value> = serde_json::from_str(&text)
+            .map_err(|e| SkillfileError::Network(format!("invalid GitLab tree JSON: {e}")))?;
+
+        if items.is_empty() {
+            break;
+        }
+
+        entries.extend(
+            items
+                .iter()
+                .filter_map(|item| gitlab_tree_blob_entry(item, &prefix, gl)),
+        );
+
+        if items.len() < GITLAB_TREE_PAGE_SIZE {
+            break;
+        }
+        page += 1;
+    }
 
     Ok(entries)
 }
@@ -2114,7 +2186,8 @@ mod tests {
 
     fn gitlab_commit_url(owner_repo: &str, ref_: &str) -> String {
         let encoded = owner_repo.replace('/', "%2F");
-        format!("https://gitlab.com/api/v4/projects/{encoded}/repository/commits/{ref_}")
+        let encoded_ref = encode_query_value(ref_);
+        format!("https://gitlab.com/api/v4/projects/{encoded}/repository/commits/{encoded_ref}")
     }
 
     fn gitlab_sha_json(sha: &str) -> String {
@@ -2143,6 +2216,17 @@ mod tests {
 
         let sha = resolve_gitlab_sha(&client, "group/repo", "v1.0.0", "gitlab.com").unwrap();
         assert_eq!(sha, "cafebabe12345678");
+    }
+
+    #[test]
+    fn resolve_gitlab_sha_encodes_slashy_ref() {
+        let mut client = MockClient::new();
+        let url = gitlab_commit_url("group/repo", "feature/cool-stuff");
+        client.add_json(&url, &gitlab_sha_json("branchsha1234"));
+
+        let sha =
+            resolve_gitlab_sha(&client, "group/repo", "feature/cool-stuff", "gitlab.com").unwrap();
+        assert_eq!(sha, "branchsha1234");
     }
 
     #[test]
@@ -2205,6 +2289,24 @@ mod tests {
     }
 
     #[test]
+    fn resolve_gitlab_sha_falls_back_to_default_branch() {
+        let mut client = MockClient::new();
+        client.add_json_none(&gitlab_commit_url("group/repo", "main"));
+        client.add_json_none(&gitlab_commit_url("group/repo", "master"));
+        client.add_json(
+            &gitlab_project_url("gitlab.com", "group/repo"),
+            r#"{"default_branch": "trunk"}"#,
+        );
+        client.add_json(
+            &gitlab_commit_url("group/repo", "trunk"),
+            &gitlab_sha_json("trunksha1234"),
+        );
+
+        let sha = resolve_gitlab_sha(&client, "group/repo", "main", "gitlab.com").unwrap();
+        assert_eq!(sha, "trunksha1234");
+    }
+
+    #[test]
     fn resolve_gitlab_sha_fails_when_both_branches_absent() {
         let mut client = MockClient::new();
         client.add_json_none(&gitlab_commit_url("group/repo", "main"));
@@ -2220,10 +2322,23 @@ mod tests {
     // GitLab fetch helpers
     // -----------------------------------------------------------------------
 
-    fn gitlab_tree_url(owner_repo: &str, ref_: &str, path: &str) -> String {
+    struct TestGitlabTree<'a> {
+        owner_repo: &'a str,
+        ref_: &'a str,
+        path: &'a str,
+    }
+
+    fn gitlab_tree_url(tree: &TestGitlabTree<'_>, page: usize) -> String {
+        let TestGitlabTree {
+            owner_repo,
+            ref_,
+            path,
+        } = tree;
         let encoded = owner_repo.replace('/', "%2F");
+        let encoded_ref = encode_query_value(ref_);
+        let encoded_path = encode_query_value(path);
         format!(
-            "https://gitlab.com/api/v4/projects/{encoded}/repository/tree?ref={ref_}&recursive=true&per_page=100&path={path}"
+            "https://gitlab.com/api/v4/projects/{encoded}/repository/tree?ref={encoded_ref}&recursive=true&per_page=100&page={page}&path={encoded_path}"
         )
     }
 
@@ -2273,6 +2388,27 @@ mod tests {
     }
 
     #[test]
+    fn fetch_gitlab_file_encodes_ref_query() {
+        let encoded_project = "group%2Fproject";
+        let encoded_path = "skills%2Fgit.md";
+        let encoded_ref = "feature%2Fgitlab";
+        let url = format!(
+            "https://gitlab.com/api/v4/projects/{encoded_project}/repository/files/{encoded_path}/raw?ref={encoded_ref}"
+        );
+        let mut client = MockClient::new();
+        client.add_bytes(&url, b"# Git skill".to_vec());
+
+        let gl = GitlabFetch {
+            client: &client,
+            owner_repo: "group/project",
+            ref_: "feature/gitlab",
+            host: "gitlab.com",
+        };
+        let result = fetch_gitlab_file(&gl, "skills/git.md").unwrap();
+        assert_eq!(result, b"# Git skill");
+    }
+
+    #[test]
     fn fetch_gitlab_file_propagates_error() {
         let sha = "fff000";
         let encoded_project = "group%2Fproject";
@@ -2301,7 +2437,14 @@ mod tests {
     fn list_gitlab_dir_recursive_returns_blobs_under_prefix() {
         let owner_repo = "group/project";
         let ref_ = "main";
-        let url = gitlab_tree_url(owner_repo, ref_, "skills/dir");
+        let url = gitlab_tree_url(
+            &TestGitlabTree {
+                owner_repo,
+                ref_,
+                path: "skills/dir",
+            },
+            1,
+        );
 
         // GitLab tree API returns a flat JSON array (not {"tree": [...]})
         let json = r#"[
@@ -2333,7 +2476,14 @@ mod tests {
     fn list_gitlab_dir_recursive_download_urls_use_file_api() {
         let owner_repo = "mygroup/myrepo";
         let ref_ = "abc123sha";
-        let url = gitlab_tree_url(owner_repo, ref_, "skills/python");
+        let url = gitlab_tree_url(
+            &TestGitlabTree {
+                owner_repo,
+                ref_,
+                path: "skills/python",
+            },
+            1,
+        );
 
         let json = r#"[{"path": "skills/python/SKILL.md", "type": "blob"}]"#;
 
@@ -2359,7 +2509,14 @@ mod tests {
     fn list_gitlab_dir_recursive_empty_returns_empty() {
         let owner_repo = "group/project";
         let ref_ = "main";
-        let url = gitlab_tree_url(owner_repo, ref_, "skills/dir");
+        let url = gitlab_tree_url(
+            &TestGitlabTree {
+                owner_repo,
+                ref_,
+                path: "skills/dir",
+            },
+            1,
+        );
 
         let mut client = MockClient::new();
         client.add_json(&url, "[]");
@@ -2378,7 +2535,14 @@ mod tests {
     fn list_gitlab_dir_recursive_4xx_returns_empty() {
         let owner_repo = "group/project";
         let ref_ = "main";
-        let url = gitlab_tree_url(owner_repo, ref_, "skills/dir");
+        let url = gitlab_tree_url(
+            &TestGitlabTree {
+                owner_repo,
+                ref_,
+                path: "skills/dir",
+            },
+            1,
+        );
 
         let mut client = MockClient::new();
         client.add_json_none(&url);
@@ -2391,5 +2555,47 @@ mod tests {
         };
         let entries = list_gitlab_dir_recursive(&gl, "skills/dir").unwrap();
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn list_gitlab_dir_recursive_fetches_multiple_pages() {
+        let owner_repo = "group/project";
+        let ref_ = "main";
+        let tree = TestGitlabTree {
+            owner_repo,
+            ref_,
+            path: "skills/dir",
+        };
+        let page_one = gitlab_tree_url(&tree, 1);
+        let page_two = gitlab_tree_url(&tree, 2);
+
+        let full_page_items = (0..100)
+            .map(|idx| format!(r#"{{"path": "skills/dir/file{idx}.md", "type": "blob"}}"#))
+            .collect::<Vec<_>>()
+            .join(",");
+        let page_one_json = format!("[{full_page_items}]");
+        let page_two_json = r#"[
+            {"path": "skills/dir/final.md", "type": "blob"}
+        ]"#;
+
+        let mut client = MockClient::new();
+        client.add_json(&page_one, &page_one_json);
+        client.add_json(&page_two, page_two_json);
+
+        let gl = GitlabFetch {
+            client: &client,
+            owner_repo,
+            ref_,
+            host: "gitlab.com",
+        };
+        let entries = list_gitlab_dir_recursive(&gl, "skills/dir").unwrap();
+
+        assert_eq!(entries.len(), 101);
+        assert!(entries
+            .iter()
+            .any(|entry| entry.relative_path == "file0.md"));
+        assert!(entries
+            .iter()
+            .any(|entry| entry.relative_path == "final.md"));
     }
 }

--- a/crates/sources/src/sync.rs
+++ b/crates/sources/src/sync.rs
@@ -17,11 +17,34 @@ use crate::strategy::{content_file, is_dir_entry, meta_sha};
 
 pub const VENDOR_DIR: &str = ".skillfile/cache";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ForgeType {
+    Github,
+    Gitlab,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RemoteRefKey {
+    forge: ForgeType,
+    owner_repo: String,
+    ref_: String,
+}
+
+impl RemoteRefKey {
+    fn new(forge: ForgeType, owner_repo: &str, ref_: &str) -> Self {
+        Self {
+            forge,
+            owner_repo: owner_repo.to_owned(),
+            ref_: ref_.to_owned(),
+        }
+    }
+}
+
 pub struct SyncContext {
     pub repo_root: PathBuf,
     pub dry_run: bool,
     pub update: bool,
-    pub sha_cache: HashMap<(String, String), String>,
+    pub sha_cache: HashMap<RemoteRefKey, String>,
     pub locked: BTreeMap<String, LockEntry>,
 }
 
@@ -62,27 +85,23 @@ fn content_exists(entry: &Entry, vdir: &Path) -> bool {
     }
 }
 
-fn cache_github_sha(ctx: &mut SyncContext, entry: &Entry, sha: &str) {
-    let SourceFields::Github {
-        owner_repo, ref_, ..
-    } = &entry.source
-    else {
-        return;
-    };
-    let cache_key = (owner_repo.clone(), ref_.clone());
-    ctx.sha_cache
-        .entry(cache_key)
-        .or_insert_with(|| sha.to_owned());
+fn remote_repo_ref(entry: &Entry) -> Option<(&str, &str, ForgeType)> {
+    match &entry.source {
+        SourceFields::Github {
+            owner_repo, ref_, ..
+        } => Some((owner_repo, ref_, ForgeType::Github)),
+        SourceFields::Gitlab {
+            owner_repo, ref_, ..
+        } => Some((owner_repo, ref_, ForgeType::Gitlab)),
+        _ => None,
+    }
 }
 
-fn cache_gitlab_sha(ctx: &mut SyncContext, entry: &Entry, sha: &str) {
-    let SourceFields::Gitlab {
-        owner_repo, ref_, ..
-    } = &entry.source
-    else {
+fn cache_remote_sha(ctx: &mut SyncContext, entry: &Entry, sha: &str) {
+    let Some((owner_repo, ref_, forge)) = remote_repo_ref(entry) else {
         return;
     };
-    let cache_key = (owner_repo.clone(), ref_.clone());
+    let cache_key = RemoteRefKey::new(forge, owner_repo, ref_);
     ctx.sha_cache
         .entry(cache_key)
         .or_insert_with(|| sha.to_owned());
@@ -108,7 +127,7 @@ pub fn sync_entry(
                 locked: &ctx.locked,
             };
             if let Some((key, le)) = sync_github_core(client, entry, &params)? {
-                cache_github_sha(ctx, entry, &le.sha);
+                cache_remote_sha(ctx, entry, &le.sha);
                 ctx.locked.insert(key, le);
             }
             Ok(())
@@ -122,7 +141,7 @@ pub fn sync_entry(
                 locked: &ctx.locked,
             };
             if let Some((key, le)) = sync_gitlab_core(client, entry, &params)? {
-                cache_gitlab_sha(ctx, entry, &le.sha);
+                cache_remote_sha(ctx, entry, &le.sha);
                 ctx.locked.insert(key, le);
             }
             Ok(())
@@ -142,7 +161,7 @@ struct SyncParams<'a> {
     repo_root: &'a Path,
     dry_run: bool,
     update: bool,
-    sha_cache: &'a HashMap<(String, String), String>,
+    sha_cache: &'a HashMap<RemoteRefKey, String>,
     locked: &'a BTreeMap<String, LockEntry>,
 }
 
@@ -284,18 +303,40 @@ fn write_github_meta(m: &GithubMeta<'_>) -> Result<(), SkillfileError> {
 }
 
 /// Input for `resolve_sha_for_entry`: coordinates + label + previously-locked SHA.
+enum ShaResolver<'a> {
+    Github,
+    Gitlab { host: &'a str },
+}
+
 struct ShaLookup<'a> {
+    cache_key: RemoteRefKey,
     owner_repo: &'a str,
     ref_: &'a str,
     label: &'a str,
     locked_sha: Option<&'a str>,
+    resolver: ShaResolver<'a>,
 }
 
-/// Resolve the SHA for a GitHub entry, returning `None` in dry-run mode.
+impl ShaResolver<'_> {
+    fn resolve(
+        &self,
+        client: &dyn HttpClient,
+        lookup: &ShaLookup<'_>,
+    ) -> Result<String, SkillfileError> {
+        match self {
+            Self::Github => resolve_github_sha(client, lookup.owner_repo, lookup.ref_),
+            Self::Gitlab { host } => {
+                resolve_gitlab_sha(client, lookup.owner_repo, lookup.ref_, host)
+            }
+        }
+    }
+}
+
+/// Resolve the SHA for a remote entry, returning `None` in dry-run mode.
 ///
 /// Uses locked SHA if available (not in `--update` mode), otherwise looks
-/// up the sha_cache, or resolves via the GitHub API.
-fn resolve_sha_for_entry(
+/// up the sha_cache, or resolves via the forge API.
+fn resolve_remote_sha_for_entry(
     client: &dyn HttpClient,
     q: &ShaLookup<'_>,
     params: &SyncParams<'_>,
@@ -309,8 +350,7 @@ fn resolve_sha_for_entry(
         return Ok(Some(ls.to_owned()));
     }
 
-    let cache_key = (q.owner_repo.to_owned(), q.ref_.to_owned());
-    if let Some(cached) = params.sha_cache.get(&cache_key) {
+    if let Some(cached) = params.sha_cache.get(&q.cache_key) {
         return Ok(Some(cached.clone()));
     }
 
@@ -325,7 +365,7 @@ fn resolve_sha_for_entry(
     }
 
     // Fallback: resolve inline (single-entry mode or missed cache)
-    let sha = resolve_github_sha(client, q.owner_repo, q.ref_)?;
+    let sha = q.resolver.resolve(client, q)?;
     Ok(Some(sha))
 }
 
@@ -383,8 +423,8 @@ fn fetch_store_github(op: &StoreOp<'_>) -> Result<String, SkillfileError> {
     Ok(raw_url)
 }
 
-/// `sha_cache` maps `(owner_repo, ref_)` -> resolved SHA. Pre-populated by
-/// `resolve_shas_parallel` so no mutation is needed here.
+/// `sha_cache` maps a forge-qualified remote ref to its resolved SHA.
+/// Pre-populated by `resolve_shas_parallel` so no mutation is needed here.
 fn sync_github_core(
     client: &dyn HttpClient,
     entry: &Entry,
@@ -417,12 +457,14 @@ fn sync_github_core(
     }
 
     let q = ShaLookup {
+        cache_key: RemoteRefKey::new(ForgeType::Github, owner_repo, ref_),
         owner_repo,
         ref_,
         label: &label,
         locked_sha: locked_sha.as_deref(),
+        resolver: ShaResolver::Github,
     };
-    let Some(sha) = resolve_sha_for_entry(client, &q, params)? else {
+    let Some(sha) = resolve_remote_sha_for_entry(client, &q, params)? else {
         return Ok(None); // dry-run
     };
 
@@ -642,46 +684,6 @@ fn fetch_store_gitlab(op: &GitlabStoreOp<'_>) -> Result<String, SkillfileError> 
     Ok(raw_url)
 }
 
-/// Resolve the SHA for a GitLab entry, returning `None` in dry-run mode.
-struct GitlabShaQuery<'a> {
-    lookup: &'a ShaLookup<'a>,
-    host: &'a str,
-}
-
-fn resolve_gitlab_sha_for_entry(
-    client: &dyn HttpClient,
-    q: &GitlabShaQuery<'_>,
-    params: &SyncParams<'_>,
-) -> Result<Option<String>, SkillfileError> {
-    let l = q.lookup;
-    if let Some(ls) = l.locked_sha {
-        progress!(
-            "{}: re-fetching (locked sha={}) ...",
-            l.label,
-            short_sha(ls)
-        );
-        return Ok(Some(ls.to_owned()));
-    }
-
-    let cache_key = (l.owner_repo.to_owned(), l.ref_.to_owned());
-    if let Some(cached) = params.sha_cache.get(&cache_key) {
-        return Ok(Some(cached.clone()));
-    }
-
-    if params.dry_run {
-        progress!(
-            "{}: resolving {}@{} ... [dry-run]",
-            l.label,
-            l.owner_repo,
-            l.ref_
-        );
-        return Ok(None);
-    }
-
-    let sha = resolve_gitlab_sha(client, l.owner_repo, l.ref_, q.host)?;
-    Ok(Some(sha))
-}
-
 /// Core sync logic for a GitLab entry. Mirrors `sync_github_core`.
 fn sync_gitlab_core(
     client: &dyn HttpClient,
@@ -716,16 +718,14 @@ fn sync_gitlab_core(
     }
 
     let lookup = ShaLookup {
+        cache_key: RemoteRefKey::new(ForgeType::Gitlab, owner_repo, ref_),
         owner_repo,
         ref_,
         label: &label,
         locked_sha: locked_sha.as_deref(),
+        resolver: ShaResolver::Gitlab { host: &host },
     };
-    let q = GitlabShaQuery {
-        lookup: &lookup,
-        host: &host,
-    };
-    let Some(sha) = resolve_gitlab_sha_for_entry(client, &q, params)? else {
+    let Some(sha) = resolve_remote_sha_for_entry(client, &lookup, params)? else {
         return Ok(None); // dry-run
     };
 
@@ -830,30 +830,10 @@ fn sync_entry_core(
     }
 }
 
-/// Which forge a repo+ref pair belongs to, so `resolve_shas_parallel` can
-/// dispatch to the correct SHA resolution function.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum ForgeType {
-    Github,
-    Gitlab,
-}
-
-/// Extract `(owner_repo, ref_)` from any remote source type.
-fn remote_repo_ref(entry: &Entry) -> Option<(&str, &str, ForgeType)> {
-    match &entry.source {
-        SourceFields::Github {
-            owner_repo, ref_, ..
-        } => Some((owner_repo, ref_, ForgeType::Github)),
-        SourceFields::Gitlab {
-            owner_repo, ref_, ..
-        } => Some((owner_repo, ref_, ForgeType::Gitlab)),
-        _ => None,
-    }
-}
-
 struct RepoRef<'a> {
     owner_repo: &'a str,
     ref_: &'a str,
+    forge: ForgeType,
 }
 
 /// Return `true` if the entry matches `rr` and lacks a locked SHA.
@@ -862,10 +842,10 @@ fn entry_needs_resolution(
     rr: &RepoRef<'_>,
     locked: &BTreeMap<String, LockEntry>,
 ) -> bool {
-    let Some((or, r, _)) = remote_repo_ref(e) else {
+    let Some((or, r, forge)) = remote_repo_ref(e) else {
         return false;
     };
-    or == rr.owner_repo && r == rr.ref_ && locked.get(&lock_key(e)).is_none()
+    or == rr.owner_repo && r == rr.ref_ && forge == rr.forge && locked.get(&lock_key(e)).is_none()
 }
 
 /// Return `true` if any entry matching `rr` lacks a locked SHA.
@@ -882,29 +862,32 @@ fn needs_sha_resolution(
         .any(|e| entry_needs_resolution(e, rr, locked))
 }
 
-/// Collect unique `(owner_repo, ref_)` pairs that need SHA resolution,
-/// tagged with their forge type so the resolver knows which API to call.
+/// Collect unique remote refs that need SHA resolution.
 fn collect_pairs_to_resolve(
     entries: &[&Entry],
     locked: &BTreeMap<String, LockEntry>,
     update: bool,
-) -> Vec<(String, String, ForgeType)> {
-    let mut need_resolve: Vec<(String, String, ForgeType)> = Vec::new();
+) -> Vec<RemoteRefKey> {
+    let mut need_resolve = Vec::new();
     let mut seen = HashSet::new();
 
     for entry in entries {
         let Some((owner_repo, ref_, forge)) = remote_repo_ref(entry) else {
             continue;
         };
-        let key_pair = (owner_repo.to_owned(), ref_.to_owned());
-        if !seen.insert(key_pair.clone()) {
+        let key = RemoteRefKey::new(forge, owner_repo, ref_);
+        if !seen.insert(key.clone()) {
             continue;
         }
         // In update mode, always re-resolve. Otherwise, skip if all entries
         // with this repo+ref already have locked SHAs.
-        let rr = RepoRef { owner_repo, ref_ };
+        let rr = RepoRef {
+            owner_repo,
+            ref_,
+            forge,
+        };
         if update || needs_sha_resolution(entries, &rr, locked) {
-            need_resolve.push((key_pair.0, key_pair.1, forge));
+            need_resolve.push(key);
         }
     }
 
@@ -917,48 +900,38 @@ struct ResolveCtx<'a> {
     update: bool,
 }
 
-/// A pending SHA resolution: repo coordinates plus which forge to call.
 struct PendingResolve {
-    owner_repo: String,
-    ref_: String,
-    forge: ForgeType,
+    key: RemoteRefKey,
 }
 
 impl PendingResolve {
     /// Dispatch to the correct forge API.
     fn resolve(&self, client: &dyn HttpClient) -> Result<String, SkillfileError> {
-        match self.forge {
-            ForgeType::Github => resolve_github_sha(client, &self.owner_repo, &self.ref_),
+        match self.key.forge {
+            ForgeType::Github => resolve_github_sha(client, &self.key.owner_repo, &self.key.ref_),
             ForgeType::Gitlab => {
                 let host = crate::http::gitlab_host();
-                resolve_gitlab_sha(client, &self.owner_repo, &self.ref_, &host)
+                resolve_gitlab_sha(client, &self.key.owner_repo, &self.key.ref_, &host)
             }
         }
     }
 }
 
-/// Resolve all unique `(owner_repo, ref_)` SHAs in parallel.
+/// Resolve all unique remote refs in parallel.
 ///
 /// In `--update` mode, all remote entries need resolution (locked SHAs ignored).
 /// In normal mode, only entries without a locked SHA need resolution.
 fn resolve_shas_parallel(
     client: &dyn HttpClient,
     ctx: &ResolveCtx<'_>,
-) -> Result<HashMap<(String, String), String>, SkillfileError> {
-    let triples = collect_pairs_to_resolve(ctx.entries, ctx.locked, ctx.update);
+) -> Result<HashMap<RemoteRefKey, String>, SkillfileError> {
+    let keys = collect_pairs_to_resolve(ctx.entries, ctx.locked, ctx.update);
 
-    if triples.is_empty() {
+    if keys.is_empty() {
         return Ok(HashMap::new());
     }
 
-    let pending: Vec<PendingResolve> = triples
-        .into_iter()
-        .map(|(owner_repo, ref_, forge)| PendingResolve {
-            owner_repo,
-            ref_,
-            forge,
-        })
-        .collect();
+    let pending: Vec<PendingResolve> = keys.into_iter().map(|key| PendingResolve { key }).collect();
 
     // Resolve in parallel using scoped threads — borrows avoid cloning.
     let results: Vec<Result<String, SkillfileError>> = std::thread::scope(|s| {
@@ -977,11 +950,11 @@ fn resolve_shas_parallel(
         let sha = result?;
         progress!(
             "  resolved {}@{} -> {}",
-            p.owner_repo,
-            p.ref_,
+            p.key.owner_repo,
+            p.key.ref_,
             short_sha(&sha)
         );
-        cache.insert((p.owner_repo, p.ref_), sha);
+        cache.insert(p.key, sha);
     }
     Ok(cache)
 }
@@ -1252,8 +1225,8 @@ mod tests {
     use crate::http::HttpClient;
 
     use super::{
-        content_exists, fetch_dir_at_sha, fetch_file_at_sha, sync_entry, vendor_dir_for,
-        SyncContext, VENDOR_DIR,
+        content_exists, fetch_dir_at_sha, fetch_file_at_sha, resolve_shas_parallel, sync_entry,
+        vendor_dir_for, ForgeType, RemoteRefKey, ResolveCtx, SyncContext, VENDOR_DIR,
     };
 
     // -----------------------------------------------------------------------
@@ -1662,15 +1635,118 @@ mod tests {
 
         sync_entry(&client, &entry1, &mut ctx).unwrap();
         // After the first call the SHA must be in the cache
-        assert!(ctx
-            .sha_cache
-            .contains_key(&("owner/repo".to_string(), "main".to_string())));
+        assert!(ctx.sha_cache.contains_key(&RemoteRefKey::new(
+            ForgeType::Github,
+            "owner/repo",
+            "main"
+        )));
 
         // The second call must succeed using the cached SHA (no second get_json call)
         sync_entry(&client, &entry2, &mut ctx).unwrap();
 
         assert!(ctx.locked.contains_key("github/skill/skill-one"));
         assert!(ctx.locked.contains_key("github/skill/skill-two"));
+    }
+
+    #[test]
+    fn sync_entry_sha_cache_isolated_between_forges() {
+        let github_sha = "1111111111111111111111111111111111111111";
+        let gitlab_sha = "2222222222222222222222222222222222222222";
+        let dir = tempfile::tempdir().unwrap();
+
+        let github_entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "gh-skill".into(),
+            source: SourceFields::Github {
+                owner_repo: "shared/repo".into(),
+                path_in_repo: "skills/gh.md".into(),
+                ref_: "main".into(),
+            },
+        };
+        let gitlab_entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "gl-skill".into(),
+            source: SourceFields::Gitlab {
+                owner_repo: "shared/repo".into(),
+                path_in_repo: "skills/gl.md".into(),
+                ref_: "main".into(),
+            },
+        };
+
+        let github_sha_url = "https://api.github.com/repos/shared/repo/commits/main".to_string();
+        let gitlab_sha_url =
+            "https://gitlab.com/api/v4/projects/shared%2Frepo/repository/commits/main".to_string();
+        let github_sha_json = serde_json::json!({ "sha": github_sha }).to_string();
+        let gitlab_sha_json = serde_json::json!({ "id": gitlab_sha }).to_string();
+        let github_raw_url =
+            format!("https://raw.githubusercontent.com/shared/repo/{github_sha}/skills/gh.md");
+        let gitlab_raw_url = format!(
+            "https://gitlab.com/api/v4/projects/shared%2Frepo/repository/files/skills%2Fgl.md/raw?ref={gitlab_sha}"
+        );
+
+        let client = MockClient::new()
+            .with_json(github_sha_url, Some(github_sha_json))
+            .with_json(gitlab_sha_url, Some(gitlab_sha_json))
+            .with_bytes(github_raw_url, b"# GitHub".to_vec())
+            .with_bytes(gitlab_raw_url, b"# GitLab".to_vec());
+
+        let mut ctx = make_sync_ctx(dir.path());
+        sync_entry(&client, &github_entry, &mut ctx).unwrap();
+        sync_entry(&client, &gitlab_entry, &mut ctx).unwrap();
+
+        assert_eq!(ctx.locked["github/skill/gh-skill"].sha, github_sha);
+        assert_eq!(ctx.locked["gitlab/skill/gl-skill"].sha, gitlab_sha);
+    }
+
+    #[test]
+    fn resolve_shas_parallel_does_not_dedup_across_forges() {
+        let github_entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "gh-skill".into(),
+            source: SourceFields::Github {
+                owner_repo: "shared/repo".into(),
+                path_in_repo: "skills/gh.md".into(),
+                ref_: "main".into(),
+            },
+        };
+        let gitlab_entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "gl-skill".into(),
+            source: SourceFields::Gitlab {
+                owner_repo: "shared/repo".into(),
+                path_in_repo: "skills/gl.md".into(),
+                ref_: "main".into(),
+            },
+        };
+        let entries = [&github_entry, &gitlab_entry];
+
+        let client = MockClient::new()
+            .with_json(
+                "https://api.github.com/repos/shared/repo/commits/main",
+                Some(serde_json::json!({ "sha": "githubsha" }).to_string()),
+            )
+            .with_json(
+                "https://gitlab.com/api/v4/projects/shared%2Frepo/repository/commits/main",
+                Some(serde_json::json!({ "id": "gitlabsha" }).to_string()),
+            );
+        let locked = BTreeMap::new();
+        let resolve_ctx = ResolveCtx {
+            entries: &entries,
+            locked: &locked,
+            update: false,
+        };
+
+        let cache = resolve_shas_parallel(&client, &resolve_ctx).unwrap();
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(
+            cache[&RemoteRefKey::new(ForgeType::Github, "shared/repo", "main")],
+            "githubsha"
+        );
+        assert_eq!(
+            cache[&RemoteRefKey::new(ForgeType::Gitlab, "shared/repo", "main")],
+            "gitlabsha"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -2155,8 +2231,9 @@ mod tests {
         let entry = gitlab_skill_entry("release-helper", "skills/release-helper");
 
         let encoded_project = "group%2Fproject";
+        let encoded_path = "skills%2Frelease-helper";
         let tree_url = format!(
-            "https://gitlab.com/api/v4/projects/{encoded_project}/repository/tree?ref={sha}&recursive=true&per_page=100&path=skills/release-helper"
+            "https://gitlab.com/api/v4/projects/{encoded_project}/repository/tree?ref={sha}&recursive=true&per_page=100&page=1&path={encoded_path}"
         );
         let tree_json = r#"[
             {"path": "skills/release-helper/SKILL.md", "type": "blob"},

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -715,6 +715,50 @@ fn add_github_at_ref_takes_priority_over_positional_ref() {
     );
 }
 
+#[test]
+fn add_gitlab_subcommand_works_with_explicit_ref() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("Skillfile"), "# empty\n").unwrap();
+
+    let output = sf(dir.path())
+        .env(
+            "SKILLFILE_CONFIG_PATH",
+            dir.path().join("missing-config.toml"),
+        )
+        .args([
+            "add",
+            "gitlab",
+            "skill",
+            "group/project",
+            "skills/SKILL.md",
+            "release/v1",
+        ])
+        .timeout(std::time::Duration::from_secs(10))
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "gitlab add should succeed without install targets: {stderr}"
+    );
+    assert!(
+        stdout.contains("Added: gitlab  skill  group/project  skills/SKILL.md  release/v1"),
+        "gitlab add should print the added entry, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("No install targets configured yet"),
+        "gitlab add should follow the direct add path, got: {stdout}"
+    );
+
+    let skillfile = std::fs::read_to_string(dir.path().join("Skillfile")).unwrap();
+    assert!(
+        skillfile.contains("gitlab  skill  group/project  skills/SKILL.md  release/v1"),
+        "gitlab add should persist the entry, got:\n{skillfile}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // add wizard: CLI routing
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**SUMMARY**
Qualify remote SHA cache entries by forge and harden GitLab URL resolution. Add paginated GitLab directory fetches and command coverage.

**RATIONALE**
GitHub and GitLab projects can share the same `owner/repo@ref` coordinates. Cache entries must preserve forge identity, and GitLab refs and directory listings must follow the API contract for slashy refs and large directories.

**CHANGES**
- Add forge-qualified `RemoteRefKey` cache entries and share remote SHA resolution between GitHub and GitLab sync paths.
- Encode GitLab refs and tree paths, query the configured default branch, and paginate GitLab directory listings.
- Route GitLab config token writes through a path-based helper for direct unit coverage.
- Add regression tests for forge cache isolation, slashy refs, GitLab pagination, default-branch fallback, and the `add gitlab` command.