### PR TITLE
feat: add list command

### DIFF
--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -1,0 +1,177 @@
+use std::path::Path;
+
+use serde::Serialize;
+use skillfile_core::error::SkillfileError;
+use skillfile_core::models::{EntityType, Entry, Manifest, SourceFields};
+use skillfile_core::parser::MANIFEST_NAME;
+
+pub struct ListOptions {
+    pub json: bool,
+    pub names_only: bool,
+    pub skills: bool,
+    pub agents: bool,
+}
+
+#[derive(Serialize)]
+struct ListEntry<'a> {
+    name: &'a str,
+    entity_type: &'a str,
+    source_type: &'a str,
+    location: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ref_: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct ListOutput<'a> {
+    entries: Vec<ListEntry<'a>>,
+    install_targets: Vec<String>,
+}
+
+fn include_entity(entity_type: EntityType, opts: &ListOptions) -> bool {
+    match (opts.skills, opts.agents) {
+        (false, false) | (true, true) => true,
+        (true, false) => entity_type == EntityType::Skill,
+        (false, true) => entity_type == EntityType::Agent,
+    }
+}
+
+fn filtered_entries<'a>(manifest: &'a Manifest, opts: &ListOptions) -> Vec<&'a Entry> {
+    manifest
+        .entries
+        .iter()
+        .filter(|entry| include_entity(entry.entity_type, opts))
+        .collect()
+}
+
+fn source_location_and_ref(source: &SourceFields) -> (String, Option<&str>) {
+    match source {
+        SourceFields::Github {
+            owner_repo,
+            path_in_repo,
+            ref_,
+        }
+        | SourceFields::Gitlab {
+            owner_repo,
+            path_in_repo,
+            ref_,
+        } => (format!("{owner_repo}:{path_in_repo}"), Some(ref_.as_str())),
+        SourceFields::Local { path } => (path.clone(), None),
+        SourceFields::Url { url } => (url.clone(), None),
+    }
+}
+
+fn source_location(source: &SourceFields) -> String {
+    source_location_and_ref(source).0
+}
+
+fn print_group(title: &str, entries: &[&Entry]) {
+    println!("{title} ({}):", entries.len());
+    for entry in entries {
+        let location = source_location(&entry.source);
+        let ref_text = source_location_and_ref(&entry.source)
+            .1
+            .map_or(String::new(), |ref_| format!("  {ref_}"));
+        println!(
+            "  {:<16} {:<7} {}{}",
+            entry.name,
+            entry.source_type(),
+            location,
+            ref_text
+        );
+    }
+}
+
+fn print_human(manifest: &Manifest, entries: &[&Entry], opts: &ListOptions) {
+    if entries.is_empty() {
+        println!("No entries in {MANIFEST_NAME}.");
+    } else {
+        let skills: Vec<&Entry> = entries
+            .iter()
+            .copied()
+            .filter(|entry| entry.entity_type == EntityType::Skill)
+            .collect();
+        let agents: Vec<&Entry> = entries
+            .iter()
+            .copied()
+            .filter(|entry| entry.entity_type == EntityType::Agent)
+            .collect();
+
+        if !skills.is_empty() || opts.skills {
+            print_group("Skills", &skills);
+        }
+        if !skills.is_empty() && !agents.is_empty() {
+            println!();
+        }
+        if !agents.is_empty() || opts.agents {
+            print_group("Agents", &agents);
+        }
+    }
+
+    if !manifest.install_targets.is_empty() {
+        let targets: Vec<String> = manifest
+            .install_targets
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        println!("\nInstall targets: {}", targets.join(", "));
+    }
+}
+
+fn print_names_only(entries: &[&Entry]) {
+    for entry in entries {
+        println!("{}", entry.name);
+    }
+}
+
+fn print_json(manifest: &Manifest, entries: &[&Entry]) -> Result<(), SkillfileError> {
+    let entries = entries
+        .iter()
+        .map(|entry| {
+            let (location, ref_) = source_location_and_ref(&entry.source);
+            ListEntry {
+                name: &entry.name,
+                entity_type: entry.entity_type.as_str(),
+                source_type: entry.source_type(),
+                location,
+                ref_,
+            }
+        })
+        .collect();
+    let install_targets = manifest
+        .install_targets
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    let output = ListOutput {
+        entries,
+        install_targets,
+    };
+    let json = serde_json::to_string_pretty(&output)
+        .map_err(|e| SkillfileError::Manifest(format!("failed to serialize list output: {e}")))?;
+    println!("{json}");
+    Ok(())
+}
+
+pub fn cmd_list(repo_root: &Path, opts: &ListOptions) -> Result<(), SkillfileError> {
+    let manifest_path = repo_root.join(MANIFEST_NAME);
+    if !manifest_path.exists() {
+        return Err(SkillfileError::Manifest(format!(
+            "{MANIFEST_NAME} not found in {}. Create one and run `skillfile init`.",
+            repo_root.display()
+        )));
+    }
+
+    let manifest = crate::config::parse_and_resolve(&manifest_path)?;
+    let entries = filtered_entries(&manifest, opts);
+
+    if opts.json {
+        print_json(&manifest, &entries)
+    } else if opts.names_only {
+        print_names_only(&entries);
+        Ok(())
+    } else {
+        print_human(&manifest, &entries, opts);
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod format;
 pub mod info;
 pub mod init;
 mod installed_variants;
+pub mod list;
 mod multi_target;
 pub mod pin;
 pub mod remove;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -283,8 +283,34 @@ Examples:
         check_upstream: bool,
     },
 
-    /// Show detailed information about a single entry
+    /// List declared skills and agents
     #[command(display_order = 24)]
+    #[command(long_about = "\
+List entries declared in the Skillfile without reading lock/cache state or
+making network calls. Shows name, source type, source location, ref, and
+configured install targets.
+
+Examples:
+  skillfile list
+  skillfile list --names-only --skills
+  skillfile list --json")]
+    List {
+        /// Output machine-readable JSON
+        #[arg(long)]
+        json: bool,
+        /// Print only entry names
+        #[arg(long)]
+        names_only: bool,
+        /// Show only skills
+        #[arg(long)]
+        skills: bool,
+        /// Show only agents
+        #[arg(long)]
+        agents: bool,
+    },
+
+    /// Show detailed information about a single entry
+    #[command(display_order = 25)]
     #[command(long_about = "\
 Display all known information about a single entry: source, lock state,
 pin state, modified state, installed paths across all targets, and cache path.
@@ -672,6 +698,20 @@ fn run_content_commands(repo_root: &Path, cmd: Command) -> Result<(), SkillfileE
     match cmd {
         Command::Completions { shell } => write_completion_registration(shell),
         Command::Validate => commands::validate::cmd_validate(repo_root),
+        Command::List {
+            json,
+            names_only,
+            skills,
+            agents,
+        } => commands::list::cmd_list(
+            repo_root,
+            &commands::list::ListOptions {
+                json,
+                names_only,
+                skills,
+                agents,
+            },
+        ),
         Command::Info { name } => commands::info::cmd_info(&name, repo_root),
         Command::Format { dry_run } => commands::format::cmd_format(repo_root, dry_run),
         Command::Pin { name, dry_run } => commands::pin::cmd_pin(&name, repo_root, dry_run),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -195,23 +195,31 @@ fn list_groups_entries_by_entity_type() {
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
 
     assert!(output.status.success(), "list should succeed: {stderr}");
+    assert_grouped_list_output(&stdout);
+}
+
+fn assert_grouped_list_output(stdout: &str) {
     assert!(
         stdout.contains("Skills (2):"),
         "missing skills group:\n{stdout}"
     );
-    assert!(stdout.contains("browser"));
-    assert!(stdout.contains("github"));
-    assert!(stdout.contains("anthropics/skills:skills/browser/SKILL.md"));
-    assert!(stdout.contains("commit"));
-    assert!(stdout.contains("local"));
-    assert!(stdout.contains("skills/commit.md"));
+    for expected in [
+        "browser",
+        "github",
+        "anthropics/skills:skills/browser/SKILL.md",
+        "commit",
+        "local",
+        "skills/commit.md",
+        "reviewer",
+        "v1",
+        "Install targets: claude-code (local)",
+    ] {
+        assert!(stdout.contains(expected), "missing {expected:?}:\n{stdout}");
+    }
     assert!(
         stdout.contains("Agents (1):"),
         "missing agents group:\n{stdout}"
     );
-    assert!(stdout.contains("reviewer"));
-    assert!(stdout.contains("v1"));
-    assert!(stdout.contains("Install targets: claude-code (local)"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -179,6 +179,89 @@ fn validate_golden_path() {
 }
 
 #[test]
+fn list_groups_entries_by_entity_type() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         github  skill  browser  anthropics/skills  skills/browser/SKILL.md  main\n\
+         local  skill  commit  skills/commit.md\n\
+         github  agent  reviewer  anthropics/skills  agents/reviewer.md  v1\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path()).arg("list").output().unwrap();
+    let stdout = normalize_separators(std::str::from_utf8(&output.stdout).unwrap());
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+    assert!(output.status.success(), "list should succeed: {stderr}");
+    assert!(
+        stdout.contains("Skills (2):"),
+        "missing skills group:\n{stdout}"
+    );
+    assert!(stdout.contains("browser"));
+    assert!(stdout.contains("github"));
+    assert!(stdout.contains("anthropics/skills:skills/browser/SKILL.md"));
+    assert!(stdout.contains("commit"));
+    assert!(stdout.contains("local"));
+    assert!(stdout.contains("skills/commit.md"));
+    assert!(
+        stdout.contains("Agents (1):"),
+        "missing agents group:\n{stdout}"
+    );
+    assert!(stdout.contains("reviewer"));
+    assert!(stdout.contains("v1"));
+    assert!(stdout.contains("Install targets: claude-code (local)"));
+}
+
+#[test]
+fn list_names_only_filters_skills() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "local  skill  browser  skills/browser.md\n\
+         local  agent  reviewer  agents/reviewer.md\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path())
+        .args(["list", "--names-only", "--skills"])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+    assert!(output.status.success(), "list should succeed: {stderr}");
+    assert_eq!(stdout, "browser\n");
+}
+
+#[test]
+fn list_json_outputs_entries_and_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  codex  global\n\
+         url  skill  rust-dev  https://example.com/rust.md\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path()).args(["list", "--json"]).output().unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+    assert!(output.status.success(), "list should succeed: {stderr}");
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["entries"][0]["name"], "rust-dev");
+    assert_eq!(json["entries"][0]["entity_type"], "skill");
+    assert_eq!(json["entries"][0]["source_type"], "url");
+    assert_eq!(
+        json["entries"][0]["location"],
+        "https://example.com/rust.md"
+    );
+    assert_eq!(json["install_targets"][0], "codex (global)");
+}
+
+#[test]
 fn validate_junie_platform() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(


### PR DESCRIPTION
Closes #64.

Adds `skillfile list` as a read-only manifest view for declared skills and agents. It does not read lock/cache state or make network calls; it just parses the resolved Skillfile and prints what is declared.

What changed:

- Adds grouped human output for skills and agents.
- Prints source type, source location, optional ref, and install targets.
- Adds `--names-only` for piping.
- Adds `--skills` / `--agents` filters.
- Adds `--json` output for scripting.
- Covers the command with CLI functional tests.

Verification:

```bash
cargo fmt
cargo build -p skillfile
cargo test list_ --test cli -- --nocapture
cargo test -p skillfile
cargo test -p skillfile-functional-tests --test cli
cargo clippy -p skillfile -- -D warnings
```
