### PR TITLE
fix: canonicalize directory-entry keys during updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to skillfile are documented here.
 
 ## Unreleased
 
+### Fixed
+
+- **Directory-entry keys now stay consistent during updates and patch application** - `skillfile install --update` preserves edits to nested files when cache paths use platform-native separators, and directory patches use the same portable keys as installed file maps by @ychampion
+
 ## v1.7.3 - 10-07-2026
 
 ### Fixed

--- a/crates/cli/src/commands/diff.rs
+++ b/crates/cli/src/commands/diff.rs
@@ -11,12 +11,11 @@ use skillfile_core::progress;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry};
 use skillfile_sources::sync::vendor_dir_for;
 
-use crate::commands::forward_slash;
 use crate::commands::installed_variants::{installed_dir_variants, installed_single_file_variants};
 use crate::commands::multi_target::{
     format_single_file_diff, modified_dir_variants, modified_single_file_variants, SingleFileDiff,
 };
-use crate::patch::walkdir;
+use crate::patch::{relative_file_key, walkdir};
 
 struct DirDiffCtx<'a> {
     entry_name: &'a str,
@@ -100,7 +99,7 @@ fn diff_local_dir(entry: &Entry, sha: &str, repo_root: &Path) -> Result<(), Skil
         .into_iter()
         .filter(|cache_file| cache_file.file_name().is_some_and(|name| name != ".meta"))
         .filter_map(|cache_file| {
-            let filename = cache_file.strip_prefix(&vdir).ok().map(forward_slash)?;
+            let filename = relative_file_key(&vdir, &cache_file)?;
             Some((filename, cache_file))
         })
         .collect();

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -15,30 +15,5 @@ pub mod skill_preview;
 pub mod status;
 pub mod validate;
 
-pub(crate) fn forward_slash(path: &std::path::Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}
-
 #[cfg(test)]
 pub(crate) mod test_support;
-
-#[cfg(test)]
-mod tests {
-    use super::forward_slash;
-
-    #[test]
-    fn forward_slash_keeps_unix_paths() {
-        assert_eq!(
-            forward_slash(std::path::Path::new("scripts/helper.py")),
-            "scripts/helper.py"
-        );
-    }
-
-    #[test]
-    fn forward_slash_normalizes_windows_paths() {
-        assert_eq!(
-            forward_slash(std::path::Path::new(r"scripts\helper.py")),
-            "scripts/helper.py"
-        );
-    }
-}

--- a/crates/cli/src/commands/pin.rs
+++ b/crates/cli/src/commands/pin.rs
@@ -9,14 +9,13 @@ use skillfile_deploy::install::install_entry;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry};
 use skillfile_sources::sync::vendor_dir_for;
 
-use crate::commands::forward_slash;
 use crate::commands::installed_variants::{installed_dir_variants, installed_single_file_variants};
 use crate::commands::multi_target::{
     divergent_targets_message, modified_dir_variants, modified_single_file_variants,
 };
 use crate::patch::{
-    dir_patch_path, generate_patch, has_dir_patch, has_patch, remove_all_dir_patches,
-    remove_dir_patch, remove_patch, walkdir, write_dir_patch, write_patch,
+    dir_patch_path, generate_patch, has_dir_patch, has_patch, relative_file_key,
+    remove_all_dir_patches, remove_dir_patch, remove_patch, walkdir, write_dir_patch, write_patch,
 };
 
 struct PinCtx<'a> {
@@ -68,7 +67,7 @@ fn load_cache_files(vdir: &Path) -> BTreeMap<String, std::path::PathBuf> {
         .into_iter()
         .filter(|cache_file| cache_file.file_name().is_some_and(|name| name != ".meta"))
         .filter_map(|cache_file| {
-            let filename = cache_file.strip_prefix(vdir).ok().map(forward_slash)?;
+            let filename = relative_file_key(vdir, &cache_file)?;
             Some((filename, cache_file))
         })
         .collect()

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -7,13 +7,12 @@ use skillfile_core::lock::{lock_key, read_lock};
 use skillfile_core::models::{short_sha, EntityType, Entry, LockEntry, Manifest, SourceFields};
 use skillfile_core::parser::MANIFEST_NAME;
 use skillfile_core::patch::{
-    apply_patch_pure, dir_patch_path, has_dir_patch, has_patch, read_patch, walkdir,
+    apply_patch_pure, dir_patch_path, has_dir_patch, has_patch, read_patch, relative_file_key,
+    walkdir,
 };
 use skillfile_deploy::paths::{installed_dir_file_sets, installed_paths};
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, meta_sha};
 use skillfile_sources::sync::vendor_dir_for;
-
-use crate::commands::forward_slash;
 
 struct DirCheckCtx<'a> {
     entry: &'a Entry,
