### PR TITLE
fix(search): surface GitHub discovery errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to skillfile are documented here.
 
 ### Fixed
 
+- **Search-to-add now reports GitHub discovery failures** - rate-limit, authentication, network, and malformed-response errors are shown instead of being silently converted into an empty result and a misleading `Path in repo:` prompt.
 - **`GITLAB_HOST` is now normalized before use** - a value written with a scheme (`https://gitlab.example.com`, the format glab's own docs use) no longer produces a broken double-scheme URL, and a trailing slash (`gitlab.example.com/`) no longer silently drops the auth token by breaking host matching. The scheme prefix and trailing slashes are stripped, so `https://gitlab.example.com/` and `gitlab.example.com` behave identically.
 
 ## v1.7.2 - 08-07-2026

--- a/crates/cli/src/commands/search.rs
+++ b/crates/cli/src/commands/search.rs
@@ -15,7 +15,7 @@ use skillfile_sources::registry::{
     fetch_agentskill_github_meta, scrape_github_meta_from_page, search_all, search_registry,
     RegistryId, SearchOptions, SearchResponse,
 };
-use skillfile_sources::resolver::{fetch_github_file, list_repo_skill_entries, GithubFetch};
+use skillfile_sources::resolver::{fetch_github_file, try_list_repo_skill_entries, GithubFetch};
 
 use super::add::{cmd_add, entry_from_github, GithubEntryArgs};
 
@@ -242,8 +242,9 @@ fn resolve_skill_path(
         skill_name,
         entity_type,
     };
-    let (candidates, resolved) = discover_skill_path(&client, &query);
+    let discovery = discover_skill_path(&client, &query);
     spinner.finish();
+    let (candidates, resolved) = discovery?;
 
     if let Some(path) = resolved {
         println!("  path: {path}");
@@ -278,34 +279,34 @@ struct SearchPathQuery<'a> {
 fn discover_skill_path(
     client: &dyn HttpClient,
     query: &SearchPathQuery<'_>,
-) -> (Vec<String>, Option<String>) {
-    let mut md_files = list_repo_skill_entries(client, query.owner_repo);
+) -> Result<(Vec<String>, Option<String>), SkillfileError> {
+    let mut md_files = try_list_repo_skill_entries(client, query.owner_repo)?;
 
     if md_files.is_empty() {
         let (canonical_files, canonical_path) =
-            try_canonical_resolution(client, query.owner_repo, query.skill_name);
+            try_canonical_resolution(client, query.owner_repo, query.skill_name)?;
         if let Some(path) = canonical_path {
-            return (Vec::new(), Some(path));
+            return Ok((Vec::new(), Some(path)));
         }
         if !canonical_files.is_empty() {
             md_files = canonical_files;
         } else if let Some(path) =
             probe_common_skill_paths(client, query.owner_repo, query.skill_name)
         {
-            return (Vec::new(), Some(path));
+            return Ok((Vec::new(), Some(path)));
         } else {
-            return (Vec::new(), None);
+            return Ok((Vec::new(), None));
         }
     }
 
     if md_files.len() == 1 {
-        return (Vec::new(), Some(md_files[0].clone()));
+        return Ok((Vec::new(), Some(md_files[0].clone())));
     }
 
     let ranked = rank_by_name_for_entity(&md_files, query.skill_name, query.entity_type);
     if let Some((path, score)) = ranked.first() {
         if *score == MatchScore::Exact {
-            return (Vec::new(), Some(path.clone()));
+            return Ok((Vec::new(), Some(path.clone())));
         }
     }
 
@@ -316,7 +317,7 @@ fn discover_skill_path(
         candidates
     };
 
-    (list, None)
+    Ok((list, None))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -430,29 +431,35 @@ fn common_skill_file_candidates(slug: &str) -> [String; 5] {
     ]
 }
 
-fn canonical_owner_repo(client: &dyn HttpClient, owner_repo: &str) -> Option<String> {
+fn canonical_owner_repo(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+) -> Result<Option<String>, SkillfileError> {
     let url = format!("https://api.github.com/repos/{owner_repo}");
-    let text = client.get_json(&url).ok()??;
-    let data: serde_json::Value = serde_json::from_str(&text).ok()?;
-    let full_name = data["full_name"].as_str()?;
-    Some(full_name.to_string())
+    let Some(text) = client.get_json(&url)? else {
+        return Ok(None);
+    };
+    let data: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+        SkillfileError::Network(format!("invalid repository response for {owner_repo}: {e}"))
+    })?;
+    Ok(data["full_name"].as_str().map(ToString::to_string))
 }
 
 fn try_canonical_resolution(
     client: &dyn HttpClient,
     owner_repo: &str,
     skill_name: &str,
-) -> (Vec<String>, Option<String>) {
-    let Some(canonical) = canonical_owner_repo(client, owner_repo) else {
-        return (Vec::new(), None);
+) -> Result<(Vec<String>, Option<String>), SkillfileError> {
+    let Some(canonical) = canonical_owner_repo(client, owner_repo)? else {
+        return Ok((Vec::new(), None));
     };
-    let md_files = list_repo_skill_entries(client, &canonical);
+    let md_files = try_list_repo_skill_entries(client, &canonical)?;
     let path = if md_files.is_empty() {
         probe_common_skill_paths(client, &canonical, skill_name)
     } else {
         None
     };
-    (md_files, path)
+    Ok((md_files, path))
 }
 
 #[cfg(debug_assertions)]
@@ -463,7 +470,7 @@ pub fn run_search_path_resolution_regression() -> Result<(), SkillfileError> {
         skill_name: "linkedin profile optimizer",
         entity_type: "skill",
     };
-    let (_, resolved) = discover_skill_path(&client, &query);
+    let (_, resolved) = discover_skill_path(&client, &query)?;
     emit_regression_resolution(resolved.as_deref())
 }
 
@@ -655,7 +662,7 @@ mod tests {
     use skillfile_sources::registry::SearchResult;
 
     struct SearchPathClient {
-        json: HashMap<String, Option<String>>,
+        json: HashMap<String, Result<Option<String>, String>>,
         bytes: HashMap<String, Vec<u8>>,
     }
 
@@ -669,12 +676,17 @@ mod tests {
 
         fn with_json(mut self, url: &str, body: Option<serde_json::Value>) -> Self {
             self.json
-                .insert(url.to_string(), body.map(|value| value.to_string()));
+                .insert(url.to_string(), Ok(body.map(|value| value.to_string())));
             self
         }
 
         fn with_bytes(mut self, url: &str, body: &[u8]) -> Self {
             self.bytes.insert(url.to_string(), body.to_vec());
+            self
+        }
+
+        fn with_json_error(mut self, url: &str, message: &str) -> Self {
+            self.json.insert(url.to_string(), Err(message.to_string()));
             self
         }
     }
@@ -690,7 +702,11 @@ mod tests {
         }
 
         fn get_json(&self, url: &str) -> Result<Option<String>, SkillfileError> {
-            Ok(self.json.get(url).cloned().flatten())
+            self.json
+                .get(url)
+                .cloned()
+                .unwrap_or(Ok(None))
+                .map_err(SkillfileError::Network)
         }
 
         fn post_json(&self, _url: &str, _body: &str) -> Result<Vec<u8>, SkillfileError> {
@@ -775,9 +791,64 @@ mod tests {
         );
 
         assert_eq!(
-            canonical_owner_repo(&client, "paramchoudhary/resumeskills").as_deref(),
+            canonical_owner_repo(&client, "paramchoudhary/resumeskills")
+                .unwrap()
+                .as_deref(),
             Some("Paramchoudhary/ResumeSkills")
         );
+    }
+
+    #[test]
+    fn canonical_owner_repo_propagates_rate_limit_error() {
+        let client = SearchPathClient::new().with_json_error(
+            "https://api.github.com/repos/example/repo",
+            "HTTP 403 fetching repository - you may be rate-limited",
+        );
+
+        let error = canonical_owner_repo(&client, "example/repo").unwrap_err();
+
+        assert!(error.to_string().contains("rate-limited"), "{error}");
+    }
+
+    #[test]
+    fn discover_skill_path_propagates_rate_limit_error() {
+        let client = SearchPathClient::new().with_json_error(
+            "https://api.github.com/repos/example/repo/git/trees/main?recursive=1",
+            "HTTP 403 fetching tree - you may be rate-limited",
+        );
+        let query = SearchPathQuery {
+            owner_repo: "example/repo",
+            skill_name: "example",
+            entity_type: "skill",
+        };
+
+        let error = discover_skill_path(&client, &query).unwrap_err();
+
+        assert!(error.to_string().contains("rate-limited"), "{error}");
+    }
+
+    #[test]
+    fn discover_skill_path_keeps_missing_repo_as_manual_fallback() {
+        let client = SearchPathClient::new()
+            .with_json(
+                "https://api.github.com/repos/example/missing/git/trees/main?recursive=1",
+                None,
+            )
+            .with_json(
+                "https://api.github.com/repos/example/missing/git/trees/master?recursive=1",
+                None,
+            )
+            .with_json("https://api.github.com/repos/example/missing", None);
+        let query = SearchPathQuery {
+            owner_repo: "example/missing",
+            skill_name: "example",
+            entity_type: "skill",
+        };
+
+        let (candidates, resolved) = discover_skill_path(&client, &query).unwrap();
+
+        assert!(candidates.is_empty());
+        assert!(resolved.is_none());
     }
 
     #[test]
@@ -812,7 +883,7 @@ mod tests {
             entity_type: "skill",
         };
 
-        let (candidates, resolved) = discover_skill_path(&client, &query);
+        let (candidates, resolved) = discover_skill_path(&client, &query).unwrap();
 
         assert!(candidates.is_empty());
         assert_eq!(
@@ -856,7 +927,7 @@ mod tests {
             entity_type: "skill",
         };
 
-        let (candidates, resolved) = discover_skill_path(&client, &query);
+        let (candidates, resolved) = discover_skill_path(&client, &query).unwrap();
 
         assert!(candidates.is_empty());
         assert_eq!(
@@ -883,7 +954,7 @@ mod tests {
             entity_type: "skill",
         };
 
-        let (candidates, resolved) = discover_skill_path(&client, &query);
+        let (candidates, resolved) = discover_skill_path(&client, &query).unwrap();
 
         assert!(resolved.is_none());
         assert_eq!(

--- a/crates/sources/src/resolver.rs
+++ b/crates/sources/src/resolver.rs
@@ -68,19 +68,37 @@ fn check_repo_renamed(client: &dyn HttpClient, owner_repo: &str) -> Option<Strin
 /// Fetch the `default_branch` field from the GitHub repo API.
 ///
 /// Returns `None` if the API call fails or the field is missing.
-fn fetch_default_branch(client: &dyn HttpClient, owner_repo: &str) -> Option<String> {
+fn try_fetch_default_branch(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+) -> Result<Option<String>, SkillfileError> {
     let url = format!("https://api.github.com/repos/{owner_repo}");
-    let text = client.get_json(&url).ok()??;
-    let data: serde_json::Value = serde_json::from_str(&text).ok()?;
-    data["default_branch"].as_str().map(ToString::to_string)
+    let Some(text) = client.get_json(&url)? else {
+        return Ok(None);
+    };
+    let data: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+        SkillfileError::Network(format!("invalid repository response for {owner_repo}: {e}"))
+    })?;
+    Ok(data["default_branch"].as_str().map(ToString::to_string))
+}
+
+fn try_non_legacy_default_branch(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+) -> Result<Option<String>, SkillfileError> {
+    let Some(branch) = try_fetch_default_branch(client, owner_repo)? else {
+        return Ok(None);
+    };
+    if branch == "main" || branch == "master" {
+        return Ok(None);
+    }
+    Ok(Some(branch))
 }
 
 fn non_legacy_default_branch(client: &dyn HttpClient, owner_repo: &str) -> Option<String> {
-    let branch = fetch_default_branch(client, owner_repo)?;
-    if branch == "main" || branch == "master" {
-        return None;
-    }
-    Some(branch)
+    try_non_legacy_default_branch(client, owner_repo)
+        .ok()
+        .flatten()
 }
 
 fn fallback_branch(ref_: &str) -> Option<&'static str> {
@@ -604,6 +622,22 @@ fn list_default_md_files(client: &dyn HttpClient, owner_repo: &str) -> Option<Ve
         })
 }
 
+fn try_list_default_md_files(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+) -> Result<Option<Vec<String>>, SkillfileError> {
+    if let Some(files) = try_list_md_files_with_ref(client, owner_repo, "main")? {
+        return Ok(Some(files));
+    }
+    if let Some(files) = try_list_md_files_with_ref(client, owner_repo, "master")? {
+        return Ok(Some(files));
+    }
+    let Some(default_branch) = try_non_legacy_default_branch(client, owner_repo)? else {
+        return Ok(None);
+    };
+    try_list_md_files_with_ref(client, owner_repo, &default_branch)
+}
+
 /// Discover skill entry paths in a GitHub repo.
 ///
 /// Returns Skillfile-ready paths: `.` for root SKILL.md, directory paths for
@@ -616,6 +650,17 @@ pub fn list_repo_skill_entries(client: &dyn HttpClient, owner_repo: &str) -> Vec
     list_default_md_files(client, owner_repo)
         .map(|files| collapse_to_entries(&files))
         .unwrap_or_default()
+}
+
+/// Discover skill entry paths while preserving network and response errors.
+/// Missing repositories and refs still produce an empty result.
+pub fn try_list_repo_skill_entries(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+) -> Result<Vec<String>, SkillfileError> {
+    Ok(try_list_default_md_files(client, owner_repo)?
+        .map(|files| collapse_to_entries(&files))
+        .unwrap_or_default())
 }
 
 pub struct RepoEntryQuery<'a> {
