### PR TITLE
fix(patch): keep pinned state stable across line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to skillfile are documented here.
 
 ## Unreleased
 
+### Fixed
+
+- **Pinned files now keep stable modification status across line-ending styles** - patch round-trips preserve a missing final newline, and CRLF/LF differences no longer make a freshly pinned file appear modified by @ychampion
+
 ## v1.7.4 - 13-07-2026
 
 ### Changed

--- a/crates/cli/src/commands/multi_target.rs
+++ b/crates/cli/src/commands/multi_target.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use skillfile_core::error::SkillfileError;
+use skillfile_core::patch::text_content_eq;
 
 use crate::commands::installed_variants::{DirVariant, SingleFileVariant};
 
@@ -28,7 +29,7 @@ pub(crate) fn modified_single_file_variants<'a>(
 ) -> Vec<&'a SingleFileVariant> {
     variants
         .iter()
-        .filter(|variant| variant.content != cache_text)
+        .filter(|variant| !text_content_eq(&variant.content, cache_text))
         .collect()
 }
 
@@ -60,11 +61,20 @@ pub(crate) fn modified_dir_content(
         }
         let cache_text = std::fs::read_to_string(cache_file)?;
         let installed_text = std::fs::read_to_string(installed)?;
-        if installed_text != cache_text {
+        if !text_content_eq(&installed_text, &cache_text) {
             modified.insert(filename.clone(), installed_text);
         }
     }
     Ok(modified)
