### PR TITLE
Fix GitHub raw file URL encoding for paths with spaces and # (closes …

### DIFF
--- a/crates/sources/src/resolver.rs
+++ b/crates/sources/src/resolver.rs
@@ -263,9 +263,10 @@ pub fn fetch_github_file(
     } else {
         path_in_repo
     };
+    let encoded_path = encode_url_path(&effective_path);
     let url = format!(
         "https://raw.githubusercontent.com/{}/{}/{}",
-        gh.owner_repo, gh.ref_, effective_path
+        gh.owner_repo, gh.ref_, encoded_path
     );
     http_get(gh.client, &url)
 }

--- a/crates/sources/src/resolver.rs
+++ b/crates/sources/src/resolver.rs
@@ -2789,4 +2789,15 @@ mod tests {
             .iter()
             .any(|entry| entry.relative_path == "final.md"));
     }
+    #[test]
+    fn test_encode_url_path_with_space() {
+        let result = encode_url_path("my skill.md");
+        assert_eq!(result, "my%20skill.md");
+    }
+
+    #[test]
+    fn test_encode_url_path_with_hash() {
+        let result = encode_url_path("my#skill.md");
+        assert_eq!(result, "my%23skill.md");
+    }
 }

--- a/crates/sources/src/resolver.rs
+++ b/crates/sources/src/resolver.rs
@@ -263,7 +263,7 @@ pub fn fetch_github_file(
     } else {
         path_in_repo
     };
-    let encoded_path = encode_url_path(&effective_path);
+    let encoded_path = encode_url_path(effective_path);
     let url = format!(
         "https://raw.githubusercontent.com/{}/{}/{}",
         gh.owner_repo, gh.ref_, encoded_path


### PR DESCRIPTION
Closes #137

## Problem
`fetch_github_file` was building the raw.githubusercontent.com URL 
directly from `effective_path` without percent-encoding it. This 
caused failures for file paths containing spaces or `#` characters, 
since GitHub's raw file API requires the path to be URL-encoded 
(the GitLab fetch path already did this correctly).

## Fix
Routed `effective_path` through the existing `encode_url_path` 
function before building the URL, matching the pattern already 
used for GitLab.

## Testing
Added unit tests to verify paths with spaces encode to `%20` and 
paths with `#` encode to `%23`.+.....

Happy to make any changes if there are issues with this fix — 
just let me know!