### PR TITLE
Fix partial sync and incomplete installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to skillfile are documented here.
 
 ---
 
+## v1.7.2 - 08-07-2026
+
+### Fixed
+
+- **`skillfile install` now keeps deploying healthy entries even when another upstream entry fails** - sync preserves successful SHA resolutions, cache fetches, and lock updates, then installs the valid cached entries before returning the upstream error instead of stopping the whole run early.
+- **Incomplete directory caches are no longer treated as valid installs** - staged cache replacement now publishes remote directory updates only after content and metadata are complete, which prevents metadata-only or partially written caches from being deployed as if they were healthy.
+- **Missing upstream directories now fail explicitly instead of looking like empty content** - GitHub and GitLab directory fetches now surface invalid or missing manifest paths as errors, rather than accepting an empty result and exiting successfully.
+- **Existing installed skill directories now pick up newly added upstream files without overwriting local edits** - nested installs fill in missing files such as helper scripts while leaving already edited files in place.
+- **Directory deployment is hardened against symlink traversal** - source and destination symlinks are now rejected across fresh installs, overwrite installs, and merge-style installs.
+
+### Changed
+
+- **Dependency refresh** - bumped `console` to 0.16.4, `similar` to 3.1.1, `insta` to 1.48.0, and `serial_test` to 3.5.0.
+
 ## v1.7.1 - 02-06-2026
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-core"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-deploy"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "dirs",
  "serde_json",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-sources"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "html-escape",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
@@ -15,9 +15,9 @@ categories = ["command-line-utilities", "development-tools"]
 
 [workspace.dependencies]
 # Internal crates
-skillfile-core = { path = "crates/core", version = "1.7.1" }
-skillfile-sources = { path = "crates/sources", version = "1.7.1" }
-skillfile-deploy = { path = "crates/deploy", version = "1.7.1" }
+skillfile-core = { path = "crates/core", version = "1.7.2" }
+skillfile-sources = { path = "crates/sources", version = "1.7.2" }
+skillfile-deploy = { path = "crates/deploy", version = "1.7.2" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/deploy/src/adapter.rs
+++ b/crates/deploy/src/adapter.rs
@@ -835,6 +835,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     fn nested_skill_entry() -> Entry {
         Entry {
             entity_type: EntityType::Skill,
@@ -847,6 +848,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     fn deploy_dir(source: &Path, root: &Path, overwrite: bool) -> DeployResult {
         adapters()
             .get("claude-code")
@@ -863,6 +865,7 @@ mod tests {
             })
     }
 
+    #[cfg(unix)]
     fn create_dir_when(path: &Path, create: bool) {
         if create {
             std::fs::create_dir_all(path).unwrap();

--- a/crates/deploy/src/adapter.rs
+++ b/crates/deploy/src/adapter.rs
@@ -193,6 +193,12 @@ impl PlatformAdapter for FileSystemAdapter {
             self.single_file_install_path(req.entry, &target_dir)
         };
 
+        let dest_is_real_dir = std::fs::symlink_metadata(&dest)
+            .is_ok_and(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink());
+        if is_dir && dest_is_real_dir && !req.opts.overwrite && !req.opts.dry_run {
+            return copy_missing_dir(req.source, &dest, req.source).unwrap_or_default();
+        }
+
         if !place_file(
             &PlaceOp {
                 source: req.source,
@@ -442,11 +448,100 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
         let entry = entry?;
         let ty = entry.file_type()?;
         let dest_path = dst.join(entry.file_name());
-        if ty.is_dir() {
+        if ty.is_symlink() {
+            return Err(symlink_error(&entry.path()));
+        } else if ty.is_dir() {
             copy_dir_recursive(&entry.path(), &dest_path)?;
-        } else {
+        } else if ty.is_file() {
             std::fs::copy(entry.path(), &dest_path)?;
+        } else {
+            return Err(symlink_error(&entry.path()));
         }
+    }
+    Ok(())
+}
+
+fn copy_missing_dir(
+    source_dir: &Path,
+    target_dir: &Path,
+    source_root: &Path,
+) -> std::io::Result<DeployResult> {
+    require_real_dir(source_dir)?;
+    ensure_real_dir(target_dir)?;
+    let mut installed = HashMap::new();
+    for entry in std::fs::read_dir(source_dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            return Err(symlink_error(&entry.path()));
+        }
+        let source_path = entry.path();
+        let target_path = target_dir.join(entry.file_name());
+        if file_type.is_dir() {
+            installed.extend(copy_missing_dir(&source_path, &target_path, source_root)?);
+            continue;
+        }
+        match std::fs::symlink_metadata(&target_path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(symlink_error(&target_path));
+            }
+            Ok(_) => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        copy_file_create_new(&source_path, &target_path)?;
+        progress!(
+            "  {} -> {}",
+            entry.file_name().to_string_lossy(),
+            target_path.display()
+        );
+        if entry.file_name() == ".meta" {
+            continue;
+        }
+        if let Ok(relative) = source_path.strip_prefix(source_root) {
+            installed.insert(forward_slash(relative), target_path);
+        }
+    }
+    Ok(installed)
+}
+
+fn require_real_dir(path: &Path) -> std::io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    Err(symlink_error(path))
+}
+
+fn ensure_real_dir(path: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => Ok(()),
+        Ok(_) => Err(symlink_error(path)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => std::fs::create_dir(path),
+        Err(error) => Err(error),
+    }
+}
+
+fn symlink_error(path: &Path) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "refusing to traverse symlink or non-directory: {}",
+            path.display()
+        ),
+    )
+}
+
+fn copy_file_create_new(source: &Path, target: &Path) -> std::io::Result<()> {
+    let mut source_file = std::fs::File::open(source)?;
+    let mut target_file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(target)?;
+    if let Err(error) = std::io::copy(&mut source_file, &mut target_file) {
+        drop(target_file);
+        let _ = std::fs::remove_file(target);
+        return Err(error);
     }
     Ok(())
 }
