### PR TITLE
fix(manifest): preserve quoted fields during rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to skillfile are documented here.
 
 ## Unreleased
 
+### Fixed
+
+- **Formatting keeps quoted manifest fields valid** - `skillfile add` and `skillfile format` now preserve paths and other fields containing whitespace or `#` instead of rewriting them into a different entry by @ychampion
+
 ## v1.7.4 - 13-07-2026
 
 ### Changed

--- a/crates/cli/src/commands/format.rs
+++ b/crates/cli/src/commands/format.rs
@@ -382,6 +382,20 @@ mod tests {
     }
 
     #[test]
+    fn cmd_format_preserves_quoted_local_path() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            "local  skill  commit  \"my skills/git commit.md\"\n",
+        );
+
+        cmd_format(dir.path(), false).unwrap();
+
+        let text = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
+        assert!(text.contains("local  skill  commit  \"my skills/git commit.md\""));
+    }
+
+    #[test]
     fn cmd_format_dry_run_does_not_write() {
         let dir = tempfile::tempdir().unwrap();
         let original = "github  skill  z/repo  z.md\ngithub  skill  a/repo  a.md\n";

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -70,11 +70,29 @@ fn split_line(line: &str) -> Vec<String> {
     parts
 }
 
-fn strip_inline_comment(parts: Vec<String>) -> Vec<String> {
-    if let Some(pos) = parts.iter().position(|p| p.starts_with('#')) {
-        parts[..pos].to_vec()
+fn strip_inline_comment(line: &str) -> &str {
+    let mut in_quotes = false;
+    let mut previous_was_whitespace = false;
+
+    for (index, ch) in line.char_indices() {
+        if ch == '"' {
+            in_quotes = !in_quotes;
+        } else if ch == '#' && !in_quotes && previous_was_whitespace {
+            return line[..index].trim_end();
+        }
+        previous_was_whitespace = ch.is_whitespace();
+    }
+
+    line
+}
+
+/// Quote a manifest field when the parser would otherwise split or comment it out.
+#[must_use]
+pub fn quote_field(field: &str) -> String {
+    if field.chars().any(char::is_whitespace) || field.contains('#') {
+        format!("\"{field}\"")
     } else {
-        parts
+        field.to_string()
     }
 }
 
@@ -420,7 +438,7 @@ pub fn parse_manifest(manifest_path: &Path) -> Result<ParseResult, SkillfileErro
             continue;
         }
 
-        let parts = strip_inline_comment(split_line(line));
+        let parts = split_line(strip_inline_comment(line));
         if parts.len() < 2 {
             acc.warnings
                 .push(format!("warning: line {lineno}: too few fields, skipping"));
@@ -451,8 +469,7 @@ pub fn parse_manifest(manifest_path: &Path) -> Result<ParseResult, SkillfileErro
 
 #[must_use]
 pub fn parse_manifest_line(line: &str) -> Option<Entry> {
-    let parts = split_line(line);
-    let parts = strip_inline_comment(parts);
+    let parts = split_line(strip_inline_comment(line));
     if parts.len() < 3 {
         return None;
     }
@@ -891,6 +908,17 @@ mod tests {
             r.manifest.entries[0].path_in_repo(),
             "path with spaces/skill.md"
         );
+    }
+
+    #[test]
+    fn quoted_hash_path_is_not_an_inline_comment() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(MANIFEST_NAME);
+        fs::write(&p, "local  skill  hash-skill  \"#skills/hash.md\"\n").unwrap();
+        let r = parse_manifest(&p).unwrap();
+        assert_eq!(r.manifest.entries.len(), 1);
+        assert_eq!(r.manifest.entries[0].name, "hash-skill");
+        assert_eq!(r.manifest.entries[0].local_path(), "#skills/hash.md");
     }
 
     #[test]

--- a/crates/sources/src/strategy.rs
+++ b/crates/sources/src/strategy.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use skillfile_core::models::{Entry, SourceFields, DEFAULT_REF};
-use skillfile_core::parser::infer_name;
+use skillfile_core::parser::{infer_name, quote_field};
 
 /// Known source types.
 pub const KNOWN_SOURCES: &[&str] = &["github", "gitlab", "local", "url"];
@@ -103,7 +103,7 @@ fn cache_has_auxiliary_files_from(root: &Path, dir: &Path) -> bool {
 /// Used by `add` and `sort` commands.
 #[must_use]
 pub fn format_parts(entry: &Entry) -> Vec<String> {
-    match &entry.source {
+    let parts = match &entry.source {
         SourceFields::Github {
             owner_repo,
             path_in_repo,
@@ -141,7 +141,8 @@ pub fn format_parts(entry: &Entry) -> Vec<String> {
             parts.push(url.clone());
             parts
         }
-    }
+    };
+    parts.into_iter().map(|part| quote_field(&part)).collect()
 }
 
 #[must_use]
@@ -321,6 +322,80 @@ mod tests {
             },
         };
         assert_eq!(format_parts(&e), vec!["git-commit", "skills/git/commit.md"]);
+    }
+
+    #[test]
+    fn format_parts_quotes_local_path_with_spaces() {
+        let e = Entry {
+            entity_type: EntityType::Skill,
+            name: "git-commit".into(),
+            source: SourceFields::Local {
+                path: "my skills/git commit.md".into(),
+            },
+        };
+        assert_eq!(
+            format_parts(&e),
+            vec!["git-commit", "\"my skills/git commit.md\""]
+        );
+    }
+
+    #[test]
+    fn format_parts_quotes_hash_in_local_path() {
+        let e = Entry {
+            entity_type: EntityType::Skill,
+            name: "hash-skill".into(),
+            source: SourceFields::Local {
+                path: "#skills/hash.md".into(),
+            },
+        };
+        assert_eq!(format_parts(&e), vec!["hash-skill", "\"#skills/hash.md\""]);
+    }
+
+    #[test]
+    fn format_parts_quotes_remote_and_url_fields() {
+        let github = Entry {
+            entity_type: EntityType::Skill,
+            name: "skill".into(),
+            source: SourceFields::Github {
+                owner_repo: "owner/repo".into(),
+                path_in_repo: "path with spaces/skill.md".into(),
+                ref_: "release #1".into(),
+            },
+        };
+        assert_eq!(
+            format_parts(&github),
+            vec![
+                "owner/repo",
+                "\"path with spaces/skill.md\"",
+                "\"release #1\""
+            ]
+        );
+
+        let gitlab = Entry {
+            entity_type: EntityType::Agent,
+            name: "agent".into(),
+            source: SourceFields::Gitlab {
+                owner_repo: "group/project".into(),
+                path_in_repo: "agents/team agent.md".into(),
+                ref_: "main".into(),
+            },
+        };
+        assert_eq!(
+            format_parts(&gitlab),
+            vec!["agent", "group/project", "\"agents/team agent.md\""]
+        );
+
+        let url = Entry {
+            entity_type: EntityType::Skill,
+            name: "remote".into(),
+            source: SourceFields::Url {
+                url: "https://example.com/skill.md#stable".into(),
+            },
+        };
+        assert_eq!(
+            format_parts(&url),
+            vec!["remote", "\"https://example.com/skill.md#stable\""]
+        );
     }
 
     fn gitlab_entry(path_in_repo: &str) -> Entry {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -425,9 +425,64 @@ fn format_golden_path() {
     assert!(entry_lines[1].contains("zebra"), "zebra should be second");
 }
 
+#[test]
+fn format_keeps_spaced_local_path_valid() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("my skills")).unwrap();
+    std::fs::write(
+        dir.path().join("my skills/git commit.md"),
+        "# Commit skill\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "local  skill  commit  \"my skills/git commit.md\"\n",
+    )
+    .unwrap();
+
+    sf(dir.path()).arg("validate").assert().success();
+    sf(dir.path()).arg("format").assert().success();
+    sf(dir.path()).arg("validate").assert().success();
+
+    let text = std::fs::read_to_string(dir.path().join("Skillfile")).unwrap();
+    assert!(text.contains("local  skill  commit  \"my skills/git commit.md\""));
+}
+
 // ---------------------------------------------------------------------------
 // add, remove
 // ---------------------------------------------------------------------------
+
+#[test]
+fn add_keeps_spaced_local_path_valid() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("my skills")).unwrap();
+    std::fs::write(
+        dir.path().join("my skills/git commit.md"),
+        "# Commit skill\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("Skillfile"), "# empty\n").unwrap();
+
+    sf(dir.path())
+        .env(
+            "SKILLFILE_CONFIG_PATH",
+            dir.path().join("missing-config.toml"),
+        )
+        .args([
+            "add",
+            "local",
+            "skill",
+            "my skills/git commit.md",
+            "--name",
+            "commit",
+        ])
+        .assert()
+        .success();
+    sf(dir.path()).arg("validate").assert().success();
+
+    let text = std::fs::read_to_string(dir.path().join("Skillfile")).unwrap();
+    assert!(text.contains("local  skill  commit  \"my skills/git commit.md\""));
+}
 
 #[test]
 fn add_then_remove() {


### PR DESCRIPTION
## Summary

- quote serialized fields containing whitespace or `#` in `add` and `format` output
- preserve quoted hash-prefixed fields when stripping inline comments

## Why

Rewriting a valid quoted path could remove its quotes, causing the next parse to treat it as a different entry. Hash-prefixed quoted fields were also mistaken for comments. Closes #146.

## Validation

- `cargo test --workspace` - passed
- `cargo clippy --workspace --all-targets -- -D warnings` - passed
- `cargo fmt --all -- --check` - passed
- `cargo build -p skillfile` - passed
- `cargo deny check` - passed
- `cargo machete` - passed