@@ -23,7 +22,7 @@ struct DirCheckCtx<'a> {
 }
 
 fn is_cache_file_modified(cache_file: &Path, ctx: &DirCheckCtx<'_>) -> Result<bool, ()> {
-    let filename = forward_slash(cache_file.strip_prefix(ctx.vdir).map_err(|_| ())?);
+    let filename = relative_file_key(ctx.vdir, cache_file).ok_or(())?;
     let inst_path = match ctx.installed.get(&filename) {
         Some(p) if p.exists() => p,
         _ => return Ok(false),

--- a/crates/core/src/patch.rs
+++ b/crates/core/src/patch.rs
@@ -9,6 +9,17 @@ pub const PATCHES_DIR: &str = ".skillfile/patches";
 // Path helpers
 // ---------------------------------------------------------------------------
 
+/// Build the portable key used for a file within a directory entry.
+///
+/// Keys always use forward slashes so cache, installed, and patch maps agree
+/// across platforms.
+#[must_use]
+pub fn relative_file_key(base: &Path, path: &Path) -> Option<String> {
+    path.strip_prefix(base)
+        .ok()
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+}
+
 #[must_use]
 pub fn patches_root(repo_root: &Path) -> PathBuf {
     repo_root.join(PATCHES_DIR)
@@ -459,6 +470,32 @@ mod tests {
                 ref_: "main".into(),
             },
         }
+    }
+
+    #[test]
+    fn relative_file_key_keeps_forward_slashes() {
+        let base = Path::new("cache");
+        assert_eq!(
+            relative_file_key(base, &base.join("nested/file.md")),
+            Some("nested/file.md".to_string())
+        );
+    }
+
+    #[test]
+    fn relative_file_key_normalizes_backslashes() {
+        let base = Path::new("cache");
+        assert_eq!(
+            relative_file_key(base, &base.join(r"nested\file.md")),
+            Some("nested/file.md".to_string())
+        );
+    }
+
+    #[test]
+    fn relative_file_key_rejects_paths_outside_base() {
+        assert_eq!(
+            relative_file_key(Path::new("cache"), Path::new("other/file.md")),
+            None
+        );
     }
 
     // --- generate_patch ---

--- a/crates/deploy/src/adapter.rs
+++ b/crates/deploy/src/adapter.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use skillfile_core::models::{EntityType, Entry, InstallOptions, Scope};
-use skillfile_core::patch::walkdir;
+use skillfile_core::patch::{relative_file_key, walkdir};
 use skillfile_core::progress;
 use skillfile_sources::strategy::is_dir_entry;
 
@@ -264,14 +264,6 @@ fn remove_orphan_flat_file(entry_name: &str, target_dir: &Path) {
     }
 }
 
-/// Convert a [`Path`] to a forward-slash string for use as patch/deploy keys.
-///
-/// On Unix this is a no-op. On Windows, `\` separators become `/` so that
-/// patch keys are portable across platforms.
-fn forward_slash(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}
-
 fn collect_dir_deploy_result(source: &Path, dest: &Path) -> DeployResult {
     let mut result = HashMap::new();
     for file in walkdir(source) {
@@ -281,7 +273,10 @@ fn collect_dir_deploy_result(source: &Path, dest: &Path) -> DeployResult {
         let Ok(rel) = file.strip_prefix(source) else {
             continue;
         };
-        result.insert(forward_slash(rel), dest.join(rel));
+        let Some(key) = relative_file_key(source, &file) else {
+            continue;
+        };
+        result.insert(key, dest.join(rel));
     }
     result
 }
@@ -306,10 +301,10 @@ fn collect_flat_installed_checked(vdir: &Path, target_dir: &Path) -> HashMap<Str
 fn collect_walkdir_relative(base: &Path) -> HashMap<String, PathBuf> {
     let mut result = HashMap::new();
     for file in walkdir(base) {
-        let Ok(rel) = file.strip_prefix(base) else {
+        let Some(key) = relative_file_key(base, &file) else {
             continue;
         };
-        result.insert(forward_slash(rel), file);
+        result.insert(key, file);
     }
     result
 }
@@ -323,13 +318,14 @@ fn collect_flat_installed(vdir: &Path, target_dir: &Path) -> HashMap<String, Pat
         {
             continue;
         }
-        let Ok(rel) = file.strip_prefix(vdir) else {
+        let dest = target_dir.join(file.file_name().unwrap_or_default());
+        if !dest.exists() {
+            continue;
+        }
+        let Some(key) = relative_file_key(vdir, &file) else {
             continue;
         };
-        let dest = target_dir.join(file.file_name().unwrap_or_default());
-        if dest.exists() {
-            result.insert(forward_slash(rel), dest);
-        }
+        result.insert(key, dest);
     }
     result
 }
@@ -372,8 +368,8 @@ fn deploy_flat(source_dir: &Path, target_dir: &Path, opts: &InstallOptions) -> D
         ) {
             continue;
         }