@@ -737,6 +832,40 @@ mod tests {
         AdapterScope {
             scope: Scope::Global,
             repo_root: root,
+        }
+    }
+
+    fn nested_skill_entry() -> Entry {
+        Entry {
+            entity_type: EntityType::Skill,
+            name: "my-skill".into(),
+            source: skillfile_core::models::SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: "skills/my-skill".into(),
+                ref_: "main".into(),
+            },
+        }
+    }
+
+    fn deploy_dir(source: &Path, root: &Path, overwrite: bool) -> DeployResult {
+        adapters()
+            .get("claude-code")
+            .unwrap()
+            .deploy_entry(&DeployRequest {
+                entry: &nested_skill_entry(),
+                source,
+                scope: Scope::Local,
+                repo_root: root,
+                opts: &InstallOptions {
+                    dry_run: false,
+                    overwrite,
+                },
+            })
+    }
+
+    fn create_dir_when(path: &Path, create: bool) {
+        if create {
+            std::fs::create_dir_all(path).unwrap();
         }
     }
 
@@ -1292,7 +1421,7 @@ mod tests {
     // -- place_file skip logic --
 
     #[test]
-    fn place_file_skips_existing_dir_when_no_overwrite() {
+    fn deploy_entry_adds_missing_file_to_existing_dir_without_overwrite() {
         use skillfile_core::models::{EntityType, SourceFields};
 
         let dir = tempfile::tempdir().unwrap();
@@ -1325,10 +1454,97 @@ mod tests {
                 overwrite: false,
             },
         });
-        // Should skip — dir already exists
-        assert!(result.is_empty());
-        // Old file still there
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key("SKILL.md"));
+        assert_eq!(
+            std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+            "# Skill"
+        );
         assert!(dest.join("OLD.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deploy_entry_does_not_follow_symlinked_destination_root() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join(".skillfile/cache/skills/my-skill");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("SKILL.md"), "# Skill").unwrap();
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let dest = dir.path().join(".claude/skills/my-skill");
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        symlink(&outside, &dest).unwrap();
+
+        let result = deploy_dir(&source, dir.path(), false);
+
+        assert!(result.is_empty());
+        assert!(!outside.join("SKILL.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deploy_entry_does_not_follow_symlinked_destination_component() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join(".skillfile/cache/skills/my-skill");
+        std::fs::create_dir_all(source.join("scripts")).unwrap();
+        std::fs::write(source.join("scripts/tool.py"), "pass\n").unwrap();
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let dest = dir.path().join(".claude/skills/my-skill");
+        std::fs::create_dir_all(&dest).unwrap();
+        symlink(&outside, dest.join("scripts")).unwrap();
+
+        let result = deploy_dir(&source, dir.path(), false);
+
+        assert!(result.is_empty());
+        assert!(!outside.join("tool.py").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deploy_entry_does_not_follow_source_symlink_on_fresh_or_overwrite_install() {
+        use std::os::unix::fs::symlink;
+
+        for overwrite in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let source = dir.path().join(".skillfile/cache/skills/my-skill");
+            std::fs::create_dir_all(&source).unwrap();
+            let outside = dir.path().join("outside.md");
+            std::fs::write(&outside, "# Outside\n").unwrap();
+            symlink(&outside, source.join("SKILL.md")).unwrap();
+            let dest = dir.path().join(".claude/skills/my-skill");
+            create_dir_when(&dest, overwrite);
+
+            let result = deploy_dir(&source, dir.path(), overwrite);
+
+            assert!(result.is_empty());
+            assert!(!dest.join("SKILL.md").exists());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deploy_entry_does_not_follow_dangling_destination_file_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join(".skillfile/cache/skills/my-skill");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("SKILL.md"), "# Skill\n").unwrap();
+        let outside = dir.path().join("outside.md");
+        let dest = dir.path().join(".claude/skills/my-skill");
+        std::fs::create_dir_all(&dest).unwrap();
+        symlink(&outside, dest.join("SKILL.md")).unwrap();
+
+        let result = deploy_dir(&source, dir.path(), false);
+
+        assert!(result.is_empty());
+        assert!(!outside.exists());
     }
 
     #[test]

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -1275,12 +1275,12 @@ pub fn cmd_install(repo_root: &Path, opts: &CmdInstallOpts<'_>) -> Result<(), Sk
     }
 
     // Fetch any missing or stale entries.
-    cmd_sync(&skillfile_sources::sync::SyncCmdOpts {
+    let sync_result = cmd_sync(&skillfile_sources::sync::SyncCmdOpts {
         repo_root,
         dry_run: opts.dry_run,
         entry_filter: None,
         update: opts.update,
-    })?;
+    });
 
     // Read new locked state (written by sync).
     let locked = read_lock(repo_root).unwrap_or_default();
@@ -1299,6 +1299,7 @@ pub fn cmd_install(repo_root: &Path, opts: &CmdInstallOpts<'_>) -> Result<(), Sk
         },
     };
     deploy_all(&manifest, &deploy_ctx)?;
+    sync_result?;
 
     if !opts.dry_run {
         progress!("Done.");
@@ -1569,6 +1570,7 @@ mod tests {
         std::fs::create_dir_all(&vdir).unwrap();
         std::fs::write(vdir.join("SKILL.md"), "# Python Pro").unwrap();
         std::fs::write(vdir.join("examples.md"), "# Examples").unwrap();
+        std::fs::write(vdir.join(".meta"), r#"{"sha":"cached"}"#).unwrap();
 
         let entry = Entry {
             entity_type: EntityType::Skill,
@@ -1605,7 +1607,7 @@ mod tests {
         std::fs::create_dir_all(&vdir).unwrap();
         std::fs::write(vdir.join("backend-developer.md"), "# Backend").unwrap();
         std::fs::write(vdir.join("frontend-developer.md"), "# Frontend").unwrap();
-        std::fs::write(vdir.join(".meta"), "{}").unwrap();
+        std::fs::write(vdir.join(".meta"), r#"{"sha":"cached"}"#).unwrap();
 
         let entry = Entry {
             entity_type: EntityType::Agent,
@@ -2766,6 +2768,7 @@ mod tests {
         let vdir = dir.path().join(format!(".skillfile/cache/skills/{name}"));
         std::fs::create_dir_all(&vdir).unwrap();
         std::fs::write(vdir.join("SKILL.md"), "# Lang Pro\n\nOriginal.\n").unwrap();
+        std::fs::write(vdir.join(".meta"), r#"{"sha":"cached"}"#).unwrap();
         std::fs::write(vdir.join("examples.md"), "# Examples\n\nOriginal.\n").unwrap();
 
         // Installed dir (nested mode for skills).
@@ -2819,6 +2822,7 @@ mod tests {
         let vdir = dir.path().join(format!(".skillfile/cache/skills/{name}"));
         std::fs::create_dir_all(&vdir).unwrap();
         std::fs::write(vdir.join("SKILL.md"), "# Lang Pro\n\nOriginal.\n").unwrap();
+        std::fs::write(vdir.join(".meta"), r#"{"sha":"cached"}"#).unwrap();
 
         let first_inst_dir = dir.path().join(format!(".claude/skills/{name}"));
         std::fs::create_dir_all(&first_inst_dir).unwrap();

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 
 use skillfile_core::error::SkillfileError;
 use skillfile_core::models::{EntityType, Entry, Manifest, SourceFields};
-use skillfile_sources::strategy::{content_file, is_cached_dir_entry};
+use skillfile_core::patch::walkdir;
+use skillfile_sources::strategy::{content_file, is_cached_dir_entry, meta_sha};
 use skillfile_sources::sync::vendor_dir_for;
 
 use crate::adapter::{adapters, AdapterScope, PlatformAdapter};
@@ -102,10 +103,30 @@ pub fn source_path(entry: &Entry, repo_root: &Path) -> Option<PathBuf> {
 fn source_path_remote(entry: &Entry, repo_root: &Path) -> Option<PathBuf> {
     let vdir = vendor_dir_for(entry, repo_root);
     if is_cached_dir_entry(entry, &vdir) {
-        vdir.exists().then_some(vdir)
+        remote_dir_cache_is_complete(entry, &vdir).then_some(vdir)
     } else {
         let filename = content_file(entry);
         (!filename.is_empty()).then(|| vdir.join(filename))
+    }
+}
+
+fn remote_dir_cache_is_complete(entry: &Entry, vdir: &Path) -> bool {
+    if meta_sha(vdir).is_none() {
+        return false;
+    }
+    match entry.entity_type {
+        EntityType::Skill => std::fs::read_dir(vdir).is_ok_and(|entries| {
+            entries.filter_map(Result::ok).any(|entry| {
+                entry.file_type().is_ok_and(|kind| kind.is_file())
+                    && entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|name| name.eq_ignore_ascii_case("SKILL.md"))
+            })
+        }),
+        EntityType::Agent => walkdir(vdir)
+            .into_iter()
+            .any(|path| path.extension().is_some_and(|extension| extension == "md")),
     }
 }
 
@@ -403,6 +424,58 @@ mod tests {
 
         let result = source_path(&entry, tmp.path());
         assert_eq!(result, Some(vdir.join("test.md")));
+    }
+
+    #[test]
+    fn source_path_remote_dir_requires_cached_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "test".into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: "skills/test".into(),
+                ref_: "main".into(),
+            },
+        };
+        let vdir = tmp.path().join(".skillfile/cache/skills/test");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::create_dir_all(vdir.join("scripts")).unwrap();
+        std::fs::write(vdir.join("scripts/helper.py"), "pass\n").unwrap();
+
+        assert_eq!(source_path(&entry, tmp.path()), None);
+
+        std::fs::write(vdir.join(".meta"), r#"{"sha":"abc123"}"#).unwrap();
+        assert_eq!(source_path(&entry, tmp.path()), None);
+
+        std::fs::write(vdir.join("skill.md"), "# Test\n").unwrap();
+        assert_eq!(source_path(&entry, tmp.path()), Some(vdir));
+    }
+
+    #[test]
+    fn source_path_remote_agent_dir_requires_metadata_and_markdown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = Entry {
+            entity_type: EntityType::Agent,
+            name: "agents".into(),
+            source: SourceFields::Github {
+                owner_repo: "o/r".into(),
+                path_in_repo: "agents".into(),
+                ref_: "main".into(),
+            },
+        };
+        let vdir = tmp.path().join(".skillfile/cache/agents/agents");
+        std::fs::create_dir_all(vdir.join("nested")).unwrap();
+        std::fs::write(vdir.join("nested/helper.py"), "pass\n").unwrap();
+
+        assert_eq!(source_path(&entry, tmp.path()), None);
+
+        std::fs::write(vdir.join(".meta"), r#"{"sha":"abc123"}"#).unwrap();
+        assert_eq!(source_path(&entry, tmp.path()), None);
+
+        std::fs::write(vdir.join("nested/agent.md"), "# Agent\n").unwrap();
+
+        assert_eq!(source_path(&entry, tmp.path()), Some(vdir));
     }
 
     #[test]

--- a/crates/deploy/tests/install_deploy_all.rs
+++ b/crates/deploy/tests/install_deploy_all.rs
@@ -250,3 +250,74 @@ fn install_unknown_platform_skips_gracefully() {
         "no conflict file must be written for unknown adapter"
     );
 }
+
+#[test]
+fn install_update_deploys_valid_cache_and_preserves_install_for_empty_cache() {
+    let dirs = Dirs::new();
+    let root = dirs.path();
+    std::fs::write(
+        root.join("Skillfile"),
+        "github skill my-skill owner/repo skills/my-skill\n\
+         github skill good-skill owner/repo skills/good-skill\n\
+         install claude-code local\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root.join(".skillfile/cache/skills/my-skill")).unwrap();
+    let good_cache = root.join(".skillfile/cache/skills/good-skill");
+    std::fs::create_dir_all(&good_cache).unwrap();
+    std::fs::write(good_cache.join("SKILL.md"), "# Deploy cached skill\n").unwrap();
+    std::fs::write(good_cache.join(".meta"), r#"{"sha":"cached"}"#).unwrap();
+    let installed = root.join(".claude/skills/my-skill/SKILL.md");
+    std::fs::create_dir_all(installed.parent().unwrap()).unwrap();
+    std::fs::write(&installed, "# Keep existing install\n").unwrap();
+    std::fs::write(root.join("Skillfile.lock"), "not valid json").unwrap();
+
+    let error = cmd_install(
+        root,
+        &CmdInstallOpts {
+            dry_run: false,
+            update: true,
+            extra_targets: None,
+        },
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("lock"));
+    assert_eq!(
+        std::fs::read_to_string(installed).unwrap(),
+        "# Keep existing install\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(root.join(".claude/skills/good-skill/SKILL.md")).unwrap(),
+        "# Deploy cached skill\n"
+    );
+}
+
+#[test]
+fn install_adds_missing_nested_files_without_overwriting_existing_files() {
+    let dirs = Dirs::new();
+    let root = dirs.path();
+    std::fs::write(
+        root.join("Skillfile"),
+        "local skill my-skill skills/my-skill\ninstall claude-code local\n",
+    )
+    .unwrap();
+    let source = root.join("skills/my-skill");
+    std::fs::create_dir_all(source.join("scripts")).unwrap();
+    std::fs::write(source.join("SKILL.md"), "# Upstream\n").unwrap();
+    std::fs::write(source.join("scripts/new.py"), "print('new')\n").unwrap();
+    let installed = root.join(".claude/skills/my-skill");
+    std::fs::create_dir_all(&installed).unwrap();
+    std::fs::write(installed.join("SKILL.md"), "# Local edit\n").unwrap();
+
+    cmd_install(root, &default_opts()).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(installed.join("SKILL.md")).unwrap(),
+        "# Local edit\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(installed.join("scripts/new.py")).unwrap(),
+        "print('new')\n"
+    );
+}

--- a/crates/sources/src/resolver.rs
+++ b/crates/sources/src/resolver.rs
@@ -833,9 +833,12 @@ fn list_dir_via_contents(
         "https://api.github.com/repos/{}/contents/{}?ref={}",
         gh.owner_repo, encoded, gh.ref_
     );
-    let Some(text) = gh.client.get_json(&url)? else {
-        return Ok(Vec::new());
-    };
+    let text = gh.client.get_json(&url)?.ok_or_else(|| {
+        SkillfileError::Network(format!(
+            "failed to list directory {}/{base_path}: 4xx error",
+            gh.owner_repo
+        ))
+    })?;
     let items: Vec<serde_json::Value> = serde_json::from_str(&text)
         .map_err(|e| SkillfileError::Network(format!("invalid contents JSON: {e}")))?;
 
@@ -1546,7 +1549,7 @@ mod tests {
     }
 
     #[test]
-    fn list_github_dir_recursive_empty_tree_and_empty_contents() {
+    fn list_github_dir_recursive_missing_contents_path_errors() {
         let owner_repo = "org/repo";
         let ref_ = "main";
 
@@ -1562,8 +1565,8 @@ mod tests {
             owner_repo,
             ref_,
         };
-        let entries = list_github_dir_recursive(&gh, "agents/dir").unwrap();
-        assert!(entries.is_empty());
+        let error = list_github_dir_recursive(&gh, "agents/dir").unwrap_err();
+        assert!(error.to_string().contains("failed to list directory"));
     }
 
     #[test]

--- a/crates/sources/src/sync.rs
+++ b/crates/sources/src/sync.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use skillfile_core::error::SkillfileError;
 use skillfile_core::lock::{lock_key, read_lock, write_lock};
@@ -16,6 +17,76 @@ use crate::resolver::{
 use crate::strategy::{content_file, is_cached_dir_entry, is_dir_entry, meta_sha};
 
 pub const VENDOR_DIR: &str = ".skillfile/cache";
+static CACHE_TX_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn cache_transaction_path(vdir: &Path, role: &str) -> PathBuf {
+    let sequence = CACHE_TX_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let name = vdir.file_name().unwrap_or_default().to_string_lossy();
+    vdir.parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!(".{name}.{role}-{}-{sequence}", std::process::id()))
+}
+
+fn remove_cache_path(path: &Path) -> std::io::Result<()> {
+    if path.is_dir() && !path.is_symlink() {
+        std::fs::remove_dir_all(path)
+    } else if path.exists() || path.is_symlink() {
+        std::fs::remove_file(path)
+    } else {
+        Ok(())
+    }
+}
+
+fn restore_cache_after_publish_failure(
+    backup: &Path,
+    vdir: &Path,
+    publish_error: &std::io::Error,
+) -> Result<(), SkillfileError> {
+    std::fs::rename(backup, vdir).map_err(|rollback_error| {
+        SkillfileError::Install(format!(
+            "failed to publish cache: {publish_error}; rollback failed: {rollback_error}"
+        ))
+    })
+}
+
+fn publish_staged_cache(staging: &Path, vdir: &Path) -> Result<(), SkillfileError> {
+    let backup = cache_transaction_path(vdir, "backup");
+    let had_cache = vdir.exists() || vdir.is_symlink();
+    if had_cache {
+        std::fs::rename(vdir, &backup)?;
+    }
+    if let Err(publish_error) = std::fs::rename(staging, vdir) {
+        if had_cache {
+            restore_cache_after_publish_failure(&backup, vdir, &publish_error)?;
+        }
+        return Err(publish_error.into());
+    }
+    if had_cache {
+        remove_cache_path(&backup)?;
+    }
+    Ok(())
+}
+
+fn replace_cache_transactionally<T>(
+    vdir: &Path,
+    write: impl FnOnce(&Path) -> Result<T, SkillfileError>,
+) -> Result<T, SkillfileError> {
+    let staging = cache_transaction_path(vdir, "staging");
+    std::fs::create_dir_all(vdir.parent().unwrap_or_else(|| Path::new(".")))?;
+    std::fs::create_dir(&staging)?;
+    let value = match write(&staging) {
+        Ok(value) => value,
+        Err(error) => {
+            let _ = remove_cache_path(&staging);
+            return Err(error);
+        }
+    };
+    if let Err(error) = publish_staged_cache(&staging, vdir) {
+        let _ = remove_cache_path(&staging);
+        return Err(error);
+    }
+    Ok(value)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum ForgeType {
@@ -179,6 +250,7 @@ struct FetchOp<'a> {
     client: &'a dyn HttpClient,
     gh: &'a GithubRef<'a>,
     vdir: &'a Path,
+    display_vdir: &'a Path,
     label: &'a str,
 }
 
@@ -247,6 +319,7 @@ fn write_github_dir(op: &FetchOp<'_>) -> Result<String, SkillfileError> {
             sha,
         },
         vdir: _,
+        display_vdir: _,
         label: _,
     } = op;
     let ghf = GithubFetch {
@@ -270,14 +343,20 @@ fn write_github_dir_entries(
             sha,
         },
         vdir,
+        display_vdir,
         label,
     } = op;
+    if dir_entries.is_empty() {
+        return Err(SkillfileError::Install(format!(
+            "directory {owner_repo}/{path_in_repo} contains no files"
+        )));
+    }
     let fetched = fetch_files_parallel(*client, dir_entries)?;
     write_fetched_dir(vdir, &fetched)?;
     progress!(
         "{label}: sha={} -> {}/ ({} files)",
         short_sha(sha),
-        vdir.display(),
+        display_vdir.display(),
         fetched.len()
     );
     Ok(github_dir_raw_url(owner_repo, path_in_repo, sha))
@@ -314,6 +393,7 @@ fn write_github_file(op: &FetchOp<'_>) -> Result<String, SkillfileError> {
             sha,
         },
         vdir,
+        display_vdir,
         label,
     } = op;
     let ghf = GithubFetch {
@@ -333,7 +413,11 @@ fn write_github_file(op: &FetchOp<'_>) -> Result<String, SkillfileError> {
         .unwrap_or("content.md");
     let dest = vdir.join(filename);
     std::fs::write(&dest, &content)?;
-    progress!("{label}: sha={} -> {}", short_sha(sha), dest.display());
+    progress!(
+        "{label}: sha={} -> {}",
+        short_sha(sha),
+        display_vdir.join(filename).display()
+    );
     Ok(format!(
         "https://raw.githubusercontent.com/{owner_repo}/{sha}/{effective_path}"
     ))
@@ -492,22 +576,25 @@ fn fetch_store_github(op: &StoreOp<'_>) -> Result<String, SkillfileError> {
         path_in_repo,
         sha,
     };
-    let fetch_op = FetchOp {
-        client: *client,
-        gh: &gh,
-        vdir,
-        label,
-    };
-    let raw_url = fetch_and_write_github(&fetch_op, is_dir_entry(entry))?;
-    write_github_meta(&GithubMeta {
-        vdir,
-        owner_repo,
-        path_in_repo,
-        ref_,
-        sha,
-        raw_url: &raw_url,
-    })?;
-    Ok(raw_url)
+    replace_cache_transactionally(vdir, |staging| {
+        let fetch_op = FetchOp {
+            client: *client,
+            gh: &gh,
+            vdir: staging,
+            display_vdir: vdir,
+            label,
+        };
+        let raw_url = fetch_and_write_github(&fetch_op, is_dir_entry(entry))?;
+        write_github_meta(&GithubMeta {
+            vdir: staging,
+            owner_repo,
+            path_in_repo,
+            ref_,
+            sha,
+            raw_url: &raw_url,
+        })?;
+        Ok(raw_url)
+    })
 }
 
 /// `sha_cache` maps a forge-qualified remote ref to its resolved SHA.
@@ -591,6 +678,7 @@ struct GitlabFetchOp<'a> {
     client: &'a dyn HttpClient,
     gl: &'a GitlabRef<'a>,
     vdir: &'a Path,
+    display_vdir: &'a Path,
     label: &'a str,
 }
 
@@ -621,6 +709,7 @@ fn write_gitlab_dir(op: &GitlabFetchOp<'_>) -> Result<String, SkillfileError> {
                 host,
             },
         vdir: _,
+        display_vdir: _,
         label: _,
     } = op;
     let glf = GitlabFetch {
@@ -647,14 +736,20 @@ fn write_gitlab_dir_entries(
                 host,
             },
         vdir,
+        display_vdir,
         label,
     } = op;
+    if dir_entries.is_empty() {
+        return Err(SkillfileError::Install(format!(
+            "directory {owner_repo}/{path_in_repo} contains no files"
+        )));
+    }
     let fetched = fetch_files_parallel(*client, dir_entries)?;
     write_fetched_dir(vdir, &fetched)?;
     progress!(
         "{label}: sha={} -> {}/ ({} files)",
         short_sha(sha),
-        vdir.display(),
+        display_vdir.display(),
         fetched.len()
     );
     Ok(gitlab_dir_raw_url(&GitlabRef {
@@ -699,6 +794,7 @@ fn write_gitlab_file(op: &GitlabFetchOp<'_>) -> Result<String, SkillfileError> {
                 host,
             },
         vdir,
+        display_vdir,
         label,
     } = op;
     let glf = GitlabFetch {
@@ -719,7 +815,11 @@ fn write_gitlab_file(op: &GitlabFetchOp<'_>) -> Result<String, SkillfileError> {
         .unwrap_or("content.md");
     let dest = vdir.join(filename);
     std::fs::write(&dest, &content)?;
-    progress!("{label}: sha={} -> {}", short_sha(sha), dest.display());
+    progress!(
+        "{label}: sha={} -> {}",
+        short_sha(sha),
+        display_vdir.join(filename).display()
+    );
     let encoded_project = owner_repo.replace('/', "%2F");
     let encoded_path = effective_path.replace('/', "%2F");
     Ok(format!(
@@ -805,23 +905,26 @@ fn fetch_store_gitlab(op: &GitlabStoreOp<'_>) -> Result<String, SkillfileError> 
         sha,
         host,
     };
-    let fetch_op = GitlabFetchOp {
-        client: *client,
-        gl: &gl,
-        vdir,
-        label,
-    };
-    let raw_url = fetch_and_write_gitlab(&fetch_op, is_dir_entry(entry))?;
-    write_gitlab_meta(&GitlabMeta {
-        vdir,
-        owner_repo,
-        path_in_repo,
-        ref_,
-        sha,
-        raw_url: &raw_url,
-        host,
-    })?;
-    Ok(raw_url)
+    replace_cache_transactionally(vdir, |staging| {
+        let fetch_op = GitlabFetchOp {
+            client: *client,
+            gl: &gl,
+            vdir: staging,
+            display_vdir: vdir,
+            label,
+        };
+        let raw_url = fetch_and_write_gitlab(&fetch_op, is_dir_entry(entry))?;
+        write_gitlab_meta(&GitlabMeta {
+            vdir: staging,
+            owner_repo,
+            path_in_repo,
+            ref_,
+            sha,
+            raw_url: &raw_url,
+            host,
+        })?;
+        Ok(raw_url)
+    })
 }
 
 /// Core sync logic for a GitLab entry. Mirrors `sync_github_core`.
@@ -1064,11 +1167,11 @@ impl PendingResolve {
 fn resolve_shas_parallel(
     client: &dyn HttpClient,
     ctx: &ResolveCtx<'_>,
-) -> Result<HashMap<RemoteRefKey, String>, SkillfileError> {
+) -> HashMap<RemoteRefKey, String> {
     let keys = collect_pairs_to_resolve(ctx.entries, ctx.locked, ctx.update);
 
     if keys.is_empty() {
-        return Ok(HashMap::new());
+        return HashMap::new();
     }
 
     let pending: Vec<PendingResolve> = keys.into_iter().map(|key| PendingResolve { key }).collect();
@@ -1087,7 +1190,9 @@ fn resolve_shas_parallel(
 
     let mut cache = HashMap::with_capacity(results.len());
     for (p, result) in pending.into_iter().zip(results) {
-        let sha = result?;
+        let Ok(sha) = result else {
+            continue;
+        };
         progress!(
             "  resolved {}@{} -> {}",
             p.key.owner_repo,
@@ -1096,11 +1201,11 @@ fn resolve_shas_parallel(
         );
         cache.insert(p.key, sha);
     }
-    Ok(cache)
+    cache
 }
 
 struct SyncJob<'a> {
-    client: &'a UreqClient,
+    client: &'a dyn HttpClient,
     repo_root: &'a Path,
     entries: &'a [&'a Entry],
     dry_run: bool,
@@ -1203,6 +1308,25 @@ fn run_sequential_sync(job: SyncJob<'_>) -> Result<(), SkillfileError> {
     Ok(())
 }
 
+fn merge_sync_results(
+    results: Vec<Result<Option<(String, LockEntry)>, SkillfileError>>,
+    locked: &mut BTreeMap<String, LockEntry>,
+) -> Option<SkillfileError> {
+    let mut first_error = None;
+    for result in results {
+        match result {
+            Ok(Some((key, entry))) => {
+                locked.insert(key, entry);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                first_error.get_or_insert(error);
+            }
+        }
+    }
+    first_error
+}
+
 /// Execute sync in parallel using two-phase SHA resolution then fetch.
 fn run_parallel_sync(job: SyncJob<'_>) -> Result<(), SkillfileError> {
     let SyncJob {
@@ -1220,7 +1344,7 @@ fn run_parallel_sync(job: SyncJob<'_>) -> Result<(), SkillfileError> {
         locked: &locked,
         update,
     };
-    let sha_cache = resolve_shas_parallel(client, &resolve_ctx)?;
+    let sha_cache = resolve_shas_parallel(client, &resolve_ctx);
 
     // Phase 2: Sync all entries in parallel
     let params = SyncParams {
@@ -1242,15 +1366,15 @@ fn run_parallel_sync(job: SyncJob<'_>) -> Result<(), SkillfileError> {
                 .collect()
         });
 
-    // Merge results into locked map
-    for result in results {
-        if let Some((key, le)) = result? {
-            locked.insert(key, le);
-        }
-    }
+    let sync_error = merge_sync_results(results, &mut locked);
 
     if !dry_run {
         write_lock(repo_root, &locked)?;
+    }
+    if let Some(error) = sync_error {
+        return Err(error);
+    }
+    if !dry_run {
         progress!("Done.");
     }
 
@@ -1365,9 +1489,68 @@ mod tests {
     use crate::http::HttpClient;
 
     use super::{
-        content_exists, fetch_dir_at_sha, fetch_file_at_sha, resolve_shas_parallel, sync_entry,
-        vendor_dir_for, ForgeType, RemoteRefKey, ResolveCtx, SyncContext, VENDOR_DIR,
+        content_exists, fetch_dir_at_sha, fetch_file_at_sha, replace_cache_transactionally,
+        resolve_shas_parallel, run_parallel_sync, sync_entry, vendor_dir_for, ForgeType,
+        RemoteRefKey, ResolveCtx, SyncContext, SyncJob, VENDOR_DIR,
     };
+
+    #[test]
+    fn transactional_cache_preserves_active_cache_when_staged_write_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let vdir = dir.path().join("skills/example");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(vdir.join("SKILL.md"), "# Existing\n").unwrap();
+        std::fs::write(vdir.join(".meta"), r#"{"sha":"old"}"#).unwrap();
+
+        let result: Result<(), SkillfileError> = replace_cache_transactionally(&vdir, |staging| {
+            std::fs::write(staging.join("SKILL.md"), "# Partial replacement\n")?;
+            Err(SkillfileError::Network("injected failure".into()))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::fs::read_to_string(vdir.join("SKILL.md")).unwrap(),
+            "# Existing\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(vdir.join(".meta")).unwrap(),
+            r#"{"sha":"old"}"#
+        );
+        assert_eq!(
+            std::fs::read_dir(vdir.parent().unwrap()).unwrap().count(),
+            1
+        );
+    }
+
+    #[test]
+    fn transactional_cache_publishes_complete_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let vdir = dir.path().join("skills/example");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(vdir.join("SKILL.md"), "# Existing\n").unwrap();
+        std::fs::write(vdir.join("stale.txt"), "stale\n").unwrap();
+
+        replace_cache_transactionally(&vdir, |staging| {
+            std::fs::write(staging.join("SKILL.md"), "# Replacement\n")?;
+            std::fs::write(staging.join(".meta"), r#"{"sha":"new"}"#)?;
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(vdir.join("SKILL.md")).unwrap(),
+            "# Replacement\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(vdir.join(".meta")).unwrap(),
+            r#"{"sha":"new"}"#
+        );
+        assert!(!vdir.join("stale.txt").exists());
+        assert_eq!(
+            std::fs::read_dir(vdir.parent().unwrap()).unwrap().count(),
+            1
+        );
+    }
 
     // -----------------------------------------------------------------------
     // MockClient
@@ -1434,6 +1617,18 @@ mod tests {
             source: SourceFields::Github {
                 owner_repo: "owner/repo".into(),
                 path_in_repo: path_in_repo.into(),
+                ref_: "main".into(),
+            },
+        }
+    }
+
+    fn github_repo_entry(name: &str, owner_repo: &str) -> Entry {
+        Entry {
+            entity_type: EntityType::Skill,
+            name: name.into(),
+            source: SourceFields::Github {
+                owner_repo: owner_repo.into(),
+                path_in_repo: format!("skills/{name}.md"),
                 ref_: "main".into(),
             },
         }
@@ -1746,6 +1941,41 @@ mod tests {
         assert!(vdir.join(".meta").exists());
     }
 
+    #[test]
+    fn sync_entry_github_missing_directory_does_not_commit_empty_cache() {
+        let sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let dir = tempfile::tempdir().unwrap();
+        let entry = Entry {
+            entity_type: EntityType::Skill,
+            name: "missing".into(),
+            source: SourceFields::Github {
+                owner_repo: "owner/repo".into(),
+                path_in_repo: "skills/missing".into(),
+                ref_: "main".into(),
+            },
+        };
+        let client = MockClient::new()
+            .with_json(
+                "https://api.github.com/repos/owner/repo/commits/main",
+                Some(serde_json::json!({ "sha": sha }).to_string()),
+            )
+            .with_json(
+                format!("https://api.github.com/repos/owner/repo/git/trees/{sha}?recursive=1"),
+                Some(r#"{"tree":[]}"#.into()),
+            )
+            .with_json(
+                format!(
+                    "https://api.github.com/repos/owner/repo/contents/skills/missing?ref={sha}"
+                ),
+                None,
+            );
+
+        let error = sync_entry(&client, &entry, &mut make_sync_ctx(dir.path())).unwrap_err();
+
+        assert!(error.to_string().contains("failed to list directory"));
+        assert!(!vendor_dir_for(&entry, dir.path()).exists());
+    }
+
     // -----------------------------------------------------------------------
     // sync_entry -- github, SHA cached across entries
     // -----------------------------------------------------------------------
@@ -1876,7 +2106,7 @@ mod tests {
             update: false,
         };
 
-        let cache = resolve_shas_parallel(&client, &resolve_ctx).unwrap();
+        let cache = resolve_shas_parallel(&client, &resolve_ctx);
 
         assert_eq!(cache.len(), 2);
         assert_eq!(
@@ -1887,6 +2117,113 @@ mod tests {
             cache[&RemoteRefKey::new(ForgeType::Gitlab, "shared/repo", "main")],
             "gitlabsha"
         );
+    }
+
+    #[test]
+    fn resolve_shas_parallel_keeps_success_when_other_resolution_fails() {
+        let good = github_repo_entry("good", "good/repo");
+        let bad = github_repo_entry("bad", "bad/repo");
+        let entries = [&good, &bad];
+        let client = MockClient::new().with_json(
+            "https://api.github.com/repos/good/repo/commits/main",
+            Some(serde_json::json!({ "sha": "goodsha" }).to_string()),
+        );
+        let locked = BTreeMap::new();
+
+        let cache = resolve_shas_parallel(
+            &client,
+            &ResolveCtx {
+                entries: &entries,
+                locked: &locked,
+                update: false,
+            },
+        );
+
+        assert_eq!(cache.len(), 1);
+        assert_eq!(
+            cache[&RemoteRefKey::new(ForgeType::Github, "good/repo", "main")],
+            "goodsha"
+        );
+    }
+
+    #[test]
+    fn parallel_sync_fetches_healthy_entry_after_other_resolution_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let good = github_repo_entry("good", "good/repo");
+        let bad = github_repo_entry("bad", "bad/repo");
+        let entries = [&good, &bad];
+        let sha = "goodsha";
+        let client = MockClient::new()
+            .with_json(
+                "https://api.github.com/repos/good/repo/commits/main",
+                Some(serde_json::json!({ "sha": sha }).to_string()),
+            )
+            .with_bytes(
+                format!("https://raw.githubusercontent.com/good/repo/{sha}/skills/good.md"),
+                b"# Good".to_vec(),
+            );
+
+        let error = run_parallel_sync(SyncJob {
+            client: &client,
+            repo_root: dir.path(),
+            entries: &entries,
+            dry_run: false,
+            update: false,
+            locked: BTreeMap::new(),
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("bad/repo"));
+        assert_eq!(
+            std::fs::read_to_string(vendor_dir_for(&good, dir.path()).join("good.md")).unwrap(),
+            "# Good"
+        );
+        let lock_text = std::fs::read_to_string(dir.path().join("Skillfile.lock")).unwrap();
+        let locked: BTreeMap<String, LockEntry> = serde_json::from_str(&lock_text).unwrap();
+        assert_eq!(locked["github/skill/good"].sha, sha);
+    }
+
+    #[test]
+    fn parallel_sync_persists_healthy_entry_after_other_fetch_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let good = github_repo_entry("good", "good/repo");
+        let bad = github_repo_entry("bad", "bad/repo");
+        let entries = [&good, &bad];
+        let good_sha = "goodsha";
+        let bad_sha = "badsha";
+        let client = MockClient::new()
+            .with_json(
+                "https://api.github.com/repos/good/repo/commits/main",
+                Some(serde_json::json!({ "sha": good_sha }).to_string()),
+            )
+            .with_json(
+                "https://api.github.com/repos/bad/repo/commits/main",
+                Some(serde_json::json!({ "sha": bad_sha }).to_string()),
+            )
+            .with_bytes(
+                format!("https://raw.githubusercontent.com/good/repo/{good_sha}/skills/good.md"),
+                b"# Good".to_vec(),
+            );
+
+        let error = run_parallel_sync(SyncJob {
+            client: &client,
+            repo_root: dir.path(),
+            entries: &entries,
+            dry_run: false,
+            update: false,
+            locked: BTreeMap::new(),
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("bad/repo"));
+        assert_eq!(
+            std::fs::read_to_string(vendor_dir_for(&good, dir.path()).join("good.md")).unwrap(),
+            "# Good"
+        );
+        let lock_text = std::fs::read_to_string(dir.path().join("Skillfile.lock")).unwrap();
+        let locked: BTreeMap<String, LockEntry> = serde_json::from_str(&lock_text).unwrap();
+        assert_eq!(locked["github/skill/good"].sha, good_sha);
+        assert!(!locked.contains_key("github/skill/bad"));
     }
 
     // -----------------------------------------------------------------------
@@ -1943,6 +2280,10 @@ mod tests {
                 ref_: "master".into(),
             },
         };
+        let vdir = vendor_dir_for(&entry, dir.path());
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(vdir.join("SKILL.md"), "# Previous\n").unwrap();
+        std::fs::write(vdir.join("removed-upstream.txt"), "stale\n").unwrap();
 
         let sha_url = "https://api.github.com/repos/virgiliojr94/book-to-skill/commits/master";
         let sha_json = serde_json::json!({ "sha": sha }).to_string();
@@ -1972,9 +2313,9 @@ mod tests {
         let mut ctx = make_sync_ctx(dir.path());
         sync_entry(&client, &entry, &mut ctx).unwrap();
 
-        let vdir = vendor_dir_for(&entry, dir.path());
         assert!(vdir.join("SKILL.md").exists());
         assert!(vdir.join("scripts/extract.py").exists());
+        assert!(!vdir.join("removed-upstream.txt").exists());
         assert_eq!(
             std::fs::read_to_string(vdir.join("scripts/extract.py")).unwrap(),
             "print('extract')\n"
@@ -2416,7 +2757,7 @@ mod tests {
     }
 
     #[test]
-    fn fetch_dir_at_sha_empty_directory_returns_empty_map() {
+    fn fetch_dir_at_sha_missing_directory_errors() {
         let sha = "deadbeef1234deadbeef1234deadbeef12345678";
         let entry = skill_entry("empty-dir", "skills/empty-dir");
 
@@ -2433,8 +2774,10 @@ mod tests {
             .with_json(contents_url, None);
 
         let result = fetch_dir_at_sha(&client, &entry, sha);
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to list directory"));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
**SUMMARY**

Preserve healthy sync results when another entry fails and prevent incomplete caches or deployments from being treated as successful. Release version `1.7.2` with regression coverage for the affected flows.

**RATIONALE**

A failed upstream entry could stop healthy entries from reaching their install targets, while partial directory caches could be published and later deployed as valid content. Existing nested installations also skipped newly added files, producing misleading partial-write errors.

Missing upstream directories were incorrectly accepted as empty directories, allowing metadata-only caches and successful exit statuses. The install and sync pipeline now preserves usable work while reporting invalid upstream state reliably.

**CHANGES**

- Preserve successful SHA resolutions, fetches, and lock entries when another parallel sync operation fails.
- Deploy usable cached entries before returning the accumulated sync error.
- Stage GitHub and GitLab cache replacements and publish them only after content and metadata are complete.
- Reject missing and empty upstream directories instead of committing metadata-only caches.
- Require committed metadata and primary content before remote directory caches can be deployed.
- Add missing nested files without overwriting existing local edits.
- Reject source and destination symlinks across merge, fresh-install, and overwrite directory-copy paths.
- Add regression coverage for partial sync, transactional cache replacement, missing upstream paths, cache validity, symlink handling, and nested installation completion.
- Bump the workspace and internal crate versions to `1.7.2`.