### PR TITLE
fix: normalize directory cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to skillfile are documented here.
 
 ### Fixed
 
+- **Directory cache keys are normalized across platforms** - `skillfile status`, `skillfile pin`, and `skillfile diff` now compare nested directory-entry files with forward-slash keys even when the local platform reports Windows-style separators, so changed nested files are not silently skipped on Windows.
 - **`GITLAB_HOST` is now normalized before use** - a value written with a scheme (`https://gitlab.example.com`, the format glab's own docs use) no longer produces a broken double-scheme URL, and a trailing slash (`gitlab.example.com/`) no longer silently drops the auth token by breaking host matching. The scheme prefix and trailing slashes are stripped, so `https://gitlab.example.com/` and `gitlab.example.com` behave identically.
 
 ## v1.7.2 - 08-07-2026

--- a/crates/cli/src/commands/diff.rs
+++ b/crates/cli/src/commands/diff.rs
@@ -11,6 +11,7 @@ use skillfile_core::progress;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry};
 use skillfile_sources::sync::vendor_dir_for;
 
+use crate::commands::forward_slash;
 use crate::commands::installed_variants::{installed_dir_variants, installed_single_file_variants};
 use crate::commands::multi_target::{
     format_single_file_diff, modified_dir_variants, modified_single_file_variants, SingleFileDiff,
@@ -99,11 +100,7 @@ fn diff_local_dir(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), Skil
         .into_iter()
         .filter(|cache_file| cache_file.file_name().is_some_and(|name| name != ".meta"))
         .filter_map(|cache_file| {
-            let filename = cache_file
-                .strip_prefix(&vdir)
-                .ok()
-                .and_then(|path| path.to_str())
-                .map(str::to_string)?;
+            let filename = cache_file.strip_prefix(&vdir).ok().map(forward_slash)?;
             Some((filename, cache_file))
         })
         .collect();

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -15,5 +15,30 @@ pub mod skill_preview;
 pub mod status;
 pub mod validate;
 
+pub(crate) fn forward_slash(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
 #[cfg(test)]
 pub(crate) mod test_support;
+
+#[cfg(test)]
+mod tests {
+    use super::forward_slash;
+
+    #[test]
+    fn forward_slash_keeps_unix_paths() {
+        assert_eq!(
+            forward_slash(std::path::Path::new("scripts/helper.py")),
+            "scripts/helper.py"
+        );
+    }
+
+    #[test]
+    fn forward_slash_normalizes_windows_paths() {
+        assert_eq!(
+            forward_slash(std::path::Path::new(r"scripts\helper.py")),
+            "scripts/helper.py"
+        );
+    }
+}

--- a/crates/cli/src/commands/pin.rs
+++ b/crates/cli/src/commands/pin.rs
@@ -9,6 +9,7 @@ use skillfile_deploy::install::install_entry;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry};
 use skillfile_sources::sync::vendor_dir_for;
 
+use crate::commands::forward_slash;
 use crate::commands::installed_variants::{installed_dir_variants, installed_single_file_variants};
 use crate::commands::multi_target::{
     divergent_targets_message, modified_dir_variants, modified_single_file_variants,
@@ -67,11 +68,7 @@ fn load_cache_files(vdir: &Path) -> BTreeMap<String, std::path::PathBuf> {
         .into_iter()
         .filter(|cache_file| cache_file.file_name().is_some_and(|name| name != ".meta"))
         .filter_map(|cache_file| {
-            let filename = cache_file
-                .strip_prefix(vdir)
-                .ok()
-                .and_then(|path| path.to_str())
-                .map(str::to_string)?;
+            let filename = cache_file.strip_prefix(vdir).ok().map(forward_slash)?;
             Some((filename, cache_file))
         })
         .collect()

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -13,6 +13,8 @@ use skillfile_deploy::paths::{installed_dir_file_sets, installed_paths};
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, meta_sha};
 use skillfile_sources::sync::vendor_dir_for;
 
+use crate::commands::forward_slash;
+
 struct DirCheckCtx<'a> {
     entry: &'a Entry,
     vdir: &'a Path,
@@ -21,11 +23,7 @@ struct DirCheckCtx<'a> {
 }
 
 fn is_cache_file_modified(cache_file: &Path, ctx: &DirCheckCtx<'_>) -> Result<bool, ()> {
-    let filename = cache_file
-        .strip_prefix(ctx.vdir)
-        .map_err(|_| ())?
-        .to_string_lossy()
-        .to_string();
+    let filename = forward_slash(cache_file.strip_prefix(ctx.vdir).map_err(|_| ())?);
     let inst_path = match ctx.installed.get(&filename) {
         Some(p) if p.exists() => p,
         _ => return Ok(false),


### PR DESCRIPTION
## Summary
- normalize directory-entry cache keys to forward slashes before comparing them with installed file maps
- apply the shared normalization in `status`, `pin`, and `diff`
- add cross-platform unit coverage for Windows-style path separators and note the fix in the changelog

Fixes #142

## Validation
- `cargo fmt --check`
- `cargo test -p skillfile`
- `cargo clippy -p skillfile --all-targets -- -D warnings`
