### PR TITLE
feat: support explicit install path targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ version = "1.7.3"
 dependencies = [
  "serde",
  "serde_json",
+ "shlex",
  "similar 3.1.1",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ semver = "1"
 # Diff/patch
 similar = "3"
 
+# Manifest field quoting
+shlex = "1"
+
 # HTML entity decoding
 html-escape = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ GitLab project paths may include subgroups. Self-hosted GitLab is supported thro
 ```text
 install  claude-code  global
 install  codex        global
+install-path  openclaw     skill  ~/.openclaw/skills
+install-path  misc-target  agent  ./local/path/to/agents
 
 github  skill  anthropics/skills  skills/slack-gif-creator
 gitlab  skill  my-group/platform-skills  skills/release
@@ -72,6 +74,8 @@ url     agent  triager  https://example.com/agents/triager.md
 ```
 
 Format details live in [SPEC.md](SPEC.md).
+
+Explicit path targets install skills as `<path>/<name>/SKILL.md` and agents as `<path>/<name>.md`.
 
 ## Common commands
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -54,6 +54,20 @@ install  <platform>  <scope>
 
 Multiple install lines are allowed (one per platform+scope combination). Duplicate install targets produce a warning during validation.
 
+### Explicit Path Targets
+
+```
+install-path  <tool-name>  <entity-type>  <path>
+```
+
+| Field | Values | Description |
+|---|---|---|
+| `tool-name` | any non-empty string | Label used in status and install output |
+| `entity-type` | `skill`, `agent` | Which kind of entry this target accepts |
+| `path` | filesystem path | Exact destination directory; `~` expands to `$HOME`, relative paths are resolved from the repo root |
+
+Each `install-path` line defines one destination for one entity type. Default directory mode is `nested` for skills and `flat` for agents. Multiple explicit path targets are allowed. Duplicate targets for the same entity type and destination path fail validation.
+
 ## Entry Lines
 
 ### Local

--- a/crates/cli/src/commands/format.rs
+++ b/crates/cli/src/commands/format.rs
@@ -6,6 +6,7 @@ use skillfile_core::parser::{parse_manifest, MANIFEST_NAME};
 use skillfile_sources::strategy::format_parts;
 
 const INSTALL_COMMENT: &str = "# install  <platform>  <scope>";
+const INSTALL_PATH_COMMENT: &str = "# install-path  <tool-name>  <entity-type>  <path>";
 
 fn section_headers(entity_type: &str) -> Vec<&'static str> {
     match entity_type {
@@ -92,7 +93,11 @@ fn extract_entry_comments(raw_text: &str) -> std::collections::HashMap<String, V
             pending.push(line.trim_end().to_string());
             continue;
         }
-        if stripped.is_empty() || stripped.starts_with("install") {
+        if stripped.is_empty() || stripped.starts_with("install ") || stripped == "install" {
+            pending.clear();
+            continue;
+        }
+        if stripped.starts_with("install-path ") || stripped == "install-path" {
             pending.clear();
             continue;
         }
@@ -134,9 +139,23 @@ pub fn sorted_manifest_text(manifest: &Manifest, raw_text: &str) -> String {
 
     // Install targets section
     if !manifest.install_targets.is_empty() {
-        lines.push(INSTALL_COMMENT.to_string());
+        if manifest.install_targets.iter().any(|target| {
+            matches!(
+                target,
+                skillfile_core::models::InstallTarget::Platform { .. }
+            )
+        }) {
+            lines.push(INSTALL_COMMENT.to_string());
+        }
+        if manifest
+            .install_targets
+            .iter()
+            .any(|target| matches!(target, skillfile_core::models::InstallTarget::Path { .. }))
+        {
+            lines.push(INSTALL_PATH_COMMENT.to_string());
+        }
         for target in &manifest.install_targets {
-            lines.push(format!("install  {}  {}", target.adapter, target.scope));
+            lines.push(target.manifest_line());
         }
     }
 
@@ -224,10 +243,7 @@ mod tests {
     }
 
     fn itarget(adapter: &str, scope: Scope) -> InstallTarget {
-        InstallTarget {
-            adapter: adapter.into(),
-            scope,
-        }
+        InstallTarget::platform(adapter, scope)
     }
 
     #[test]

--- a/crates/cli/src/commands/format.rs
+++ b/crates/cli/src/commands/format.rs
@@ -398,6 +398,15 @@ mod tests {
     }
 
     #[test]
+    fn cmd_format_preserves_quoted_install_path_tool_name() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "install-path  \"my tool\"  skill  ./out\n");
+        cmd_format(dir.path(), false).unwrap();
+        let text = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
+        assert!(text.contains("install-path  'my tool'  skill  ./out"));
+    }
+
+    #[test]
     fn cmd_format_dry_run_does_not_write() {
         let dir = tempfile::tempdir().unwrap();
         let original = "github  skill  z/repo  z.md\ngithub  skill  a/repo  a.md\n";

--- a/crates/cli/src/commands/info.rs
+++ b/crates/cli/src/commands/info.rs
@@ -6,8 +6,9 @@ use skillfile_core::models::{short_sha, Entry, Manifest, SourceFields};
 use skillfile_core::parser::MANIFEST_NAME;
 use skillfile_core::patch::walkdir;
 use skillfile_core::patch::{has_dir_patch, has_patch, patch_path, patches_root};
-use skillfile_deploy::adapter::{adapters, AdapterScope, DirInstallMode};
+use skillfile_deploy::adapter::DirInstallMode;
 use skillfile_deploy::paths::{installed_paths, source_path};
+use skillfile_deploy::target::ResolvedInstallTarget;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry};
 use skillfile_sources::sync::vendor_dir_for;
 
@@ -126,27 +127,21 @@ fn installed_locations_for_dir_entry(
 ) -> Result<Vec<InstalledLocation>, SkillfileError> {
     let mut locations = Vec::new();
     for target in &manifest.install_targets {
-        let adapter = adapters().get(&target.adapter).ok_or_else(|| {
-            SkillfileError::Manifest(format!("unknown adapter '{}'", target.adapter))
-        })?;
-        if !adapter.supports(entry.entity_type) {
+        let resolved = ResolvedInstallTarget::from_target(target)?;
+        if !resolved.supports(entry.entity_type) {
             continue;
         }
-        let ctx = AdapterScope {
-            scope: target.scope,
-            repo_root,
-        };
-        let dir_mode = adapter
+        let dir_mode = resolved
             .dir_mode(entry.entity_type)
             .unwrap_or(DirInstallMode::Nested);
         if dir_mode == DirInstallMode::Nested {
-            let target_dir = adapter.target_dir(entry.entity_type, &ctx);
+            let target_dir = resolved.target_dir(entry.entity_type, repo_root);
             locations.push(nested_dir_location(entry, &target_dir));
         } else {
             locations.extend(flat_dir_locations(
                 entry,
                 repo_root,
-                adapter.target_dir(entry.entity_type, &ctx),
+                resolved.target_dir(entry.entity_type, repo_root),
             ));
         }
     }
@@ -590,14 +585,8 @@ mod tests {
         let manifest = Manifest {
             entries: vec![entry.clone()],
             install_targets: vec![
-                InstallTarget {
-                    adapter: "claude-code".into(),
-                    scope: Scope::Local,
-                },
-                InstallTarget {
-                    adapter: "copilot".into(),
-                    scope: Scope::Local,
-                },
+                InstallTarget::platform("claude-code", Scope::Local),
+                InstallTarget::platform("copilot", Scope::Local),
             ],
         };
         let installed = dir.path().join(".claude/skills/foo");
@@ -633,10 +622,7 @@ mod tests {
         };
         let manifest = Manifest {
             entries: vec![entry.clone()],
-            install_targets: vec![InstallTarget {
-                adapter: "claude-code".into(),
-                scope: Scope::Local,
-            }],
+            install_targets: vec![InstallTarget::platform("claude-code", Scope::Local)],
         };
         let installed = dir.path().join(".claude/agents");
         std::fs::create_dir_all(&installed).unwrap();

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -118,10 +118,7 @@ fn write_personal_config(new_targets: &[(String, String)]) -> Result<(), Skillfi
     use skillfile_core::models::{InstallTarget, Scope};
     let targets: Vec<InstallTarget> = new_targets
         .iter()
-        .map(|(a, s)| InstallTarget {
-            adapter: a.clone(),
-            scope: Scope::parse(s).unwrap_or(Scope::Local),
-        })
+        .map(|(a, s)| InstallTarget::platform(a.clone(), Scope::parse(s).unwrap_or(Scope::Local)))
         .collect();
     crate::config::write_user_targets(&targets)?;
     Ok(())
@@ -458,6 +455,25 @@ fn persist_targets(
     Ok(())
 }
 
+fn print_init_outro(entry_count: usize) -> Result<(), SkillfileError> {
+    let outro = if entry_count == 0 {
+        "You're all set! Next up:".to_string()
+    } else {
+        let word = if entry_count == 1 { "entry" } else { "entries" };
+        format!(
+            "Platforms configured! This Skillfile already has {entry_count} {word}.\n  \
+             \u{1f680} Run `skillfile install` to fetch and deploy them."
+        )
+    };
+    cliclack::outro(format!(
+        "{outro}\n  \
+         \u{2795} `skillfile add` to add a skill or agent\n  \
+         \u{1f50d} `skillfile search` to discover community skills\n  \
+         \u{1f4ac} `skillfile completions <bash|zsh|fish>` for tab completion"
+    ))?;
+    Ok(())
+}
+
 pub fn cmd_init(repo_root: &Path) -> Result<(), SkillfileError> {
     // TTY guard: cliclack requires an interactive terminal. Check stdin, stdout,
     // and the CI env var because some CI runners (macOS GitHub Actions) report
@@ -489,19 +505,21 @@ pub fn cmd_init(repo_root: &Path) -> Result<(), SkillfileError> {
     let existing_set: std::collections::HashSet<&str> = existing
         .iter()
         .chain(user_targets.iter())
-        .map(|t| t.adapter.as_str())
+        .filter_map(|t| match t {
+            skillfile_core::models::InstallTarget::Platform { adapter, .. } => {
+                Some(adapter.as_str())
+            }
+            skillfile_core::models::InstallTarget::Path { .. } => None,
+        })
         .collect();
 
     if !existing.is_empty() || !user_targets.is_empty() {
         let mut lines: Vec<String> = existing
             .iter()
-            .map(|t| format!("install  {}  {}  (Skillfile)", t.adapter, t.scope))
+            .map(|t| format!("{}  (Skillfile)", t.manifest_line()))
             .collect();
         for t in &user_targets {
-            lines.push(format!(
-                "install  {}  {}  (personal config)",
-                t.adapter, t.scope
-            ));
+            lines.push(format!("{}  (personal config)", t.manifest_line()));
         }
         cliclack::note("Existing config", lines.join("\n"))?;
     }
@@ -516,23 +534,7 @@ pub fn cmd_init(repo_root: &Path) -> Result<(), SkillfileError> {
     persist_targets(&manifest_path, destination, &new_targets)?;
     setup_forge_tokens()?;
     update_gitignore(repo_root)?;
-
-    let outro = if result.manifest.entries.is_empty() {
-        "You're all set! Next up:".to_string()
-    } else {
-        let n = result.manifest.entries.len();
-        let word = if n == 1 { "entry" } else { "entries" };
-        format!(
-            "Platforms configured! This Skillfile already has {n} {word}.\n  \
-                 \u{1f680} Run `skillfile install` to fetch and deploy them."
-        )
-    };
-    cliclack::outro(format!(
-        "{outro}\n  \
-         \u{2795} `skillfile add` to add a skill or agent\n  \
-         \u{1f50d} `skillfile search` to discover community skills\n  \
-         \u{1f4ac} `skillfile completions <bash|zsh|fish>` for tab completion"
-    ))?;
+    print_init_outro(result.manifest.entries.len())?;
 
     Ok(())
 }

--- a/crates/cli/src/commands/installed_variants.rs
+++ b/crates/cli/src/commands/installed_variants.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use skillfile_core::error::SkillfileError;
 use skillfile_core::models::{Entry, Manifest};
-use skillfile_deploy::adapter::{adapters, AdapterScope};
+use skillfile_deploy::target::ResolvedInstallTarget;
 
 pub(crate) struct SingleFileVariant {
     pub(crate) label: String,
@@ -20,24 +20,17 @@ pub(crate) fn installed_single_file_variants(
     manifest: &Manifest,
     repo_root: &Path,
 ) -> Result<Vec<SingleFileVariant>, SkillfileError> {
-    let all_adapters = adapters();
     let mut variants = Vec::new();
 
     for target in &manifest.install_targets {
-        let Some(adapter) = all_adapters.get(&target.adapter) else {
+        let Ok(resolved) = ResolvedInstallTarget::from_target(target) else {
             continue;
         };
-        if !adapter.supports(entry.entity_type) {
+        if !resolved.supports(entry.entity_type) {
             continue;
         }
 
-        let path = adapter.installed_path(
-            entry,
-            &AdapterScope {
-                scope: target.scope,
-                repo_root,
-            },
-        );
+        let path = resolved.installed_path(entry, repo_root);
         if !path.exists() {
             continue;
         }
@@ -56,24 +49,17 @@ pub(crate) fn installed_dir_variants(
     manifest: &Manifest,
     repo_root: &Path,
 ) -> Vec<DirVariant> {
-    let all_adapters = adapters();
     let mut variants = Vec::new();
 
     for target in &manifest.install_targets {
-        let Some(adapter) = all_adapters.get(&target.adapter) else {
+        let Ok(resolved) = ResolvedInstallTarget::from_target(target) else {
             continue;
         };
-        if !adapter.supports(entry.entity_type) {
+        if !resolved.supports(entry.entity_type) {
             continue;
         }
 
-        let files = adapter.installed_dir_files(
-            entry,
-            &AdapterScope {
-                scope: target.scope,
-                repo_root,
-            },
-        );
+        let files = resolved.installed_dir_files(entry, repo_root);
         if files.is_empty() {
             continue;
         }

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -533,10 +533,7 @@ mod tests {
     }
 
     fn claude_local_target() -> InstallTarget {
-        InstallTarget {
-            adapter: "claude-code".into(),
-            scope: Scope::Local,
-        }
+        InstallTarget::platform("claude-code", Scope::Local)
     }
 
     fn agent_manifest() -> Manifest {
@@ -1044,10 +1041,7 @@ mod tests {
             entries: vec![local_entry("x", "x.md")],
             install_targets: vec![
                 claude_local_target(),
-                InstallTarget {
-                    adapter: "cursor".into(),
-                    scope: Scope::Global,
-                },
+                InstallTarget::platform("cursor", Scope::Global),
             ],
         };
         let out = format_summary(&manifest, dir.path());
@@ -1102,10 +1096,7 @@ mod tests {
             entries: vec![entry.clone()],
             install_targets: vec![
                 claude_local_target(),
-                InstallTarget {
-                    adapter: "copilot".into(),
-                    scope: Scope::Local,
-                },
+                InstallTarget::platform("copilot", Scope::Local),
             ],
         };
 
@@ -1167,10 +1158,7 @@ mod tests {
             entries: dir_skill_manifest().entries,
             install_targets: vec![
                 claude_local_target(),
-                InstallTarget {
-                    adapter: "copilot".into(),
-                    scope: Scope::Local,
-                },
+                InstallTarget::platform("copilot", Scope::Local),
             ],
         };
         let entry = &manifest.entries[0];

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -1,12 +1,13 @@
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use console::{style, StyledObject};
 use skillfile_core::error::SkillfileError;
 use skillfile_core::lock::{lock_key, read_lock};
-use skillfile_core::models::{Manifest, Scope, SourceFields};
+use skillfile_core::models::{EntityType, InstallTarget, Manifest, SourceFields};
 use skillfile_core::parser::{parse_manifest, MANIFEST_NAME};
 use skillfile_deploy::adapter::adapters;
+use skillfile_deploy::target::ResolvedInstallTarget;
 
 fn check_duplicate_names(manifest: &Manifest, errors: &mut Vec<String>) {
     let mut seen: HashMap<String, String> = HashMap::new();
@@ -41,25 +42,80 @@ fn check_local_paths(manifest: &Manifest, repo_root: &Path, errors: &mut Vec<Str
 fn check_platforms(manifest: &Manifest, errors: &mut Vec<String>) {
     let all_adapters = adapters();
     for target in &manifest.install_targets {
-        if !all_adapters.contains(&target.adapter) {
-            errors.push(format!("unknown platform: '{}'", target.adapter));
+        let InstallTarget::Platform { adapter, .. } = target else {
+            continue;
+        };
+        if !all_adapters.contains(adapter) {
+            errors.push(format!("unknown platform: '{adapter}'"));
         }
     }
 }
 
-fn check_duplicate_targets(manifest: &Manifest, errors: &mut Vec<String>) {
-    let mut seen_targets: HashSet<(String, Scope)> = HashSet::new();
-    for target in &manifest.install_targets {
-        let key = (target.adapter.clone(), target.scope);
-        if seen_targets.contains(&key) {
-            errors.push(format!(
-                "duplicate install target: '{} {}'",
-                target.adapter, target.scope
-            ));
-        } else {
-            seen_targets.insert(key);
+fn duplicate_target_message(
+    target: &InstallTarget,
+    entity_type: EntityType,
+    path: &Path,
+) -> String {
+    let target_label = match target {
+        InstallTarget::Platform { adapter, scope } => {
+            format!("{adapter} {scope}")
+        }
+        InstallTarget::Path {
+            tool_name,
+            entity_type,
+            path,
+        } => format!("{tool_name} {entity_type} {path}"),
+    };
+    format!(
+        "duplicate install target for {entity_type} path '{}': '{target_label}'",
+        path.display()
+    )
+}
+
+fn normalized_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
         }
     }
+    normalized
+}
+
+fn resolved_target_paths(target: &InstallTarget, repo_root: &Path) -> Vec<(EntityType, PathBuf)> {
+    let Ok(resolved) = ResolvedInstallTarget::from_target(target) else {
+        return Vec::new();
+    };
+    EntityType::ALL
+        .iter()
+        .copied()
+        .filter(|entity_type| resolved.supports(*entity_type))
+        .map(|entity_type| {
+            let path = normalized_path(&resolved.target_dir(entity_type, repo_root));
+            (entity_type, path)
+        })
+        .collect()
+}
+
+fn check_duplicate_targets(manifest: &Manifest, repo_root: &Path, errors: &mut Vec<String>) {
+    let mut seen_targets: HashSet<(EntityType, PathBuf)> = HashSet::new();
+    let duplicate_messages = manifest
+        .install_targets
+        .iter()
+        .flat_map(|target| {
+            resolved_target_paths(target, repo_root)
+                .into_iter()
+                .map(move |(entity_type, path)| (target, entity_type, path))
+        })
+        .filter_map(|(target, entity_type, path)| {
+            (!seen_targets.insert((entity_type, path.clone())))
+                .then(|| duplicate_target_message(target, entity_type, &path))
+        });
+    errors.extend(duplicate_messages);
 }
 
 fn check_orphaned_locks(
@@ -120,7 +176,7 @@ pub fn cmd_validate(repo_root: &Path) -> Result<(), SkillfileError> {
     check_duplicate_names(&manifest, &mut errors);
     check_local_paths(&manifest, repo_root, &mut errors);
     check_platforms(&manifest, &mut errors);
-    check_duplicate_targets(&manifest, &mut errors);
+    check_duplicate_targets(&manifest, repo_root, &mut errors);
     check_orphaned_locks(&manifest, repo_root, &mut errors)?;
 
     if !errors.is_empty() {
@@ -266,6 +322,30 @@ mod tests {
         write_manifest(
             dir.path(),
             "install  claude-code  global\ninstall  claude-code  global\n",
+        );
+        let result = cmd_validate(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_install_target_resolves_path_aliases() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "install-path  custom-a  skill  ./out/skills\n\
+             install-path  custom-b  skill  out/./skills\n",
+        );
+        let result = cmd_validate(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_install_target_matches_builtin_resolved_path() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "install  claude-code  local\n\
+             install-path  custom  skill  .claude/skills\n",
         );
         let result = cmd_validate(dir.path());
         assert!(result.is_err());

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -65,11 +65,14 @@ struct InstallEntry {
 // Conversions
 // ---------------------------------------------------------------------------
 
-impl From<&InstallTarget> for InstallEntry {
-    fn from(target: &InstallTarget) -> Self {
-        Self {
-            platform: target.adapter.clone(),
-            scope: target.scope.to_string(),
+impl InstallEntry {
+    fn from_target(target: &InstallTarget) -> Option<Self> {
+        match target {
+            InstallTarget::Platform { adapter, scope } => Some(Self {
+                platform: adapter.clone(),
+                scope: scope.to_string(),
+            }),
+            InstallTarget::Path { .. } => None,
         }
     }
 }
@@ -77,10 +80,7 @@ impl From<&InstallTarget> for InstallEntry {
 impl InstallEntry {
     fn to_install_target(&self) -> Option<InstallTarget> {
         let scope = Scope::parse(&self.scope)?;
-        Some(InstallTarget {
-            adapter: self.platform.clone(),
-            scope,
-        })
+        Some(InstallTarget::platform(self.platform.clone(), scope))
     }
 }
 
@@ -152,7 +152,10 @@ pub fn write_user_targets_to(targets: &[InstallTarget], path: &Path) -> Result<(
         github_token: existing.github_token,
         gitlab_token: existing.gitlab_token,
         gitlab_host: existing.gitlab_host,
-        install: targets.iter().map(InstallEntry::from).collect(),
+        install: targets
+            .iter()
+            .filter_map(InstallEntry::from_target)
+            .collect(),
     };
     write_config_to(&config, path)
 }
@@ -323,10 +326,11 @@ mod tests {
 
         let targets = read_user_targets_from(&path);
         assert_eq!(targets.len(), 2);
-        assert_eq!(targets[0].adapter, "claude-code");
-        assert_eq!(targets[0].scope, Scope::Global);
-        assert_eq!(targets[1].adapter, "cursor");
-        assert_eq!(targets[1].scope, Scope::Local);
+        assert_eq!(
+            targets[0],
+            InstallTarget::platform("claude-code", Scope::Global)
+        );
+        assert_eq!(targets[1], InstallTarget::platform("cursor", Scope::Local));
     }
 
     #[test]
@@ -342,7 +346,10 @@ mod tests {
 
         let targets = read_user_targets_from(&path);
         assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].adapter, "claude-code");
+        assert_eq!(
+            targets[0],
+            InstallTarget::platform("claude-code", Scope::Global)
+        );
     }
 
     #[test]
@@ -370,10 +377,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nested").join("dir").join("config.toml");
 
-        let targets = vec![InstallTarget {
-            adapter: "claude-code".to_string(),
-            scope: Scope::Global,
-        }];
+        let targets = vec![InstallTarget::platform("claude-code", Scope::Global)];
         write_user_targets_to(&targets, &path).unwrap();
 
         assert!(path.exists());
@@ -389,23 +393,21 @@ mod tests {
         let path = dir.path().join("config.toml");
 
         let targets = vec![
-            InstallTarget {
-                adapter: "claude-code".to_string(),
-                scope: Scope::Global,
-            },
-            InstallTarget {
-                adapter: "gemini-cli".to_string(),
-                scope: Scope::Local,
-            },
+            InstallTarget::platform("claude-code", Scope::Global),
+            InstallTarget::platform("gemini-cli", Scope::Local),
         ];
         write_user_targets_to(&targets, &path).unwrap();
 
         let read_back = read_user_targets_from(&path);
         assert_eq!(read_back.len(), 2);
-        assert_eq!(read_back[0].adapter, "claude-code");
-        assert_eq!(read_back[0].scope, Scope::Global);
-        assert_eq!(read_back[1].adapter, "gemini-cli");
-        assert_eq!(read_back[1].scope, Scope::Local);
+        assert_eq!(
+            read_back[0],
+            InstallTarget::platform("claude-code", Scope::Global)
+        );
+        assert_eq!(
+            read_back[1],
+            InstallTarget::platform("gemini-cli", Scope::Local)
+        );
     }
 
     #[test]
@@ -413,10 +415,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
 
-        let targets = vec![InstallTarget {
-            adapter: "claude-code".to_string(),
-            scope: Scope::Global,
-        }];
+        let targets = vec![InstallTarget::platform("claude-code", Scope::Global)];
         write_user_targets_to(&targets, &path).unwrap();
 
         let content = std::fs::read_to_string(&path).unwrap();
@@ -431,17 +430,17 @@ mod tests {
     fn resolve_targets_into_prefers_manifest_targets() {
         let mut manifest = Manifest {
             entries: vec![],
-            install_targets: vec![InstallTarget {
-                adapter: "from-skillfile".to_string(),
-                scope: Scope::Global,
-            }],
+            install_targets: vec![InstallTarget::platform("from-skillfile", Scope::Global)],
         };
 
         // Even if user config has targets, manifest targets should win.
         // resolve_targets_into only fills when manifest is empty.
         resolve_targets_into(&mut manifest);
         assert_eq!(manifest.install_targets.len(), 1);
-        assert_eq!(manifest.install_targets[0].adapter, "from-skillfile");
+        assert_eq!(
+            manifest.install_targets[0],
+            InstallTarget::platform("from-skillfile", Scope::Global)
+        );
     }
 
     #[test]
@@ -458,7 +457,10 @@ mod tests {
 
         let targets = read_user_targets_from(&path);
         assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].adapter, "claude-code");
+        assert_eq!(
+            targets[0],
+            InstallTarget::platform("claude-code", Scope::Global)
+        );
     }
 
     // ---------------------------------------------------------------------------
@@ -499,10 +501,7 @@ mod tests {
         let path = dir.path().join("config.toml");
 
         // Write install entries first.
-        let targets = vec![InstallTarget {
-            adapter: "claude-code".to_string(),
-            scope: Scope::Global,
-        }];
+        let targets = vec![InstallTarget::platform("claude-code", Scope::Global)];
         write_user_targets_to(&targets, &path).unwrap();
 
         // Now write a token — install entries must survive.
@@ -525,10 +524,7 @@ mod tests {
         std::fs::write(&path, "github_token = \"ghp_keep_me\"\n").unwrap();
 
         // Overwrite install targets — token must survive.
-        let targets = vec![InstallTarget {
-            adapter: "gemini-cli".to_string(),
-            scope: Scope::Local,
-        }];
+        let targets = vec![InstallTarget::platform("gemini-cli", Scope::Local)];
         write_user_targets_to(&targets, &path).unwrap();
 
         let config = read_config_from(&path);
@@ -581,10 +577,7 @@ mod tests {
         )
         .unwrap();
 
-        let targets = vec![InstallTarget {
-            adapter: "claude-code".to_string(),
-            scope: Scope::Global,
-        }];
+        let targets = vec![InstallTarget::platform("claude-code", Scope::Global)];
         write_user_targets_to(&targets, &path).unwrap();
 
         let config = read_config_from(&path);
@@ -598,10 +591,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
 
-        let targets = vec![InstallTarget {
-            adapter: "claude-code".to_string(),
-            scope: Scope::Global,
-        }];
+        let targets = vec![InstallTarget::platform("claude-code", Scope::Global)];
         write_user_targets_to(&targets, &path).unwrap();
 
         write_gitlab_config_token_to("glpat-preserved", &path).unwrap();

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 similar = { workspace = true }
+shlex = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/core/src/models.rs
+++ b/crates/core/src/models.rs
@@ -264,16 +264,97 @@ impl fmt::Display for Entry {
 // InstallTarget
 // ---------------------------------------------------------------------------
 
-/// An install target line from the Skillfile: `install <adapter> <scope>`.
+/// An install target line from the Skillfile.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InstallTarget {
-    pub adapter: String,
-    pub scope: Scope,
+pub enum InstallTarget {
+    Platform {
+        adapter: String,
+        scope: Scope,
+    },
+    Path {
+        tool_name: String,
+        entity_type: EntityType,
+        path: String,
+    },
+}
+
+impl InstallTarget {
+    #[must_use]
+    pub fn platform(adapter: impl Into<String>, scope: Scope) -> Self {
+        Self::Platform {
+            adapter: adapter.into(),
+            scope,
+        }
+    }
+
+    #[must_use]
+    pub fn path(
+        tool_name: impl Into<String>,
+        entity_type: EntityType,
+        path: impl Into<String>,
+    ) -> Self {
+        Self::Path {
+            tool_name: tool_name.into(),
+            entity_type,
+            path: path.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn platform_name(&self) -> &str {
+        match self {
+            Self::Platform { adapter, .. } => adapter,
+            Self::Path { tool_name, .. } => tool_name,
+        }
+    }
+
+    #[must_use]
+    pub fn scope(&self) -> Option<Scope> {
+        match self {
+            Self::Platform { scope, .. } => Some(*scope),
+            Self::Path { .. } => None,
+        }
+    }
+
+    #[must_use]
+    pub fn entity_type(&self) -> Option<EntityType> {
+        match self {
+            Self::Platform { .. } => None,
+            Self::Path { entity_type, .. } => Some(*entity_type),
+        }
+    }
+
+    #[must_use]
+    pub fn path_str(&self) -> Option<&str> {
+        match self {
+            Self::Platform { .. } => None,
+            Self::Path { path, .. } => Some(path),
+        }
+    }
+
+    #[must_use]
+    pub fn manifest_line(&self) -> String {
+        match self {
+            Self::Platform { adapter, scope } => format!("install  {adapter}  {scope}"),
+            Self::Path {
+                tool_name,
+                entity_type,
+                path,
+            } => format!("install-path  {tool_name}  {entity_type}  {path}"),
+        }
+    }
 }
 
 impl fmt::Display for InstallTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} ({})", self.adapter, self.scope)
+        match self {
+            Self::Platform { adapter, scope } => write!(f, "{adapter} ({scope})"),
+            Self::Path {
+                tool_name,
+                entity_type,
+                path,
+            } => write!(f, "{tool_name} {entity_type} ({path})"),
+        }
     }
 }
 
@@ -505,13 +586,19 @@ mod tests {
 
     #[test]
     fn install_target_with_scope_enum() {
-        let t = InstallTarget {
-            adapter: "claude-code".into(),
-            scope: Scope::Global,
-        };
-        assert_eq!(t.adapter, "claude-code");
-        assert_eq!(t.scope, Scope::Global);
+        let t = InstallTarget::platform("claude-code", Scope::Global);
+        assert_eq!(t.platform_name(), "claude-code");
+        assert_eq!(t.scope(), Some(Scope::Global));
         assert_eq!(t.to_string(), "claude-code (global)");
+    }
+
+    #[test]
+    fn install_path_target_fields() {
+        let t = InstallTarget::path("openclaw", EntityType::Skill, "~/.openclaw/skills");
+        assert_eq!(t.platform_name(), "openclaw");
+        assert_eq!(t.entity_type(), Some(EntityType::Skill));
+        assert_eq!(t.path_str(), Some("~/.openclaw/skills"));
+        assert_eq!(t.to_string(), "openclaw skill (~/.openclaw/skills)");
     }
 
     #[test]
@@ -530,10 +617,7 @@ mod tests {
                 path: "test.md".into(),
             },
         };
-        let t = InstallTarget {
-            adapter: "claude-code".into(),
-            scope: Scope::Local,
-        };
+        let t = InstallTarget::platform("claude-code", Scope::Local);
         let m = Manifest {
             entries: vec![e],
             install_targets: vec![t],

--- a/crates/core/src/models.rs
+++ b/crates/core/src/models.rs
@@ -341,7 +341,8 @@ impl InstallTarget {
                 entity_type,
                 path,
             } => format!(
-                "install-path  {tool_name}  {entity_type}  {}",
+                "install-path  {}  {entity_type}  {}",
+                quote_manifest_field(tool_name),
                 quote_manifest_field(path)
             ),
         }
@@ -618,6 +619,12 @@ mod tests {
             t.manifest_line(),
             "install-path  openclaw  skill  './custom skills'"
         );
+    }
+
+    #[test]
+    fn install_path_manifest_line_quotes_tool_name_when_needed() {
+        let t = InstallTarget::path("my tool", EntityType::Skill, "./out");
+        assert_eq!(t.manifest_line(), "install-path  'my tool'  skill  ./out");
     }
 
     #[test]

--- a/crates/core/src/models.rs
+++ b/crates/core/src/models.rs
@@ -340,8 +340,18 @@ impl InstallTarget {
                 tool_name,
                 entity_type,
                 path,
-            } => format!("install-path  {tool_name}  {entity_type}  {path}"),
+            } => format!(
+                "install-path  {tool_name}  {entity_type}  {}",
+                quote_manifest_field(path)
+            ),
         }
+    }
+}
+
+fn quote_manifest_field(value: &str) -> String {
+    match shlex::try_quote(value) {
+        Ok(quoted) => quoted.into_owned(),
+        Err(_) => value.to_string(),
     }
 }
 
@@ -599,6 +609,33 @@ mod tests {
         assert_eq!(t.entity_type(), Some(EntityType::Skill));
         assert_eq!(t.path_str(), Some("~/.openclaw/skills"));
         assert_eq!(t.to_string(), "openclaw skill (~/.openclaw/skills)");
+    }
+
+    #[test]
+    fn install_path_manifest_line_quotes_path_when_needed() {
+        let t = InstallTarget::path("openclaw", EntityType::Skill, "./custom skills");
+        assert_eq!(
+            t.manifest_line(),
+            "install-path  openclaw  skill  './custom skills'"
+        );
+    }
+
+    #[test]
+    fn install_path_manifest_line_quotes_hash_path() {
+        let t = InstallTarget::path("openclaw", EntityType::Skill, "./skills#custom");
+        assert_eq!(
+            t.manifest_line(),
+            "install-path  openclaw  skill  './skills#custom'"
+        );
+    }
+
+    #[test]
+    fn install_path_manifest_line_quotes_embedded_double_quote() {
+        let t = InstallTarget::path("openclaw", EntityType::Skill, "./custom \"skills\"");
+        assert_eq!(
+            t.manifest_line(),
+            "install-path  openclaw  skill  './custom \"skills\"'"
+        );
     }
 
     #[test]

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -322,10 +322,8 @@ fn parse_install_line(parts: &[String], lineno: usize, acc: &mut ParseAccumulato
     }
     let scope_str = &parts[2];
     if let Some(scope) = Scope::parse(scope_str) {
-        acc.install_targets.push(InstallTarget {
-            adapter: parts[1].clone(),
-            scope,
-        });
+        acc.install_targets
+            .push(InstallTarget::platform(parts[1].clone(), scope));
     } else {
         let valid: Vec<&str> = Scope::ALL
             .iter()
@@ -337,6 +335,51 @@ fn parse_install_line(parts: &[String], lineno: usize, acc: &mut ParseAccumulato
             valid.join(", ")
         ));
     }
+}
+
+fn parse_install_path_line(parts: &[String], lineno: usize, acc: &mut ParseAccumulator) {
+    if parts.len() < 4 {
+        acc.warnings.push(format!(
+            "warning: line {lineno}: install-path line needs: tool-name entity-type path"
+        ));
+        return;
+    }
+
+    let tool_name = &parts[1];
+    if tool_name.trim().is_empty() {
+        acc.warnings.push(format!(
+            "warning: line {lineno}: install-path tool-name must not be empty"
+        ));
+        return;
+    }
+
+    let entity_type_str = &parts[2];
+    let Some(entity_type) = EntityType::parse(entity_type_str) else {
+        let valid: Vec<&str> = EntityType::ALL
+            .iter()
+            .map(super::models::EntityType::as_str)
+            .collect();
+        acc.warnings.push(format!(
+            "warning: line {lineno}: invalid entity type '{entity_type_str}', \
+             must be one of: {}",
+            valid.join(", ")
+        ));
+        return;
+    };
+
+    let path = &parts[3];
+    if path.trim().is_empty() {
+        acc.warnings.push(format!(
+            "warning: line {lineno}: install-path path must not be empty"
+        ));
+        return;
+    }
+
+    acc.install_targets.push(InstallTarget::path(
+        tool_name.clone(),
+        entity_type,
+        path.clone(),
+    ));
 }
 
 fn validate_and_push_entry(entry: Entry, lineno: usize, acc: &mut ParseAccumulator) {
@@ -429,6 +472,7 @@ pub fn parse_manifest(manifest_path: &Path) -> Result<ParseResult, SkillfileErro
 
         match parts[0].as_str() {
             "install" => parse_install_line(&parts, lineno, &mut acc),
+            "install-path" => parse_install_path_line(&parts, lineno, &mut acc),
             _ if KNOWN_SOURCES.contains(&parts[0].as_str()) => {
                 process_source_line(&parts, lineno, &mut acc);
             }
@@ -761,8 +805,7 @@ mod tests {
         let r = parse_manifest(&p).unwrap();
         assert_eq!(r.manifest.install_targets.len(), 1);
         let t = &r.manifest.install_targets[0];
-        assert_eq!(t.adapter, "claude-code");
-        assert_eq!(t.scope, Scope::Global);
+        assert_eq!(t, &InstallTarget::platform("claude-code", Scope::Global));
     }
 
     #[test]
@@ -774,8 +817,29 @@ mod tests {
         );
         let r = parse_manifest(&p).unwrap();
         assert_eq!(r.manifest.install_targets.len(), 2);
-        assert_eq!(r.manifest.install_targets[0].scope, Scope::Global);
-        assert_eq!(r.manifest.install_targets[1].scope, Scope::Local);
+        assert_eq!(
+            r.manifest.install_targets[0],
+            InstallTarget::platform("claude-code", Scope::Global)
+        );
+        assert_eq!(
+            r.manifest.install_targets[1],
+            InstallTarget::platform("claude-code", Scope::Local)
+        );
+    }
+
+    #[test]
+    fn install_path_target_parsed() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(
+            dir.path(),
+            "install-path  openclaw  skill  ~/.openclaw/skills",
+        );
+        let r = parse_manifest(&p).unwrap();
+        assert_eq!(r.manifest.install_targets.len(), 1);
+        assert_eq!(
+            r.manifest.install_targets[0],
+            InstallTarget::path("openclaw", EntityType::Skill, "~/.openclaw/skills")
+        );
     }
 
     #[test]
@@ -848,7 +912,25 @@ mod tests {
         let p = write_manifest(dir.path(), "install  claude-code  global  # primary target");
         let r = parse_manifest(&p).unwrap();
         assert_eq!(r.manifest.install_targets.len(), 1);
-        assert_eq!(r.manifest.install_targets[0].scope, Scope::Global);
+        assert_eq!(
+            r.manifest.install_targets[0],
+            InstallTarget::platform("claude-code", Scope::Global)
+        );
+    }
+
+    #[test]
+    fn inline_comment_on_install_path_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(
+            dir.path(),
+            "install-path  misc-target  agent  ./agents  # custom target",
+        );
+        let r = parse_manifest(&p).unwrap();
+        assert_eq!(r.manifest.install_targets.len(), 1);
+        assert_eq!(
+            r.manifest.install_targets[0],
+            InstallTarget::path("misc-target", EntityType::Agent, "./agents")
+        );
     }
 
     #[test]
@@ -970,7 +1052,10 @@ mod tests {
             let p = write_manifest(dir.path(), &format!("install  claude-code  {scope_str}"));
             let r = parse_manifest(&p).unwrap();
             assert_eq!(r.manifest.install_targets.len(), 1);
-            assert_eq!(r.manifest.install_targets[0].scope, *expected);
+            assert_eq!(
+                r.manifest.install_targets[0],
+                InstallTarget::platform("claude-code", *expected)
+            );
         }
     }
 
@@ -984,6 +1069,33 @@ mod tests {
             .warnings
             .iter()
             .any(|w| w.to_lowercase().contains("scope") || w.to_lowercase().contains("warning")));
+    }
+
+    #[test]
+    fn invalid_install_path_entity_type_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(dir.path(), "install-path  misc-target  bot  ./target");
+        let r = parse_manifest(&p).unwrap();
+        assert!(r.manifest.install_targets.is_empty());
+        assert!(r.warnings.iter().any(|w| w.contains("invalid entity type")));
+    }
+
+    #[test]
+    fn empty_install_path_tool_name_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(dir.path(), "install-path  \"\"  skill  ./target");
+        let r = parse_manifest(&p).unwrap();
+        assert!(r.manifest.install_targets.is_empty());
+        assert!(r.warnings.iter().any(|w| w.contains("tool-name")));
+    }
+
+    #[test]
+    fn empty_install_path_path_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(dir.path(), "install-path  misc-target  skill  \"\"");
+        let r = parse_manifest(&p).unwrap();
+        assert!(r.manifest.install_targets.is_empty());
+        assert!(r.warnings.iter().any(|w| w.contains("path")));
     }
 
     // -------------------------------------------------------------------
@@ -1020,10 +1132,7 @@ mod tests {
         assert_eq!(r.manifest.install_targets.len(), 1);
         assert_eq!(
             r.manifest.install_targets[0],
-            InstallTarget {
-                adapter: "claude-code".into(),
-                scope: Scope::Global,
-            }
+            InstallTarget::platform("claude-code", Scope::Global)
         );
     }
 

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -40,34 +40,12 @@ fn is_valid_name(name: &str) -> bool {
             .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')
 }
 
-fn flush_token(current: &mut String, parts: &mut Vec<String>) {
-    if !current.is_empty() {
-        parts.push(std::mem::take(current));
-    }
-}
-
-/// Split a manifest line respecting double-quoted fields.
+/// Split a manifest line using shell-style field quoting.
 ///
 /// Unquoted lines split identically to whitespace split.
-/// Double-quoted fields preserve internal spaces.
-fn split_line(line: &str) -> Vec<String> {
-    let mut parts = Vec::new();
-    let mut current = String::new();
-    let mut in_quotes = false;
-
-    for ch in line.chars() {
-        if ch == '"' {
-            in_quotes = !in_quotes;
-            continue;
-        }
-        if ch.is_whitespace() && !in_quotes {
-            flush_token(&mut current, &mut parts);
-            continue;
-        }
-        current.push(ch);
-    }
-    flush_token(&mut current, &mut parts);
-    parts
+/// Quoted fields preserve internal spaces and comment markers.
+fn split_line(line: &str) -> Option<Vec<String>> {
+    shlex::split(line)
 }
 
 fn strip_inline_comment(parts: Vec<String>) -> Vec<String> {
@@ -463,7 +441,12 @@ pub fn parse_manifest(manifest_path: &Path) -> Result<ParseResult, SkillfileErro
             continue;
         }
 
-        let parts = strip_inline_comment(split_line(line));
+        let Some(parts) = split_line(line) else {
+            acc.warnings
+                .push(format!("warning: line {lineno}: invalid quoting, skipping"));
+            continue;
+        };
+        let parts = strip_inline_comment(parts);
         if parts.len() < 2 {
             acc.warnings
                 .push(format!("warning: line {lineno}: too few fields, skipping"));
@@ -495,7 +478,7 @@ pub fn parse_manifest(manifest_path: &Path) -> Result<ParseResult, SkillfileErro
 
 #[must_use]
 pub fn parse_manifest_line(line: &str) -> Option<Entry> {
-    let parts = split_line(line);
+    let parts = split_line(line)?;
     let parts = strip_inline_comment(parts);
     if parts.len() < 3 {
         return None;
@@ -1170,8 +1153,8 @@ mod tests {
             &p,
             [
                 240, 174, 174, 174, 240, 174, 174, 170, 240, 105, 116, 104, 117, 97, 10, 103, 105,
-                116, 104, 117, 98, 12, 97, 103, 101, 110, 116, 12, 117, 115, 64, 116, 97, 108, 170,
-                170, 115, 47, 108, 1, 57, 12, 108, 12, 59, 239, 191, 10,
+                116, 104, 117, 98, 32, 97, 103, 101, 110, 116, 32, 117, 115, 64, 116, 97, 108, 170,
+                170, 115, 47, 108, 1, 57, 32, 108, 32, 59, 239, 191, 10,
             ],
         )
         .unwrap();
@@ -1232,7 +1215,7 @@ mod tests {
     #[test]
     fn split_line_simple() {
         assert_eq!(
-            split_line("github  agent  owner/repo  agent.md"),
+            split_line("github  agent  owner/repo  agent.md").unwrap(),
             vec!["github", "agent", "owner/repo", "agent.md"]
         );
     }
@@ -1240,15 +1223,32 @@ mod tests {
     #[test]
     fn split_line_quoted() {
         assert_eq!(
-            split_line("local  skill  \"my dir/foo.md\""),
+            split_line("local  skill  \"my dir/foo.md\"").unwrap(),
             vec!["local", "skill", "my dir/foo.md"]
         );
     }
 
     #[test]
+    fn split_line_single_quoted() {
+        assert_eq!(
+            split_line("local  skill  'my dir/foo.md'").unwrap(),
+            vec!["local", "skill", "my dir/foo.md"]
+        );
+    }
+
+    #[test]
+    fn invalid_quoting_warns_and_skips_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_manifest(dir.path(), "local  skill  \"unterminated.md");
+        let r = parse_manifest(&p).unwrap();
+        assert!(r.manifest.entries.is_empty());
+        assert!(r.warnings.iter().any(|w| w.contains("invalid quoting")));
+    }
+
+    #[test]
     fn split_line_tabs() {
         assert_eq!(
-            split_line("local\tskill\tfoo.md"),
+            split_line("local\tskill\tfoo.md").unwrap(),
             vec!["local", "skill", "foo.md"]
         );
     }

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -80,7 +80,11 @@ pub fn resolve_explicit_owner_repo_ref(
     at_ref: Option<String>,
     positional_ref: Option<&str>,
 ) -> Option<String> {
-    at_ref.or_else(|| positional_ref.map(String::from))
+    at_ref.filter(|ref_| !ref_.trim().is_empty()).or_else(|| {
+        positional_ref
+            .filter(|ref_| !ref_.trim().is_empty())
+            .map(String::from)
+    })
 }
 
 /// Resolve the effective ref from the `@`-syntax parsed ref and an explicit positional ref.
@@ -106,6 +110,17 @@ fn parse_github_owner_repo(
          — expected 'owner/repo' or 'owner/repo@ref' format"
     ));
     None
+}
+
+fn validate_repo_path(path: &str, source_type: &str, lineno: usize) -> Result<(), String> {
+    let path = path.trim();
+    if path == "." || Path::new(path).file_name().is_some() {
+        return Ok(());
+    }
+    Err(format!(
+        "warning: line {lineno}: {source_type} entry has invalid repository path '{path}' \
+         — expected a non-root path or '.'"
+    ))
 }
 
 /// Parse a github entry line. parts[0]=source_type, parts[1]=entity_type, etc.
@@ -147,6 +162,11 @@ fn parse_github_entry(
         (parts[2].clone(), parsed_repo, &parts[4], ref_)
     };
 
+    if let Err(warning) = validate_repo_path(path_in_repo, "github", lineno) {
+        warnings.push(warning);
+        return (None, warnings);
+    }
+
     let entry = Entry {
         entity_type,
         name,
@@ -174,7 +194,7 @@ fn parse_gitlab_entry(
             ));
             return (None, warnings);
         }
-        let ref_ = parts.get(4).map_or(DEFAULT_REF, String::as_str);
+        let ref_ = resolve_owner_repo_ref(None, parts.get(4).map(String::as_str));
         (infer_name(&parts[3]), &parts[2], &parts[3], ref_)
     } else {
         if parts.len() < 5 {
@@ -191,9 +211,14 @@ fn parse_gitlab_entry(
             ));
             return (None, warnings);
         }
-        let ref_ = parts.get(5).map_or(DEFAULT_REF, String::as_str);
+        let ref_ = resolve_owner_repo_ref(None, parts.get(5).map(String::as_str));
         (parts[2].clone(), &parts[3], &parts[4], ref_)
     };
+
+    if let Err(warning) = validate_repo_path(path_in_repo, "gitlab", lineno) {
+        warnings.push(warning);
+        return (None, warnings);
+    }
 
     let entry = Entry {
         entity_type,
@@ -201,7 +226,7 @@ fn parse_gitlab_entry(
         source: SourceFields::Gitlab {
             owner_repo: owner_repo.clone(),
             path_in_repo: path_in_repo.clone(),
-            ref_: ref_.to_owned(),
+            ref_,
         },
     };
     (Some(entry), warnings)
@@ -540,6 +565,60 @@ mod tests {
         p
     }
 
+    fn assert_repo_path_rejected(source_type: &str, path: &str) {
+        for line in [
+            format!("{source_type}  skill  owner/repo  {path}"),
+            format!("{source_type}  skill  named  owner/repo  {path}"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let p = write_manifest(dir.path(), &line);
+            let r = parse_manifest(&p).unwrap();
+            assert!(r.manifest.entries.is_empty(), "accepted: {line}");
+            assert!(
+                r.warnings.iter().any(|warning| warning
+                    .contains(&format!("{source_type} entry has invalid repository path"))),
+                "missing warning for: {line}"
+            );
+        }
+    }
+
+    fn assert_dot_repo_path_preserved(source_type: &str) {
+        for line in [
+            format!("{source_type}  skill  owner/repo  ."),
+            format!("{source_type}  skill  named  owner/repo  ."),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let p = write_manifest(dir.path(), &line);
+            let r = parse_manifest(&p).unwrap();
+            assert_eq!(r.manifest.entries.len(), 1, "rejected: {line}");
+            assert!(matches!(
+                &r.manifest.entries[0].source,
+                SourceFields::Github { path_in_repo, .. }
+                    | SourceFields::Gitlab { path_in_repo, .. }
+                    if path_in_repo == "."
+            ));
+        }
+    }
+
+    fn assert_empty_repo_ref_defaults_to_main(source_type: &str) {
+        for line in [
+            format!("{source_type}  skill  owner/repo  path  \"\""),
+            format!("{source_type}  skill  named  owner/repo  path  \"\""),
+            format!("{source_type}  skill  owner/repo  path  \"   \""),
+            format!("{source_type}  skill  named  owner/repo  path  \"   \""),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let p = write_manifest(dir.path(), &line);
+            let r = parse_manifest(&p).unwrap();
+            assert_eq!(r.manifest.entries.len(), 1, "rejected: {line}");
+            assert!(matches!(
+                &r.manifest.entries[0].source,
+                SourceFields::Github { ref_, .. } | SourceFields::Gitlab { ref_, .. }
+                    if ref_ == DEFAULT_REF
+            ));
+        }
+    }
+
     // -------------------------------------------------------------------
     // Existing entry types (explicit name + ref)
     // -------------------------------------------------------------------
@@ -680,6 +759,38 @@ mod tests {
         );
         let r = parse_manifest(&p).unwrap();
         assert_eq!(r.manifest.entries[0].ref_(), "main");
+    }
+
+    #[test]
+    fn repository_sources_reject_empty_and_root_only_paths() {
+        for (source_type, path) in [
+            ("github", "\"\""),
+            ("github", "\"   \""),
+            ("github", "/"),
+            ("github", "//"),
+            ("github", "/./"),
+            ("gitlab", "\"\""),
+            ("gitlab", "\"   \""),
+            ("gitlab", "/"),
+            ("gitlab", "//"),
+            ("gitlab", "/./"),
+        ] {
+            assert_repo_path_rejected(source_type, path);
+        }
+    }
+
+    #[test]
+    fn repository_sources_preserve_dot_root_path() {
+        for source_type in ["github", "gitlab"] {
+            assert_dot_repo_path_preserved(source_type);
+        }
+    }
+
+    #[test]
+    fn repository_sources_default_empty_refs() {
+        for source_type in ["github", "gitlab"] {
+            assert_empty_repo_ref_defaults_to_main(source_type);
+        }
     }
 
     // -------------------------------------------------------------------

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -19,8 +19,9 @@ use skillfile_core::progress;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, is_dir_entry};
 use skillfile_sources::sync::{cmd_sync, vendor_dir_for};
 
-use crate::adapter::{adapters, AdapterScope, DeployRequest, DirInstallMode, PlatformAdapter};
+use crate::adapter::{DeployRequest, DirInstallMode};
 use crate::paths::source_path;
+use crate::target::ResolvedInstallTarget;
 
 static SNAPSHOT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -168,12 +169,6 @@ fn divergent_auto_pin_error(entry_name: &str, labels: &[String]) -> SkillfileErr
     ))
 }
 
-fn target_adapter(target: &InstallTarget) -> Result<&'static dyn PlatformAdapter, SkillfileError> {
-    adapters()
-        .get(&target.adapter)
-        .ok_or_else(|| SkillfileError::Manifest(format!("unknown adapter '{}'", target.adapter)))
-}
-
 struct SingleInstalledVariant {
     label: String,
     content: String,
@@ -186,15 +181,11 @@ fn installed_single_file_variants(
 ) -> Result<Vec<SingleInstalledVariant>, SkillfileError> {
     let mut variants = Vec::new();
     for target in &manifest.install_targets {
-        let adapter = target_adapter(target)?;
-        if !adapter.supports(entry.entity_type) {
+        let resolved = ResolvedInstallTarget::from_target(target)?;
+        if !resolved.supports(entry.entity_type) {
             continue;
         }
-        let scope = AdapterScope {
-            scope: target.scope,
-            repo_root,
-        };
-        let path = adapter.installed_path(entry, &scope);
+        let path = resolved.installed_path(entry, repo_root);
         if !path.exists() {
             continue;
         }
@@ -350,15 +341,11 @@ fn installed_dir_variants(
 ) -> Result<Vec<DirInstalledVariant>, SkillfileError> {
     let mut variants = Vec::new();
     for target in &manifest.install_targets {
-        let adapter = target_adapter(target)?;
-        if !adapter.supports(entry.entity_type) {
+        let resolved = ResolvedInstallTarget::from_target(target)?;
+        if !resolved.supports(entry.entity_type) {
             continue;
         }
-        let scope = AdapterScope {
-            scope: target.scope,
-            repo_root,
-        };
-        let files = adapter.installed_dir_files(entry, &scope);
+        let files = resolved.installed_dir_files(entry, repo_root);
         if files.is_empty() {
             continue;
         }
@@ -732,7 +719,7 @@ struct InstallValidationCtx<'a> {
     target: &'a InstallTarget,
     repo_root: &'a Path,
     source: &'a Path,
-    adapter: &'a dyn PlatformAdapter,
+    resolved_target: ResolvedInstallTarget<'a>,
     is_dir: bool,
     opts: &'a InstallOptions,
 }
@@ -771,17 +758,18 @@ fn nested_expected_paths(source: &Path, dest_root: &Path) -> HashMap<String, Pat
 }
 
 fn planned_install_paths(ctx: &InstallValidationCtx<'_>) -> HashMap<String, PathBuf> {
-    let scope = AdapterScope {
-        scope: ctx.target.scope,
-        repo_root: ctx.repo_root,
-    };
-    let target_dir = ctx.adapter.target_dir(ctx.entry.entity_type, &scope);
+    let target_dir = ctx
+        .resolved_target
+        .target_dir(ctx.entry.entity_type, ctx.repo_root);
     if !ctx.is_dir {
         let key = format!("{}.md", ctx.entry.name);
-        return HashMap::from([(key, ctx.adapter.installed_path(ctx.entry, &scope))]);
+        return HashMap::from([(
+            key,
+            ctx.resolved_target.installed_path(ctx.entry, ctx.repo_root),
+        )]);
     }
 
-    match ctx.adapter.dir_mode(ctx.entry.entity_type) {
+    match ctx.resolved_target.dir_mode(ctx.entry.entity_type) {
         Some(DirInstallMode::Flat) => flat_expected_paths(ctx.source, &target_dir),
         _ => nested_expected_paths(ctx.source, &target_dir.join(&ctx.entry.name)),
     }
@@ -798,14 +786,12 @@ fn patch_effect_path(ctx: &InstallValidationCtx<'_>) -> PathBuf {
 }
 
 fn install_effect_paths(ctx: &InstallValidationCtx<'_>) -> Vec<PathBuf> {
-    let scope = AdapterScope {
-        scope: ctx.target.scope,
-        repo_root: ctx.repo_root,
-    };
-    let target_dir = ctx.adapter.target_dir(ctx.entry.entity_type, &scope);
+    let target_dir = ctx
+        .resolved_target
+        .target_dir(ctx.entry.entity_type, ctx.repo_root);
     let mut paths = if !ctx.is_dir {
-        vec![ctx.adapter.installed_path(ctx.entry, &scope)]
-    } else if ctx.adapter.dir_mode(ctx.entry.entity_type) == Some(DirInstallMode::Flat) {
+        vec![ctx.resolved_target.installed_path(ctx.entry, ctx.repo_root)]
+    } else if ctx.resolved_target.dir_mode(ctx.entry.entity_type) == Some(DirInstallMode::Flat) {
         flat_expected_paths(ctx.source, &target_dir)
             .into_values()
             .collect()
@@ -813,7 +799,7 @@ fn install_effect_paths(ctx: &InstallValidationCtx<'_>) -> Vec<PathBuf> {
         vec![target_dir.join(&ctx.entry.name)]
     };
 
-    if ctx.adapter.dir_mode(ctx.entry.entity_type) != Some(DirInstallMode::Flat) {
+    if ctx.resolved_target.dir_mode(ctx.entry.entity_type) != Some(DirInstallMode::Flat) {
         paths.push(target_dir.join(format!("{}.md", ctx.entry.name)));
     }
     paths.push(patch_effect_path(ctx));
@@ -837,11 +823,10 @@ fn install_effect_paths_for_target(
     target: &InstallTarget,
     repo_root: &Path,
 ) -> Vec<PathBuf> {
-    let all_adapters = adapters();
-    let Some(adapter) = all_adapters.get(&target.adapter) else {
+    let Ok(resolved_target) = ResolvedInstallTarget::from_target(target) else {
         return Vec::new();
     };
-    if !adapter.supports(entry.entity_type) {
+    if !resolved_target.supports(entry.entity_type) {
         return Vec::new();
     }
     let Some(source) = source_path(entry, repo_root).filter(|path| path.exists()) else {
@@ -853,7 +838,7 @@ fn install_effect_paths_for_target(
         target,
         repo_root,
         source: &source,
-        adapter,
+        resolved_target,
         is_dir: is_dir_entry(entry) || source.is_dir(),
         opts: &default_opts,
     };
@@ -966,13 +951,16 @@ fn deploy_and_patch_entry(
     validation_ctx: &InstallValidationCtx<'_>,
     plan: &InstallPlan,
 ) -> Result<InstallOutcome, SkillfileError> {
-    let installed = validation_ctx.adapter.deploy_entry(&DeployRequest {
-        entry: validation_ctx.entry,
-        source: validation_ctx.source,
-        scope: validation_ctx.target.scope,
-        repo_root: validation_ctx.repo_root,
-        opts: validation_ctx.opts,
-    });
+    let installed = validation_ctx
+        .resolved_target
+        .adapter()
+        .deploy_entry(&DeployRequest {
+            entry: validation_ctx.entry,
+            source: validation_ctx.source,
+            scope: validation_ctx.resolved_target.scope(),
+            repo_root: validation_ctx.repo_root,
+            opts: validation_ctx.opts,
+        });
 
     if validation_ctx.opts.dry_run {
         return Ok(InstallOutcome::Skipped(InstallSkipReason::DryRun));
@@ -1007,12 +995,11 @@ pub fn install_entry_with_outcome(
     let default_opts = InstallOptions::default();
     let opts = ctx.opts.unwrap_or(&default_opts);
 
-    let all_adapters = adapters();
-    let Some(adapter) = all_adapters.get(&target.adapter) else {
+    let Ok(resolved_target) = ResolvedInstallTarget::from_target(target) else {
         return Ok(InstallOutcome::Skipped(InstallSkipReason::UnknownAdapter));
     };
 
-    if !adapter.supports(entry.entity_type) {
+    if !resolved_target.supports(entry.entity_type) {
         return Ok(InstallOutcome::Skipped(
             InstallSkipReason::UnsupportedEntity,
         ));
@@ -1032,7 +1019,7 @@ pub fn install_entry_with_outcome(
         target,
         repo_root: ctx.repo_root,
         source: &source,
-        adapter,
+        resolved_target,
         is_dir,
         opts,
     };
@@ -1168,18 +1155,18 @@ fn install_entry_or_conflict(
 
 fn deploy_all(manifest: &Manifest, ctx: &DeployCtx<'_>) -> Result<(), SkillfileError> {
     let mode = if ctx.opts.dry_run { " [dry-run]" } else { "" };
-    let all_adapters = adapters();
 
     for target in &manifest.install_targets {
-        if !all_adapters.contains(&target.adapter) {
-            eprintln!("warning: unknown platform '{}', skipping", target.adapter);
+        if matches!(target, InstallTarget::Platform { .. })
+            && ResolvedInstallTarget::from_target(target).is_err()
+        {
+            eprintln!(
+                "warning: unknown platform '{}', skipping",
+                target.platform_name()
+            );
             continue;
         }
-        progress!(
-            "Installing for {} ({}){mode}...",
-            target.adapter,
-            target.scope
-        );
+        progress!("Installing for {target}{mode}...");
         for entry in &manifest.entries {
             install_entry_or_conflict(entry, target, ctx)?;
         }
@@ -1240,7 +1227,7 @@ fn print_first_install_hint(manifest: &Manifest) {
     let platforms: Vec<String> = manifest
         .install_targets
         .iter()
-        .map(|t| format!("{} ({})", t.adapter, t.scope))
+        .map(ToString::to_string)
         .collect();
     progress!("  Configured platforms: {}", platforms.join(", "));
     progress!("  Run `skillfile init` to add or change platforms.");
@@ -1410,10 +1397,7 @@ mod tests {
     }
 
     fn make_target(adapter: &str, scope: Scope) -> InstallTarget {
-        InstallTarget {
-            adapter: adapter.into(),
-            scope,
-        }
+        InstallTarget::platform(adapter, scope)
     }
 
     // -- install_entry: local source --

--- a/crates/deploy/src/lib.rs
+++ b/crates/deploy/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod adapter;
 pub mod install;
 pub mod paths;
+pub mod target;

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -7,7 +7,8 @@ use skillfile_core::patch::walkdir;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, meta_sha};
 use skillfile_sources::sync::vendor_dir_for;
 
-use crate::adapter::{adapters, AdapterScope, PlatformAdapter};
+use crate::adapter::{adapters, AdapterScope};
+use crate::target::ResolvedInstallTarget;
 
 pub fn resolve_target_dir(
     adapter_name: &str,
@@ -26,12 +27,8 @@ pub fn installed_path(
     manifest: &Manifest,
     repo_root: &Path,
 ) -> Result<PathBuf, SkillfileError> {
-    let adapter = first_target(manifest)?;
-    let ctx = AdapterScope {
-        scope: manifest.install_targets[0].scope,
-        repo_root,
-    };
-    Ok(adapter.installed_path(entry, &ctx))
+    let target = first_supporting_target(entry, manifest)?;
+    Ok(target.installed_path(entry, repo_root))
 }
 
 /// Installed paths for a single-file entry across all install targets.
@@ -42,15 +39,11 @@ pub fn installed_paths(
 ) -> Result<Vec<PathBuf>, SkillfileError> {
     let mut paths = Vec::new();
     for target in &manifest.install_targets {
-        let adapter = adapter_for(target)?;
-        if !adapter.supports(entry.entity_type) {
+        let target = resolved_target(target)?;
+        if !target.supports(entry.entity_type) {
             continue;
         }
-        let ctx = AdapterScope {
-            scope: target.scope,
-            repo_root,
-        };
-        paths.push(adapter.installed_path(entry, &ctx));
+        paths.push(target.installed_path(entry, repo_root));
     }
     Ok(paths)
 }
@@ -61,12 +54,8 @@ pub fn installed_dir_files(
     manifest: &Manifest,
     repo_root: &Path,
 ) -> Result<HashMap<String, PathBuf>, SkillfileError> {
-    let adapter = first_target(manifest)?;
-    let ctx = AdapterScope {
-        scope: manifest.install_targets[0].scope,
-        repo_root,
-    };
-    Ok(adapter.installed_dir_files(entry, &ctx))
+    let target = first_supporting_target(entry, manifest)?;
+    Ok(target.installed_dir_files(entry, repo_root))
 }
 
 /// Installed file maps for a directory entry across all install targets.
@@ -77,15 +66,11 @@ pub fn installed_dir_file_sets(
 ) -> Result<Vec<HashMap<String, PathBuf>>, SkillfileError> {
     let mut file_sets = Vec::new();
     for target in &manifest.install_targets {
-        let adapter = adapter_for(target)?;
-        if !adapter.supports(entry.entity_type) {
+        let target = resolved_target(target)?;
+        if !target.supports(entry.entity_type) {
             continue;
         }
-        let ctx = AdapterScope {
-            scope: target.scope,
-            repo_root,
-        };
-        file_sets.push(adapter.installed_dir_files(entry, &ctx));
+        file_sets.push(target.installed_dir_files(entry, repo_root));
     }
     Ok(file_sets)
 }
@@ -130,21 +115,31 @@ fn remote_dir_cache_is_complete(entry: &Entry, vdir: &Path) -> bool {
     }
 }
 
-fn first_target(manifest: &Manifest) -> Result<&'static dyn PlatformAdapter, SkillfileError> {
+fn first_supporting_target<'a>(
+    entry: &Entry,
+    manifest: &'a Manifest,
+) -> Result<ResolvedInstallTarget<'a>, SkillfileError> {
     if manifest.install_targets.is_empty() {
         return Err(SkillfileError::Manifest(
             "no install targets configured — run `skillfile install` first".into(),
         ));
     }
-    adapter_for(&manifest.install_targets[0])
+    for target in &manifest.install_targets {
+        let resolved = resolved_target(target)?;
+        if resolved.supports(entry.entity_type) {
+            return Ok(resolved);
+        }
+    }
+    Err(SkillfileError::Manifest(format!(
+        "no install target supports {} '{}'",
+        entry.entity_type, entry.name
+    )))
 }
 
-fn adapter_for(
+fn resolved_target(
     target: &skillfile_core::models::InstallTarget,
-) -> Result<&'static dyn PlatformAdapter, SkillfileError> {
-    adapters()
-        .get(&target.adapter)
-        .ok_or_else(|| SkillfileError::Manifest(format!("unknown adapter '{}'", target.adapter)))
+) -> Result<ResolvedInstallTarget<'_>, SkillfileError> {
+    ResolvedInstallTarget::from_target(target)
 }
 
 #[cfg(test)]
@@ -210,10 +205,7 @@ mod tests {
         };
         let manifest = Manifest {
             entries: vec![entry.clone()],
-            install_targets: vec![InstallTarget {
-                adapter: "unknown".into(),
-                scope: Scope::Global,
-            }],
+            install_targets: vec![InstallTarget::platform("unknown", Scope::Global)],
         };
         let result = installed_path(&entry, &manifest, Path::new("/tmp"));
         assert!(result.is_err());
@@ -234,10 +226,7 @@ mod tests {
         };
         let manifest = Manifest {
             entries: vec![entry.clone()],
-            install_targets: vec![InstallTarget {
-                adapter: "claude-code".into(),
-                scope: Scope::Local,
-            }],
+            install_targets: vec![InstallTarget::platform("claude-code", Scope::Local)],
         };
         let result = installed_path(&entry, &manifest, tmp.path()).unwrap();
         assert_eq!(result, tmp.path().join(".claude/agents/test.md"));
@@ -258,14 +247,8 @@ mod tests {
         let manifest = Manifest {
             entries: vec![entry.clone()],
             install_targets: vec![
-                InstallTarget {
-                    adapter: "claude-code".into(),
-                    scope: Scope::Local,
-                },
-                InstallTarget {
-                    adapter: "copilot".into(),
-                    scope: Scope::Local,
-                },
+                InstallTarget::platform("claude-code", Scope::Local),
+                InstallTarget::platform("copilot", Scope::Local),
             ],
         };
 
@@ -308,10 +291,7 @@ mod tests {
         };
         let manifest = Manifest {
             entries: vec![entry.clone()],
-            install_targets: vec![InstallTarget {
-                adapter: "claude-code".into(),
-                scope: Scope::Local,
-            }],
+            install_targets: vec![InstallTarget::platform("claude-code", Scope::Local)],
         };
         let skill_dir = tmp.path().join(".claude/skills/my-skill");
         std::fs::create_dir_all(&skill_dir).unwrap();
@@ -336,14 +316,8 @@ mod tests {
         let manifest = Manifest {
             entries: vec![entry.clone()],
             install_targets: vec![
-                InstallTarget {
-                    adapter: "claude-code".into(),
-                    scope: Scope::Local,
-                },
-                InstallTarget {
-                    adapter: "copilot".into(),
-                    scope: Scope::Local,
-                },
+                InstallTarget::platform("claude-code", Scope::Local),
+                InstallTarget::platform("copilot", Scope::Local),
             ],
         };
         let claude_dir = tmp.path().join(".claude/skills/my-skill");
@@ -372,10 +346,7 @@ mod tests {
         };
         let manifest = Manifest {
             entries: vec![entry.clone()],
-            install_targets: vec![InstallTarget {
-                adapter: "claude-code".into(),
-                scope: Scope::Local,
-            }],
+            install_targets: vec![InstallTarget::platform("claude-code", Scope::Local)],
         };
         // Create vendor cache
         let vdir = tmp.path().join(".skillfile/cache/agents/my-agents");

--- a/crates/deploy/src/target.rs
+++ b/crates/deploy/src/target.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use skillfile_core::error::SkillfileError;
+use skillfile_core::models::{EntityType, Entry, InstallTarget, Scope};
+
+use crate::adapter::{
+    adapters, AdapterScope, DirInstallMode, EntityConfig, FileSystemAdapter, PlatformAdapter,
+};
+
+pub enum ResolvedInstallTarget<'a> {
+    BuiltIn {
+        adapter: &'a dyn PlatformAdapter,
+        scope: Scope,
+    },
+    Explicit {
+        adapter: FileSystemAdapter,
+    },
+}
+
+impl<'a> ResolvedInstallTarget<'a> {
+    pub fn from_target(target: &'a InstallTarget) -> Result<Self, SkillfileError> {
+        match target {
+            InstallTarget::Platform { adapter, scope } => Ok(Self::BuiltIn {
+                adapter: built_in_adapter(adapter)?,
+                scope: *scope,
+            }),
+            InstallTarget::Path {
+                tool_name,
+                entity_type,
+                path,
+            } => Ok(Self::Explicit {
+                adapter: explicit_adapter(tool_name, *entity_type, path),
+            }),
+        }
+    }
+
+    pub fn supports(&self, entity_type: EntityType) -> bool {
+        self.adapter().supports(entity_type)
+    }
+
+    pub fn scope(&self) -> Scope {
+        match self {
+            Self::BuiltIn { scope, .. } => *scope,
+            Self::Explicit { .. } => Scope::Global,
+        }
+    }
+
+    pub fn adapter(&self) -> &dyn PlatformAdapter {
+        match self {
+            Self::BuiltIn { adapter, .. } => *adapter,
+            Self::Explicit { adapter } => adapter,
+        }
+    }
+
+    pub fn adapter_scope<'b>(&self, repo_root: &'b Path) -> AdapterScope<'b> {
+        AdapterScope {
+            scope: self.scope(),
+            repo_root,
+        }
+    }
+
+    pub fn target_dir(&self, entity_type: EntityType, repo_root: &Path) -> PathBuf {
+        let scope = self.adapter_scope(repo_root);
+        self.adapter().target_dir(entity_type, &scope)
+    }
+
+    pub fn dir_mode(&self, entity_type: EntityType) -> Option<DirInstallMode> {
+        self.adapter().dir_mode(entity_type)
+    }
+
+    pub fn installed_path(&self, entry: &Entry, repo_root: &Path) -> PathBuf {
+        let scope = self.adapter_scope(repo_root);
+        self.adapter().installed_path(entry, &scope)
+    }
+
+    pub fn installed_dir_files(&self, entry: &Entry, repo_root: &Path) -> HashMap<String, PathBuf> {
+        let scope = self.adapter_scope(repo_root);
+        self.adapter().installed_dir_files(entry, &scope)
+    }
+}
+
+fn built_in_adapter(adapter: &str) -> Result<&'static dyn PlatformAdapter, SkillfileError> {
+    adapters()
+        .get(adapter)
+        .ok_or_else(|| SkillfileError::Manifest(format!("unknown adapter '{adapter}'")))
+}
+
+fn explicit_adapter(tool_name: &str, entity_type: EntityType, path: &str) -> FileSystemAdapter {
+    let mut entities = HashMap::new();
+    entities.insert(
+        entity_type,
+        EntityConfig {
+            global_path: path.to_string(),
+            local_path: path.to_string(),
+            dir_mode: default_dir_mode(entity_type),
+        },
+    );
+    FileSystemAdapter::new(tool_name, entities)
+}
+
+fn default_dir_mode(entity_type: EntityType) -> DirInstallMode {
+    match entity_type {
+        EntityType::Skill => DirInstallMode::Nested,
+        EntityType::Agent => DirInstallMode::Flat,
+    }
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -21,6 +21,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,16 +318,20 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "skillfile-core"
-version = "1.6.4"
+version = "1.7.3"
 dependencies = [
  "serde",
  "serde_json",
+ "shlex",
  "similar",
  "thiserror",
 ]

--- a/fuzz/fuzz_targets/parse_manifest.rs
+++ b/fuzz/fuzz_targets/parse_manifest.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use skillfile_core::models::SourceFields;
+use skillfile_core::models::{InstallTarget, SourceFields};
 use std::collections::HashSet;
 use std::io::Write;
 
@@ -107,12 +107,25 @@ fuzz_target!(|data: &[u8]| {
         }
     }
 
-    // 4. Install target invariants — adapter and scope are well-formed.
+    // 4. Install target invariants — platform and path targets are well-formed.
     for target in &manifest.install_targets {
-        assert!(
-            !target.adapter.is_empty(),
-            "install target has empty adapter name",
-        );
+        match target {
+            InstallTarget::Platform { adapter, .. } => {
+                assert!(
+                    !adapter.is_empty(),
+                    "install target has empty adapter name",
+                );
+            }
+            InstallTarget::Path {
+                tool_name, path, ..
+            } => {
+                assert!(
+                    !tool_name.is_empty(),
+                    "install-path target has empty tool name",
+                );
+                assert!(!path.is_empty(), "install-path target has empty path");
+            }
+        }
     }
 
     // 5. Warnings are well-formed strings (non-empty, no panics during formatting).

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,6 +21,10 @@ name = "install_directory_layout"
 path = "install_directory_layout.rs"
 
 [[test]]
+name = "install_path"
+path = "install_path.rs"
+
+[[test]]
 name = "junie"
 path = "junie.rs"
 

--- a/tests/install_path.rs
+++ b/tests/install_path.rs
@@ -1,0 +1,67 @@
+use skillfile_functional_tests::sf;
+
+#[test]
+fn install_path_deploys_skill_nested_and_agent_flat() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    std::fs::create_dir_all(root.join("agents")).unwrap();
+    std::fs::write(root.join("skills/demo-skill.md"), "# Demo Skill\n").unwrap();
+    std::fs::write(root.join("agents/demo-agent.md"), "# Demo Agent\n").unwrap();
+
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path  custom-skill  skill  ./out/skills\n\
+         install-path  custom-agent  agent  ./out/agents\n\
+         local  skill  demo-skill  skills/demo-skill.md\n\
+         local  agent  demo-agent  agents/demo-agent.md\n",
+    )
+    .unwrap();
+
+    sf(root).arg("install").assert().success();
+
+    let deployed_skill = root.join("out/skills/demo-skill/SKILL.md");
+    assert_eq!(
+        std::fs::read_to_string(&deployed_skill).unwrap(),
+        "# Demo Skill\n"
+    );
+
+    let deployed_agent = root.join("out/agents/demo-agent.md");
+    assert_eq!(
+        std::fs::read_to_string(&deployed_agent).unwrap(),
+        "# Demo Agent\n"
+    );
+
+    assert!(!root.join("out/skills/demo-agent/SKILL.md").exists());
+    assert!(!root.join("out/agents/demo-skill.md").exists());
+}
+
+#[test]
+fn install_path_expands_home() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let home = tempfile::tempdir().unwrap();
+
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    std::fs::write(root.join("skills/home-skill.md"), "# Home Skill\n").unwrap();
+
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path  home-target  skill  ~/custom-skills\n\
+         local  skill  home-skill  skills/home-skill.md\n",
+    )
+    .unwrap();
+
+    sf(root)
+        .env("HOME", home.path())
+        .arg("install")
+        .assert()
+        .success();
+
+    let deployed_skill = home.path().join("custom-skills/home-skill/SKILL.md");
+    assert_eq!(
+        std::fs::read_to_string(&deployed_skill).unwrap(),
+        "# Home Skill\n"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #111. Implements the proposed solution: deploy skills and agents to custom paths via `install-path` targets in the manifest.

Supports tools without built-in adapters, tools with customizable home locations, and other non-standard repo/env setups.

## Changes

- Add manifest parsing for `install-path <tool-name> <entity-type> <path>`
  - Skills deploy as directories: `<path>/<name>/SKILL.md`
  - Agents deploy as files: `<path>/<agent-name>.md`
  - Expand `~` against `$HOME`; resolve relative paths from repo root
- Wire installs through existing deploy/patch/status flows; preserve existing `install <platform> <scope>` behavior
- Document new syntax in `README.md`, `SPEC.md`
- Add tests for path deployment and path expansion
- Use `shlex` directly for manifest field parsing/formatting to match `SPEC.md`

## Other notes

- Personal config handling unchanged; `install-path` is manifest-only.
- Duplicate validation is by `entity_type + path`; multiple install locations can share a tool name.
- Small `cmd_init` refactor: extracted outro printing into `print_init_outro`; no behavior changes.

## Testing completed

```sh
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --test install_path
cargo test --workspace
```