-        if let Ok(rel) = src.strip_prefix(source_dir) {
-            result.insert(forward_slash(rel), dest);
+        if let Some(key) = relative_file_key(source_dir, src) {
+            result.insert(key, dest);
         }
     }
     result
@@ -498,8 +494,8 @@ fn copy_missing_dir(
         if entry.file_name() == ".meta" {
             continue;
         }
-        if let Ok(relative) = source_path.strip_prefix(source_root) {
-            installed.insert(forward_slash(relative), target_path);
+        if let Some(key) = relative_file_key(source_root, &source_path) {
+            installed.insert(key, target_path);
         }
     }
     Ok(installed)
@@ -1670,18 +1666,6 @@ mod tests {
         let files = a.installed_dir_files(&entry, &local(dir.path()));
         assert!(files.contains_key("backend.md"));
         assert!(!files.contains_key("frontend.md"));
-    }
-
-    #[test]
-    fn forward_slash_converts_backslashes() {
-        assert_eq!(forward_slash(Path::new("a/b/c")), "a/b/c");
-        assert_eq!(forward_slash(Path::new("simple.md")), "simple.md");
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn forward_slash_converts_windows_separators() {
-        assert_eq!(forward_slash(Path::new(r"a\b\c.md")), "a/b/c.md");
     }
 
     #[test]

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -13,7 +13,8 @@ use skillfile_core::models::{
 use skillfile_core::parser::{parse_manifest, MANIFEST_NAME};
 use skillfile_core::patch::{
     apply_patch_pure, dir_patch_path, generate_patch, has_patch, patch_path, patches_root,
-    read_patch, remove_dir_patch, remove_patch, walkdir, write_dir_patch, write_patch,
+    read_patch, relative_file_key, remove_dir_patch, remove_patch, walkdir, write_dir_patch,
+    write_patch,
 };
 use skillfile_core::progress;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, is_dir_entry};
@@ -97,10 +98,8 @@ fn apply_dir_patches(
         .collect();
 
     for patch_file in patch_files {
-        let Some(rel) = patch_file
-            .strip_prefix(&patches_dir)
-            .ok()
-            .and_then(|p| p.to_str())
+        let Some(rel) = relative_file_key(&patches_dir, &patch_file)
+            .as_deref()
             .and_then(|s| s.strip_suffix(".patch"))
             .map(str::to_string)
         else {
@@ -126,8 +125,12 @@ fn apply_dir_patches(
         let new_patch = generate_patch(&cache_text, &patched, &rel);
         if new_patch.is_empty() {
             std::fs::remove_file(&patch_file)?;
-        } else {
-            write_dir_patch(&dir_patch_path(ctx.entry, &rel, ctx.repo_root), &new_patch)?;
+            continue;
+        }
+        let canonical_patch = dir_patch_path(ctx.entry, &rel, ctx.repo_root);
+        write_dir_patch(&canonical_patch, &new_patch)?;
+        if patch_file != canonical_patch {
+            std::fs::remove_file(&patch_file)?;
         }
     }
     Ok(())
@@ -326,11 +329,7 @@ fn load_cache_files(vdir: &Path) -> BTreeMap<String, PathBuf> {
         .into_iter()
         .filter(|cache_file| cache_file.file_name().is_none_or(|name| name != ".meta"))
         .filter_map(|cache_file| {
-            let filename = cache_file
-                .strip_prefix(vdir)
-                .ok()
-                .and_then(|path| path.to_str())
-                .map(str::to_string)?;
+            let filename = relative_file_key(vdir, &cache_file)?;
             Some((filename, cache_file))
         })
         .collect()
@@ -723,10 +722,6 @@ fn restore_path_snapshot(snapshot: &PathSnapshot) -> std::io::Result<()> {
     copy_path(snapshot_path, &snapshot.live_path)
 }
 
-fn forward_slash(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}
-
 struct InstallValidationCtx<'a> {
     entry: &'a Entry,
     target: &'a InstallTarget,
@@ -752,9 +747,9 @@ fn flat_expected_paths(source: &Path, target_dir: &Path) -> HashMap<String, Path
         .into_iter()
         .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
         .filter_map(|path| {
-            let rel = path.strip_prefix(source).ok()?;
             let name = path.file_name()?;
-            Some((forward_slash(rel), target_dir.join(name)))
+            let key = relative_file_key(source, &path)?;
+            Some((key, target_dir.join(name)))
         })
         .collect()
 }
@@ -765,7 +760,8 @@ fn nested_expected_paths(source: &Path, dest_root: &Path) -> HashMap<String, Pat
         .filter(|path| path.file_name().is_none_or(|name| name != ".meta"))
         .filter_map(|path| {
             let rel = path.strip_prefix(source).ok()?;
-            Some((forward_slash(rel), dest_root.join(rel)))
+            let key = relative_file_key(source, &path)?;
+            Some((key, dest_root.join(rel)))
         })
         .collect()
 }
@@ -2798,6 +2794,47 @@ mod tests {
     }
 
     #[test]
+    fn auto_pin_dir_entry_normalizes_cache_file_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let name = "lang-pro";
+
+        let mut locked: BTreeMap<String, LockEntry> = BTreeMap::new();
+        locked.insert(
+            format!("github/skill/{name}"),
+            LockEntry {
+                sha: "deadbeefdeadbeefdeadbeef".into(),
+                raw_url: format!("https://example.com/{name}"),
+            },
+        );
+        write_lock_fixture(dir.path(), &locked);
+
+        let vdir = dir.path().join(format!(".skillfile/cache/skills/{name}"));
+        let cache_file = vdir.join(r"nested\file.md");
+        std::fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
+        std::fs::write(&cache_file, "# Original\n").unwrap();
+
+        let installed_file = dir
+            .path()
+            .join(format!(".claude/skills/{name}/nested/file.md"));
+        std::fs::create_dir_all(installed_file.parent().unwrap()).unwrap();
+        std::fs::write(&installed_file, "# Modified\n").unwrap();
+
+        let entry = make_dir_skill_entry(name);
+        let manifest = Manifest {
+            entries: vec![entry.clone()],
+            install_targets: vec![make_target("claude-code", Scope::Local)],
+        };
+
+        auto_pin_entry(&entry, &manifest, dir.path()).unwrap();
+
+        let patch = dir_patch_fixture_path(dir.path(), &entry, "nested/file.md");
+        assert!(
+            patch.exists(),
+            "auto-pin must match cache and installed files through canonical keys"
+        );
+    }
+
+    #[test]
     fn auto_pin_dir_entry_uses_second_target_when_first_is_clean() {
         let dir = tempfile::tempdir().unwrap();
         let name = "lang-pro";
@@ -3021,6 +3058,59 @@ mod tests {
             expected_rebased_to_new_cache,
             "rebased patch applied to new_cache must reproduce installed_content"
         );
+    }
+
+    #[test]
+    fn apply_dir_patches_normalizes_patch_file_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let entry = make_dir_skill_entry("lang-pro");
+        let patch_text = concat!(
+            "--- a/nested/file.md\n",
+            "+++ b/nested/file.md\n",
+            "@@ -1 +1 @@\n",
+            "-# Original\n",
+            "+# Modified\n",
+        );
+
+        let patches_dir = dir.path().join(".skillfile/patches/skills/lang-pro");
+        let platform_keyed_patch = patches_dir.join(r"nested\file.md.patch");
+        std::fs::create_dir_all(platform_keyed_patch.parent().unwrap()).unwrap();
+        std::fs::write(&platform_keyed_patch, patch_text).unwrap();
+
+        let installed_file = dir.path().join(".claude/skills/lang-pro/nested/file.md");
+        std::fs::create_dir_all(installed_file.parent().unwrap()).unwrap();
+        std::fs::write(&installed_file, "# Original\n").unwrap();
+
+        let source_dir = dir.path().join(".skillfile/cache/skills/lang-pro");
+        let source_file = source_dir.join("nested/file.md");
+        std::fs::create_dir_all(source_file.parent().unwrap()).unwrap();
+        std::fs::write(&source_file, "# Original\n").unwrap();
+
+        let installed_files =
+            HashMap::from([("nested/file.md".to_string(), installed_file.clone())]);
+
+        apply_dir_patches(
+            &PatchCtx {
+                entry: &entry,
+                repo_root: dir.path(),
+            },
+            &installed_files,
+            &source_dir,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&installed_file).unwrap(),
+            "# Modified\n"
+        );
+        let canonical_patch = dir_patch_fixture_path(dir.path(), &entry, "nested/file.md");
+        assert!(canonical_patch.exists());
+        if platform_keyed_patch != canonical_patch {
+            assert!(
+                !platform_keyed_patch.exists(),
+                "rebasing must not leave a second non-canonical patch path"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- centralize directory-entry relative keys in `skillfile_core`
- use the shared key contract across CLI, deploy, auto-pin, and patch application
- cover backslash-style cache and patch keys with regressions

## Why

Cache, installed, and patch maps could represent the same nested file with different separators. On Windows, that made `install --update` skip local edits during auto-pin and made directory patch lookup miss installed files.

Closes #154.

## Validation

- `cargo build -p skillfile`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo deny check`
- `cargo machete`
- `shellcheck install.sh`