@@ -684,9 +729,25 @@ fn list_md_files_with_ref(
     owner_repo: &str,
     ref_: &str,
 ) -> Option<Vec<String>> {
+    try_list_md_files_with_ref(client, owner_repo, ref_)
+        .ok()
+        .flatten()
+}
+
+fn try_list_md_files_with_ref(
+    client: &dyn HttpClient,
+    owner_repo: &str,
+    ref_: &str,
+) -> Result<Option<Vec<String>>, SkillfileError> {
     let url = format!("https://api.github.com/repos/{owner_repo}/git/trees/{ref_}?recursive=1");
-    let text = client.get_json(&url).ok()??;
-    let data: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let Some(text) = client.get_json(&url)? else {
+        return Ok(None);
+    };
+    let data: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+        SkillfileError::Network(format!(
+            "invalid tree response for {owner_repo}@{ref_}: {e}"
+        ))
+    })?;
     let empty = Vec::new();
     let tree = data["tree"].as_array().unwrap_or(&empty);
 
@@ -707,7 +768,7 @@ fn list_md_files_with_ref(
         })
         .collect();
 
-    Some(files)
+    Ok(Some(files))
 }
 
 #[derive(Debug, Clone)]
@@ -2108,6 +2169,31 @@ mod tests {
         client.add_json_err(&tree_url("org/repo", "main"), "connection refused");
         client.add_json_err(&tree_url("org/repo", "master"), "connection refused");
         assert!(list_repo_skill_entries(&client, "org/repo").is_empty());
+    }
+
+    #[test]
+    fn try_skill_entries_propagates_rate_limit_error() {
+        let mut client = MockClient::new();
+        client.add_json_err(
+            &tree_url("org/repo", "main"),
+            "HTTP 403 fetching tree - you may be rate-limited",
+        );
+
+        let error = try_list_repo_skill_entries(&client, "org/repo").unwrap_err();
+
+        assert!(error.to_string().contains("rate-limited"), "{error}");
+    }
+
+    #[test]
+    fn try_skill_entries_keeps_missing_repo_as_empty() {
+        let mut client = MockClient::new();
+        client.add_json_none(&tree_url("org/repo", "main"));
+        client.add_json_none(&tree_url("org/repo", "master"));
+        client.add_json_none(&repo_url("org/repo"));
+
+        assert!(try_list_repo_skill_entries(&client, "org/repo")
+            .unwrap()
+            .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve GitHub discovery errors during search-to-add path resolution
- keep missing repositories and empty skill trees on the existing manual-path fallback
- cover rate-limit propagation in the source and CLI layers

## Why

GitHub 403 responses were converted into empty discovery results, so search-to-add showed `Path in repo:` as if no skills existed. This keeps 404/422 as missing while surfacing rate-limit, authentication, network, and malformed-response errors.

Fixes #147

## Validation

- `cargo test --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo build -p skillfile` — passed
- `cargo deny check` — passed
- `cargo fmt --check` — passed