### PR TITLE
Normalize GITLAB_HOST before building URLs (fixes #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to skillfile are documented here.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **`GITLAB_HOST` is now normalized before use** - a value written with a scheme (`https://gitlab.example.com`, the format glab's own docs use) no longer produces a broken double-scheme URL, and a trailing slash (`gitlab.example.com/`) no longer silently drops the auth token by breaking host matching. The scheme prefix and trailing slashes are stripped, so `https://gitlab.example.com/` and `gitlab.example.com` behave identically.
+
 ## v1.7.2 - 08-07-2026
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ GitLab:
 
 - `GITLAB_TOKEN`
 - `GITLAB_PRIVATE_TOKEN`
-- `GITLAB_HOST` for self-hosted instances
+- `GITLAB_HOST` for self-hosted instances - a bare hostname such as `gitlab.example.com` (a `https://` prefix or trailing slash is accepted and normalized away)
 
 `skillfile init` can also save token settings in user config.
 

--- a/crates/sources/src/http.rs
+++ b/crates/sources/src/http.rs
@@ -160,14 +160,37 @@ fn glab_cli_token() -> Option<String> {
         .map(ToString::to_string)
 }
 
+/// Normalizes a configured GitLab host into a bare hostname (optionally with a
+/// port and path prefix) suitable for splicing into `https://{host}/api/v4/...`.
+///
+/// `GITLAB_HOST` is a user-facing value and is easy to get wrong: glab's own
+/// docs write it with a scheme (`https://gitlab.example.com`), and a trailing
+/// slash is a natural mistake. Left unmodified, a scheme produces a
+/// double-scheme URL (`https://https://...`) that fails every request, and a
+/// trailing slash makes `is_gitlab_url` host comparison never match, silently
+/// dropping the auth token. Normalizing here fixes both at the single source.
+fn normalize_gitlab_host(host: &str) -> String {
+    let trimmed = host.trim();
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    without_scheme.trim_end_matches('/').to_string()
+}
+
 /// Returns the GitLab host. Priority: GITLAB_HOST env > config file > "gitlab.com".
 pub fn gitlab_host() -> String {
-    if let Some(host) = std::env::var("GITLAB_HOST").ok().filter(|h| !h.is_empty()) {
+    if let Some(host) = std::env::var("GITLAB_HOST")
+        .ok()
+        .map(|h| normalize_gitlab_host(&h))
+        .filter(|h| !h.is_empty())
+    {
         return host;
     }
     if let Some(Some(host)) = GITLAB_CONFIG_HOST.get() {
+        let host = normalize_gitlab_host(host);
         if !host.is_empty() {
-            return host.clone();
+            return host;
         }
     }
     "gitlab.com".to_string()
@@ -740,5 +763,84 @@ mod tests {
             "http://gitlab.com/api/v4/projects/foo",
             "gitlab.com"
         ));
+    }
+
+    // -- normalize_gitlab_host tests -----------------------------------------
+    //
+    // GITLAB_HOST is user-facing and easily mis-formatted; normalization must
+    // reduce a bare host, an https/http-prefixed host, and a trailing-slash
+    // host to the same canonical value so URL construction and the
+    // `is_gitlab_url` auth gate agree.
+
+    #[test]
+    fn normalize_gitlab_host_leaves_bare_host_unchanged() {
+        assert_eq!(
+            normalize_gitlab_host("gitlab.example.com"),
+            "gitlab.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_gitlab_host_strips_https_scheme() {
+        assert_eq!(
+            normalize_gitlab_host("https://gitlab.example.com"),
+            "gitlab.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_gitlab_host_strips_http_scheme() {
+        assert_eq!(
+            normalize_gitlab_host("http://gitlab.example.com"),
+            "gitlab.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_gitlab_host_strips_trailing_slashes() {
+        assert_eq!(
+            normalize_gitlab_host("gitlab.example.com/"),
+            "gitlab.example.com"
+        );
+        assert_eq!(
+            normalize_gitlab_host("gitlab.example.com///"),
+            "gitlab.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_gitlab_host_strips_scheme_and_trailing_slash() {
+        assert_eq!(
+            normalize_gitlab_host("https://gitlab.example.com/"),
+            "gitlab.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_gitlab_host_trims_whitespace() {
+        assert_eq!(
+            normalize_gitlab_host("  https://gitlab.example.com/  "),
+            "gitlab.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_gitlab_host_variants_all_agree() {
+        let canonical = "gitlab.example.com";
+        for input in [
+            "gitlab.example.com",
+            "https://gitlab.example.com",
+            "http://gitlab.example.com",
+            "gitlab.example.com/",
+            "https://gitlab.example.com/",
+        ] {
+            let host = normalize_gitlab_host(input);
+            assert_eq!(host, canonical, "input {input:?} did not normalize");
+            // The normalized host must satisfy the auth gate for a built URL.
+            assert!(
+                is_gitlab_url(&format!("https://{host}/api/v4/projects/foo"), &host),
+                "is_gitlab_url failed for input {input:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #136.

GITLAB_HOST was used verbatim, so two easy to hit formats broke things:

- A value with a scheme like `https://gitlab.example.com` (the format glab own docs use) got spliced into `https://{host}/api/v4/...`, giving `https://https://...`, so every GitLab request failed with a confusing connection/DNS error.
- A trailing slash like `gitlab.example.com/` parsed fine but made `is_gitlab_url` compare `gitlab.example.com` against `gitlab.example.com/`. That never matched, so the token was silently never attached and private projects came back as "not found" even with a valid `GITLAB_TOKEN`.

The fix normalizes the host once in `gitlab_host()`: trim whitespace, strip a `http(s)://` prefix, strip trailing slashes. This is applied to both the env var and the config file value, so `https://gitlab.example.com/` and `gitlab.example.com` now behave identically.

I went with normalizing rather than rejecting since it is friendlier and matches how the value is commonly written, but happy to switch to a hard error if you would prefer that.

Tests: added unit tests in `crates/sources/src/http.rs` covering the scheme prefix, trailing slash, whitespace, and combined cases, plus one that confirms every variant normalizes to the same host and that the normalized host passes the `is_gitlab_url` auth gate (`https://{host}/api/...`). Also updated the README to document the accepted format and added a CHANGELOG entry.

Ran locally: `cargo fmt --check`, `cargo clippy -p skillfile-sources --all-targets -- -D warnings`, and `cargo test --workspace` all pass.