### PR TITLE
fix(add): reject piped input before interactive prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to skillfile are documented here.
 
 ## Unreleased
 
+### Fixed
+
+- **Interactive add now rejects piped input instead of hanging** - bare `skillfile add` and bulk selection require stdin as well as stderr to be attached to a terminal before starting their interactive UI by @ychampion
+
 ## v1.7.4 - 13-07-2026
 
 ### Changed

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -13,6 +13,17 @@ use skillfile_deploy::install::{
 use skillfile_sources::strategy::format_parts;
 use skillfile_sources::sync::{sync_entry, vendor_dir_for, SyncContext};
 
+fn has_interactive_stdio(stdin_is_terminal: bool, stderr_is_terminal: bool) -> bool {
+    stdin_is_terminal && stderr_is_terminal
+}
+
+fn is_interactive_terminal() -> bool {
+    has_interactive_stdio(
+        std::io::stdin().is_terminal(),
+        std::io::stderr().is_terminal(),
+    )
+}
+
 fn format_line(entry: &Entry) -> String {
     let mut parts = vec![
         entry.source_type().to_string(),
@@ -215,7 +226,7 @@ fn select_entries(
     if args.no_interactive {
         return Ok(entries.to_vec());
     }
-    if !std::io::stderr().is_terminal() {
+    if !is_interactive_terminal() {
         return Err(SkillfileError::Manifest(
             "interactive selection requires a terminal; use --no-interactive".to_string(),
         ));
@@ -458,7 +469,7 @@ pub fn cmd_add(entry: &Entry, repo_root: &Path) -> Result<(), SkillfileError> {
 /// add functions. Each flow terminates in a function that is already
 /// tested independently.
 pub fn cmd_add_interactive(repo_root: &Path) -> Result<(), SkillfileError> {
-    if !std::io::stderr().is_terminal() {
+    if !is_interactive_terminal() {
         return Err(SkillfileError::Manifest(
             "interactive wizard requires a terminal; use `skillfile add github|local|url` directly"
                 .to_owned(),
@@ -671,6 +682,14 @@ mod tests {
 
     fn write_manifest(dir: &Path, content: &str) {
         std::fs::write(dir.join(MANIFEST_NAME), content).unwrap();
+    }
+
+    #[test]
+    fn interactive_stdio_requires_both_streams() {
+        assert!(has_interactive_stdio(true, true));
+        assert!(!has_interactive_stdio(true, false));
+        assert!(!has_interactive_stdio(false, true));
+        assert!(!has_interactive_stdio(false, false));
     }
 
     #[test]

--- a/tests/interactive.rs
+++ b/tests/interactive.rs
@@ -53,6 +53,27 @@ fn pty_input_sanity_check() {
     session.exp_eof().ok();
 }
 
+#[test]
+fn add_wizard_rejects_piped_stdin() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("Skillfile"), "# empty\n").unwrap();
+
+    // Keep stderr attached to rexpect's PTY while piping only stdin.
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", "printf '\\n' | \"$SKILLFILE_BIN\" add"])
+        .current_dir(dir.path())
+        .env("SKILLFILE_BIN", skillfile_bin());
+
+    let mut session = rexpect::session::spawn_command(cmd, Some(2_000))
+        .expect("failed to spawn skillfile add with piped stdin");
+    session
+        .exp_string("interactive wizard requires a terminal")
+        .expect("piped stdin should be rejected before the prompt starts");
+    session
+        .exp_eof()
+        .expect("skillfile add should exit after rejecting piped stdin");
+}
+
 // ---------------------------------------------------------------------------
 // init wizard
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- require interactive stdin before starting either `skillfile add` UI
- add a PTY regression that pipes stdin while keeping stderr attached to a terminal

## Why

Bare `skillfile add` could start its prompt with piped stdin and then wait indefinitely for input.

Closes #160.

## Validation

- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --check`
- `cargo deny check`
- `cargo machete`