### PR TITLE
Prepare 1.7.4 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ All notable changes to skillfile are documented here.
 
 ## Unreleased
 
+## v1.7.4 - 13-07-2026
+
+### Changed
+
+- **Dependency refresh** - bumped `clap_complete` to 4.6.7.
+
 ### Fixed
 
 - **Directory-entry keys now stay consistent during updates and patch application** - `skillfile install --update` preserves edits to nested files when cache paths use platform-native separators, and directory patches use the same portable keys as installed file maps by @ychampion
+- **GitHub single-file fetches now handle encoded paths correctly** - GitHub entries that point directly at files with spaces, `#`, or non-ASCII characters in their path now fetch the intended raw file instead of failing with an invalid URI error or requesting the wrong path by @humammoin09-blip
 
 ## v1.7.3 - 10-07-2026
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-core"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-deploy"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "dirs",
  "serde_json",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "skillfile-sources"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "html-escape",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "1.7.3"
+version = "1.7.4"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
@@ -15,9 +15,9 @@ categories = ["command-line-utilities", "development-tools"]
 
 [workspace.dependencies]
 # Internal crates
-skillfile-core = { path = "crates/core", version = "1.7.3" }
-skillfile-sources = { path = "crates/sources", version = "1.7.3" }
-skillfile-deploy = { path = "crates/deploy", version = "1.7.3" }
+skillfile-core = { path = "crates/core", version = "1.7.4" }
+skillfile-sources = { path = "crates/sources", version = "1.7.4" }
+skillfile-deploy = { path = "crates/deploy", version = "1.7.4" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/sources/src/resolver.rs
+++ b/crates/sources/src/resolver.rs
@@ -1442,6 +1442,56 @@ mod tests {
     }
 
     #[test]
+    fn fetch_github_file_encodes_space_in_path() {
+        let sha = "abc123";
+        let url = format!("https://raw.githubusercontent.com/org/repo/{sha}/skills/my%20skill.md");
+        let mut client = MockClient::new();
+        client.add_bytes(&url, b"# Skill with space".to_vec());
+
+        let gh = GithubFetch {
+            client: &client,
+            owner_repo: "org/repo",
+            ref_: sha,
+        };
+        let result = fetch_github_file(&gh, "skills/my skill.md").unwrap();
+        assert_eq!(result, b"# Skill with space");
+    }
+
+    #[test]
+    fn fetch_github_file_encodes_hash_in_path() {
+        let sha = "abc123";
+        let url = format!("https://raw.githubusercontent.com/org/repo/{sha}/skills/my%23skill.md");
+        let mut client = MockClient::new();
+        client.add_bytes(&url, b"# Skill with hash".to_vec());
+
+        let gh = GithubFetch {
+            client: &client,
+            owner_repo: "org/repo",
+            ref_: sha,
+        };
+        let result = fetch_github_file(&gh, "skills/my#skill.md").unwrap();
+        assert_eq!(result, b"# Skill with hash");
+    }
+
+    #[test]
+    fn fetch_github_file_encodes_unicode_in_path() {
+        let sha = "abc123";
+        let url = format!(
+            "https://raw.githubusercontent.com/org/repo/{sha}/skills/%E6%8C%89%E9%92%AE.md"
+        );
+        let mut client = MockClient::new();
+        client.add_bytes(&url, b"# Unicode skill".to_vec());
+
+        let gh = GithubFetch {
+            client: &client,
+            owner_repo: "org/repo",
+            ref_: sha,
+        };
+        let result = fetch_github_file(&gh, "skills/按钮.md").unwrap();
+        assert_eq!(result, b"# Unicode skill");
+    }
+
+    #[test]
     fn fetch_github_file_propagates_error() {
         let sha = "fff000";
         let url = format!("https://raw.githubusercontent.com/org/repo/{sha}/missing.md");


### PR DESCRIPTION
**SUMMARY**
Prepare `skillfile` `v1.7.4` release metadata and add regression coverage for GitHub raw file path encoding.

**RATIONALE**
The next patch release needs to include the merged GitHub path encoding fix and the directory update fix since `v1.7.3`. Fetch-level tests lock the GitHub raw URL behavior so paths with spaces, `#`, and Unicode stay covered at the boundary that previously regressed.

**CHANGES**
- Bump workspace package versions and internal crate requirements from `1.7.3` to `1.7.4`.
- Update `Cargo.lock` package versions for the `skillfile` workspace crates.
- Add `fetch_github_file` tests for encoded spaces, `#`, and Unicode paths in `crates/sources/src/resolver.rs`.