+}
+
+pub(crate) fn dir_content_eq(left: &DirContentMap, right: &DirContentMap) -> bool {
+    left.len() == right.len()
+        && left.iter().all(|(filename, content)| {
+            right
+                .get(filename)
+                .is_some_and(|other| text_content_eq(content, other))
+        })
 }
 
 pub(crate) fn modified_dir_variants(

--- a/crates/cli/src/commands/pin.rs
+++ b/crates/cli/src/commands/pin.rs
@@ -11,11 +11,12 @@ use skillfile_sources::sync::vendor_dir_for;
 
 use crate::commands::installed_variants::{installed_dir_variants, installed_single_file_variants};
 use crate::commands::multi_target::{
-    divergent_targets_message, modified_dir_variants, modified_single_file_variants,
+    dir_content_eq, divergent_targets_message, modified_dir_variants, modified_single_file_variants,
 };
 use crate::patch::{
     dir_patch_path, generate_patch, has_dir_patch, has_patch, relative_file_key,
-    remove_all_dir_patches, remove_dir_patch, remove_patch, walkdir, write_dir_patch, write_patch,
+    remove_all_dir_patches, remove_dir_patch, remove_patch, text_content_eq, walkdir,
+    write_dir_patch, write_patch,
 };
 
 struct PinCtx<'a> {
@@ -81,7 +82,7 @@ fn representative_dir_changes<'a>(
     let representative = &modified[0].1;
     if modified
         .iter()
-        .any(|(_, changed)| changed != representative)
+        .any(|(_, changed)| !dir_content_eq(changed, representative))
     {
         return Err(divergent_targets_message(entry_name, &labels));
     }
@@ -129,7 +130,7 @@ fn pin_single_file_content(
     let representative = &modified[0].content;
     if modified
         .iter()
-        .any(|variant| variant.content != *representative)
+        .any(|variant| !text_content_eq(&variant.content, representative))
     {
         let labels: Vec<String> = modified
             .iter()

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -8,7 +8,7 @@ use skillfile_core::models::{short_sha, EntityType, Entry, LockEntry, Manifest, 
 use skillfile_core::parser::MANIFEST_NAME;
 use skillfile_core::patch::{
     apply_patch_pure, dir_patch_path, has_dir_patch, has_patch, read_patch, relative_file_key,
-    walkdir,
+    text_content_eq, walkdir,
 };
 use skillfile_deploy::paths::{installed_dir_file_sets, installed_paths};
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, meta_sha};
@@ -30,7 +30,7 @@ fn is_cache_file_modified(cache_file: &Path, ctx: &DirCheckCtx<'_>) -> Result<bo
     let cache_text = std::fs::read_to_string(cache_file).map_err(|_| ())?;
     let expected_text = expected_dir_file_text(&filename, &cache_text, ctx)?;
     let installed_text = std::fs::read_to_string(inst_path).map_err(|_| ())?;
-    Ok(installed_text != expected_text)
+    Ok(!text_content_eq(&installed_text, &expected_text))
 }
 
 fn check_dir_files_modified(
@@ -109,7 +109,7 @@ fn check_single_file_modified(
             continue;
         }
         let installed_text = std::fs::read_to_string(&installed_path).map_err(|_| ())?;
-        if installed_text != expected_text {
+        if !text_content_eq(&installed_text, &expected_text) {
             return Ok(true);
         }
     }

--- a/crates/core/src/patch.rs
+++ b/crates/core/src/patch.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use crate::error::SkillfileError;
@@ -147,6 +148,21 @@ fn remove_empty_parent(path: &Path) {
 // Diff generation
 // ---------------------------------------------------------------------------
 
+fn normalize_crlf(text: &str) -> Cow<'_, str> {
+    if text.contains("\r\n") {
+        Cow::Owned(text.replace("\r\n", "\n"))
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+/// Compare text using the line-ending normalization applied by patches.
+/// A missing final newline remains significant.
+#[must_use]
+pub fn text_content_eq(left: &str, right: &str) -> bool {
+    normalize_crlf(left) == normalize_crlf(right)
+}
+
 /// Generate a unified diff of original → modified. Empty string if identical.
 /// All output lines are guaranteed to end with '\n'.
 /// Format: `--- a/{label}` / `+++ b/{label}`, 3 lines of context.
@@ -167,7 +183,13 @@ pub fn generate_patch(original: &str, modified: &str, label: &str) -> String {
         return String::new();
     }
 
-    let diff = similar::TextDiff::from_lines(original, modified);
+    let original = normalize_crlf(original);
+    let modified = normalize_crlf(modified);
+    if original == modified {
+        return String::new();
+    }
+
+    let diff = similar::TextDiff::from_lines(&original, &modified);
     let raw = format!(
         "{}",
         diff.unified_diff()
@@ -179,8 +201,8 @@ pub fn generate_patch(original: &str, modified: &str, label: &str) -> String {
         return String::new();
     }
 
-    // Post-process: remove "\ No newline at end of file" markers,
-    // normalize any lines not ending with \n.
+    // Keep standard missing-newline markers so application can reconstruct the
+    // exact final-newline state. Patch-file lines themselves always end in \n.
     let mut result = String::new();
     for line in raw.split_inclusive('\n') {
         normalize_diff_line(line, &mut result);
@@ -191,17 +213,8 @@ pub fn generate_patch(original: &str, modified: &str, label: &str) -> String {
 
 /// Process one line from a raw unified-diff output into `result`.
 ///
-/// "\ No newline at end of file" markers are dropped (but a trailing newline is
-/// ensured on the preceding content line). Every other line is guaranteed to end
-/// with `'\n'`.
+/// Every patch-file line is guaranteed to end with `'\n'`.
 fn normalize_diff_line(line: &str, result: &mut String) {
-    if line.starts_with("\\ ") {
-        // "\ No newline at end of file" — ensure the preceding line ends with \n
-        if !result.ends_with('\n') {
-            result.push('\n');
-        }
-        return;
-    }
     result.push_str(line);
     if !line.ends_with('\n') {
         result.push('\n');
@@ -253,6 +266,14 @@ fn parse_hunks(patch_text: &str) -> Result<Vec<Hunk>, SkillfileError> {
     Ok(hunks)
 }
 
+fn remove_line_ending(line: &mut String) {
+    if line.ends_with("\r\n") {
+        line.truncate(line.len() - 2);
+    } else if line.ends_with('\n') {
+        line.pop();
+    }
+}
+
 fn collect_hunk_body(lines: &[&str], pi: &mut usize) -> Vec<String> {
     let mut body: Vec<String> = Vec::new();
     while *pi < lines.len() {
@@ -261,7 +282,7 @@ fn collect_hunk_body(lines: &[&str], pi: &mut usize) -> Vec<String> {
             break;
         }
         if hl.starts_with("\\ ") {
-            // "\ No newline at end of file" — skip
+            body.last_mut().into_iter().for_each(remove_line_ending);
             *pi += 1;
             continue;
         }
@@ -383,8 +404,8 @@ pub fn apply_patch_pure(original: &str, patch_text: &str) -> Result<String, Skil
     }
 
     // Normalize CRLF to LF so patches apply cleanly on Windows.
-    let original = &original.replace("\r\n", "\n");
-    let patch_text = &patch_text.replace("\r\n", "\n");
+    let original = normalize_crlf(original);
+    let patch_text = normalize_crlf(patch_text);
 
     // Split into lines preserving newlines (like Python's splitlines(keepends=True))
     let lines: Vec<String> = original
@@ -394,7 +415,7 @@ pub fn apply_patch_pure(original: &str, patch_text: &str) -> Result<String, Skil
 
     let mut state = PatchState::new(&lines);
 
-    for hunk in parse_hunks(patch_text)? {
+    for hunk in parse_hunks(&patch_text)? {
         // Build context: lines with ' ' or '-' prefix, stripped of prefix and trailing \n
         let ctx_lines: Vec<&str> = hunk
             .body
@@ -822,20 +843,36 @@ mod tests {
 
     #[test]
     fn generate_patch_no_trailing_newline_roundtrip() {
-        // apply_patch_pure must reconstruct the modified text even when neither
-        // side ends with a newline.
         let orig = "line one\nline two";
         let modified = "line one\nline changed";
         let patch = generate_patch(orig, modified, "test.md");
         assert!(!patch.is_empty());
-        // The patch must normalise to a clean result — at minimum not error.
+        assert!(patch.contains("\\ No newline at end of file"));
         let result = apply_patch_pure(orig, &patch).unwrap();
-        // The applied result should match modified (possibly with a trailing newline
-        // added by the normalization, so we compare trimmed content).
-        assert_eq!(
-            result.trim_end_matches('\n'),
-            modified.trim_end_matches('\n')
-        );
+        assert_eq!(result, modified);
+    }
+
+    #[test]
+    fn generate_patch_normalizes_crlf() {
+        let orig = "line one\r\nline two\r\n";
+        let modified = "line one\r\nline changed\r\n";
+        let patch = generate_patch(orig, modified, "test.md");
+        assert!(!patch.is_empty());
+        assert!(!patch.contains('\r'));
+        let result = apply_patch_pure(orig, &patch).unwrap();
+        assert_eq!(result, "line one\nline changed\n");
+    }
+
+    #[test]
+    fn text_content_eq_normalizes_only_crlf() {
+        assert!(text_content_eq(
+            "line one\r\nline two\r\n",
+            "line one\nline two\n"
+        ));
+        assert!(!text_content_eq(
+            "line one\nline two",
+            "line one\nline two\n"
+        ));
     }
 
     // --- apply_patch_pure: "\ No newline at end of file" marker in patch ---
@@ -855,7 +892,7 @@ mod tests {
             "\\ No newline at end of file\n",
         );
         let result = apply_patch_pure(orig, patch).unwrap();
-        assert_eq!(result, "line1\nchanged\n");
+        assert_eq!(result, "line1\nchanged");
     }
 
     // --- walkdir: edge cases ---

--- a/crates/core/src/patch.rs
+++ b/crates/core/src/patch.rs
@@ -267,9 +267,7 @@ fn parse_hunks(patch_text: &str) -> Result<Vec<Hunk>, SkillfileError> {
 }
 
 fn remove_line_ending(line: &mut String) {
-    if line.ends_with("\r\n") {
-        line.truncate(line.len() - 2);
-    } else if line.ends_with('\n') {
+    if line.ends_with('\n') {
         line.pop();
     }
 }
@@ -861,6 +859,11 @@ mod tests {
         assert!(!patch.contains('\r'));
         let result = apply_patch_pure(orig, &patch).unwrap();
         assert_eq!(result, "line one\nline changed\n");
+    }
+
+    #[test]
+    fn generate_patch_ignores_crlf_only_changes() {
+        assert!(generate_patch("line one\r\n", "line one\n", "test.md").is_empty());
     }
 
     #[test]

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -2539,6 +2539,15 @@ mod tests {
     }
 
     #[test]
+    fn auto_pin_preserves_malformed_patch() {
+        assert!(patch_already_covers(
+            "@@ invalid\n",
+            "Original\n",
+            "Modified\n"
+        ));
+    }
+
+    #[test]
     fn auto_pin_dir_comparison_treats_crlf_as_equivalent() {
         let left = BTreeMap::from([("SKILL.md".into(), "Modified\n".into())]);
         let right = BTreeMap::from([("SKILL.md".into(), "Modified\r\n".into())]);

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -13,8 +13,8 @@ use skillfile_core::models::{
 use skillfile_core::parser::{parse_manifest, MANIFEST_NAME};
 use skillfile_core::patch::{
     apply_patch_pure, dir_patch_path, generate_patch, has_patch, patch_path, patches_root,
-    read_patch, relative_file_key, remove_dir_patch, remove_patch, walkdir, write_dir_patch,
-    write_patch,
+    read_patch, relative_file_key, remove_dir_patch, remove_patch, text_content_eq, walkdir,
+    write_dir_patch, write_patch,
 };
 use skillfile_core::progress;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, is_dir_entry};
@@ -148,9 +148,9 @@ fn apply_dir_patches(
 /// the patch captures.
 fn patch_already_covers(patch_text: &str, cache_text: &str, installed_text: &str) -> bool {
     match apply_patch_pure(cache_text, patch_text) {
-        Ok(expected) if installed_text == expected => true, // no new edits
-        Err(_) => true,                                     // cache inconsistent — preserve
-        Ok(_) => false,                                     // additional edits — fall through
+        Ok(expected) if text_content_eq(installed_text, &expected) => true, // no new edits
+        Err(_) => true, // cache inconsistent — preserve
+        Ok(_) => false, // additional edits — fall through
     }
 }
 
@@ -216,7 +216,7 @@ fn representative_single_file_content(
 ) -> Result<Option<String>, SkillfileError> {
     let modified: Vec<&SingleInstalledVariant> = variants
         .iter()
-        .filter(|variant| variant.content != cache_text)
+        .filter(|variant| !text_content_eq(&variant.content, cache_text))
         .collect();
     if modified.is_empty() {
         return Ok(None);
@@ -224,7 +224,7 @@ fn representative_single_file_content(
     let representative = &modified[0].content;
     if modified
         .iter()
-        .any(|variant| variant.content != *representative)
+        .any(|variant| !text_content_eq(&variant.content, representative))
     {
         let labels: Vec<String> = modified
             .iter()
@@ -380,11 +380,20 @@ fn modified_dir_content(
         };
         let cache_text = std::fs::read_to_string(cache_file)?;
         let installed_text = std::fs::read_to_string(installed_path)?;
-        if installed_text != cache_text {
+        if !text_content_eq(&installed_text, &cache_text) {
             modified.insert(filename.clone(), installed_text);
         }
     }
     Ok(modified)
+}
+
+fn dir_modified_content_eq(left: &DirModifiedMap, right: &DirModifiedMap) -> bool {
+    left.len() == right.len()
+        && left.iter().all(|(filename, content)| {
+            right
+                .get(filename)
+                .is_some_and(|other| text_content_eq(content, other))
+        })
 }
 
 fn representative_dir_changes(
@@ -405,7 +414,7 @@ fn representative_dir_changes(
     let representative = &modified[0].1;
     if modified
         .iter()
-        .any(|(_, changed)| changed != representative)
+        .any(|(_, changed)| !dir_modified_content_eq(changed, representative))
     {
         let labels: Vec<String> = modified.iter().map(|(label, _)| label.clone()).collect();
         return Err(divergent_auto_pin_error(entry_name, &labels));
@@ -2506,6 +2515,35 @@ mod tests {
         auto_pin_entry(&entry, &manifest, dir.path()).unwrap();
 
         assert!(!patch_fixture_path(dir.path(), &entry).exists());
+    }
+
+    #[test]
+    fn auto_pin_comparisons_treat_crlf_as_equivalent() {
+        let patch = "--- a/test.md\n+++ b/test.md\n@@ -1 +1 @@\n-Original\n+Modified\n";
+        assert!(patch_already_covers(patch, "Original\n", "Modified\r\n"));
+
+        let variants = vec![
+            SingleInstalledVariant {
+                label: "claude-code (local)".into(),
+                content: "Modified\n".into(),
+            },
+            SingleInstalledVariant {
+                label: "cursor (local)".into(),
+                content: "Modified\r\n".into(),
+            },
+        ];
+        assert_eq!(
+            representative_single_file_content("test", "Original\n", &variants).unwrap(),
+            Some("Modified\n".into())
+        );
+    }
+
+    #[test]
+    fn auto_pin_dir_comparison_treats_crlf_as_equivalent() {
+        let left = BTreeMap::from([("SKILL.md".into(), "Modified\n".into())]);
+        let right = BTreeMap::from([("SKILL.md".into(), "Modified\r\n".into())]);
+
+        assert!(dir_modified_content_eq(&left, &right));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -648,6 +648,35 @@ fn assert_info_lock_pin_cache_output(stdout: &str) {
 }
 
 #[test]
+fn pin_status_preserves_installed_line_endings() {
+    for (name, installed_text) in [
+        ("no-final-newline", "# Skill\n\nPinned without newline."),
+        ("crlf", "# Skill\r\n\r\nPinned with CRLF.\r\n"),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        write_remote_skill_fixture(
+            dir.path(),
+            &RemoteSkillFixture {
+                name,
+                installed_text: Some(installed_text),
+                patch_text: None,
+            },
+        );
+
+        sf(dir.path()).args(["pin", name]).assert().success();
+
+        let output = sf(dir.path()).arg("status").output().unwrap();
+        let stdout = std::str::from_utf8(&output.stdout).unwrap();
+        let entry_line = output_line(stdout, name);
+        assert!(output.status.success(), "status failed:\n{stdout}");
+        assert!(
+            !entry_line.contains("[modified]"),
+            "freshly pinned entry must be clean:\n{stdout}"
+        );
+    }
+}
+
+#[test]
 fn install_first_run_shows_platform_hint() {
     let dir = tempfile::tempdir().unwrap();
     write_local_manifest(dir.path());


### PR DESCRIPTION
Fixes #163

## Summary

- preserve missing-final-newline markers through patch generation and application
- treat CRLF and LF content consistently across pin, status, multi-target, and update paths
- cover byte-exact patch round-trips and real pin/status behavior

## Why

A freshly pinned file could still appear modified when it had no final newline or used CRLF endings because patch application and installed-content comparisons used different normalization rules.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build -p skillfile`
- `cargo test --workspace`
- `cargo test --test upstream`
- `cargo deny check`
- `cargo machete`