### PR TITLE
fix(cli): honor false boolean environment flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to skillfile are documented here.
 
 ## Unreleased
 
+### Fixed
+
+- **Boolean environment flags now require explicit true values** - `CI=false` no longer blocks `skillfile init`, while `SKILLFILE_QUIET=0` and `SKILLFILE_NO_UPDATE_NOTIFIER=0` no longer enable their respective flags by @floze-the-genius
+
 ## v1.8.0 - 17-07-2026
 
 ### Added

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -474,17 +474,36 @@ fn print_init_outro(entry_count: usize) -> Result<(), SkillfileError> {
     Ok(())
 }
 
+fn init_guard_error(
+    is_ci: bool,
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+) -> Option<&'static str> {
+    if is_ci {
+        Some(
+            "skillfile init is unavailable when CI=true.\n\
+             Use `skillfile add` for scripted/CI usage.",
+        )
+    } else if !stdin_is_terminal || !stdout_is_terminal {
+        Some(
+            "skillfile init requires an interactive terminal.\n\
+             Use `skillfile add` for scripted/CI usage.",
+        )
+    } else {
+        None
+    }
+}
+
 pub fn cmd_init(repo_root: &Path) -> Result<(), SkillfileError> {
     // TTY guard: cliclack requires an interactive terminal. Check stdin, stdout,
     // and the CI env var because some CI runners (macOS GitHub Actions) report
     // piped fds as TTY.
-    let is_ci = std::env::var("CI").is_ok();
-    if is_ci || !io::stdin().is_terminal() || !io::stdout().is_terminal() {
-        return Err(SkillfileError::Manifest(
-            "skillfile init requires an interactive terminal.\n\
-             Use `skillfile add` for scripted/CI usage."
-                .into(),
-        ));
+    if let Some(message) = init_guard_error(
+        crate::env_flag("CI"),
+        io::stdin().is_terminal(),
+        io::stdout().is_terminal(),
+    ) {
+        return Err(SkillfileError::Manifest(message.into()));
     }
 
     cliclack::intro(console::style(" skillfile init ").on_cyan().black())?;
@@ -546,6 +565,32 @@ pub fn cmd_init(repo_root: &Path) -> Result<(), SkillfileError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn init_guard_distinguishes_ci_from_missing_terminal() {
+        assert_eq!(
+            init_guard_error(true, true, true),
+            Some(
+                "skillfile init is unavailable when CI=true.\n\
+                 Use `skillfile add` for scripted/CI usage."
+            )
+        );
+        assert_eq!(
+            init_guard_error(false, false, true),
+            Some(
+                "skillfile init requires an interactive terminal.\n\
+                 Use `skillfile add` for scripted/CI usage."
+            )
+        );
+        assert_eq!(
+            init_guard_error(false, true, false),
+            Some(
+                "skillfile init requires an interactive terminal.\n\
+                 Use `skillfile add` for scripted/CI usage."
+            )
+        );
+        assert_eq!(init_guard_error(false, true, true), None);
+    }
 
     // -- build_manifest_with_targets --
 

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -474,17 +474,13 @@ fn print_init_outro(entry_count: usize) -> Result<(), SkillfileError> {
     Ok(())
 }
 
-fn init_guard_error(
-    is_ci: bool,
-    stdin_is_terminal: bool,
-    stdout_is_terminal: bool,
-) -> Option<&'static str> {
+fn init_guard_error(is_ci: bool, has_interactive_terminal: bool) -> Option<&'static str> {
     if is_ci {
         Some(
             "skillfile init is unavailable when CI=true.\n\
              Use `skillfile add` for scripted/CI usage.",
         )
-    } else if !stdin_is_terminal || !stdout_is_terminal {
+    } else if !has_interactive_terminal {
         Some(
             "skillfile init requires an interactive terminal.\n\
              Use `skillfile add` for scripted/CI usage.",
@@ -500,8 +496,7 @@ pub fn cmd_init(repo_root: &Path) -> Result<(), SkillfileError> {
     // piped fds as TTY.
     if let Some(message) = init_guard_error(
         crate::env_flag("CI"),
-        io::stdin().is_terminal(),
-        io::stdout().is_terminal(),
+        io::stdin().is_terminal() && io::stdout().is_terminal(),
     ) {
         return Err(SkillfileError::Manifest(message.into()));
     }
@@ -569,27 +564,20 @@ mod tests {
     #[test]
     fn init_guard_distinguishes_ci_from_missing_terminal() {
         assert_eq!(
-            init_guard_error(true, true, true),
+            init_guard_error(true, true),
             Some(
                 "skillfile init is unavailable when CI=true.\n\
                  Use `skillfile add` for scripted/CI usage."
             )
         );
         assert_eq!(
-            init_guard_error(false, false, true),
+            init_guard_error(false, false),
             Some(
                 "skillfile init requires an interactive terminal.\n\
                  Use `skillfile add` for scripted/CI usage."
             )
         );
-        assert_eq!(
-            init_guard_error(false, true, false),
-            Some(
-                "skillfile init requires an interactive terminal.\n\
-                 Use `skillfile add` for scripted/CI usage."
-            )
-        );
-        assert_eq!(init_guard_error(false, true, true), None);
+        assert_eq!(init_guard_error(false, true), None);
     }
 
     // -- build_manifest_with_targets --

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,3 +1,40 @@
 pub mod commands;
 pub mod config;
 pub mod patch;
+
+/// Return whether an environment variable contains an enabled boolean flag.
+///
+/// Boolean flags are enabled only by the documented values `1` and `true`.
+pub fn env_flag(name: &str) -> bool {
+    env_value_is_true(std::env::var(name).ok().as_deref())
+}
+
+fn env_value_is_true(value: Option<&str>) -> bool {
+    matches!(value, Some("1" | "true"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::env_value_is_true;
+
+    #[test]
+    fn env_flags_require_explicit_true_values() {
+        for value in [Some("1"), Some("true")] {
+            assert!(env_value_is_true(value), "{value:?} should enable the flag");
+        }
+
+        for value in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("yes"),
+            Some("TRUE"),
+        ] {
+            assert!(
+                !env_value_is_true(value),
+                "{value:?} should not enable the flag"
+            );
+        }
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -829,7 +829,7 @@ fn run() -> Result<(), SkillfileError> {
             e.exit();
         }
     };
-    let quiet = cli.quiet || std::env::var("SKILLFILE_QUIET").is_ok_and(|v| !v.is_empty());
+    let quiet = cli.quiet || skillfile::env_flag("SKILLFILE_QUIET");
     skillfile_core::output::set_quiet(quiet);
     let repo_root = PathBuf::from(".");
     run_content_commands(&repo_root, cli.command)

--- a/crates/cli/src/update_check.rs
+++ b/crates/cli/src/update_check.rs
@@ -63,10 +63,10 @@ pub fn cache_path() -> Option<PathBuf> {
 }
 
 pub fn should_check() -> bool {
-    if std::env::var("SKILLFILE_NO_UPDATE_NOTIFIER").is_ok_and(|v| !v.is_empty()) {
+    if skillfile::env_flag("SKILLFILE_NO_UPDATE_NOTIFIER") {
         return false;
     }
-    if std::env::var("CI").is_ok_and(|v| v == "true" || v == "1") {
+    if skillfile::env_flag("CI") {
         return false;
     }
     std::io::stderr().is_terminal()
@@ -235,6 +235,7 @@ fn parse_timestamp(s: &str) -> Option<SystemTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     // -----------------------------------------------------------------------
     // is_newer — pure semver comparison
@@ -292,16 +293,12 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[serial]
     fn should_check_blocked_by_no_update_notifier() {
-        // Note: env var manipulation is not thread-safe, but these tests
-        // are simple enough that interference is unlikely.
         let key = "SKILLFILE_NO_UPDATE_NOTIFIER";
         let original = std::env::var(key).ok();
 
         std::env::set_var(key, "1");
-        assert!(!should_check());
-
-        std::env::set_var(key, "yes");
         assert!(!should_check());
 
         // Restore
@@ -312,6 +309,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn should_check_blocked_by_ci_true() {
         let key = "CI";
         let original = std::env::var(key).ok();
@@ -329,6 +327,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn should_check_not_blocked_by_empty_notifier_var() {
         let key = "SKILLFILE_NO_UPDATE_NOTIFIER";
         let original = std::env::var(key).ok();
@@ -343,6 +342,28 @@ mod tests {
         match original {
             Some(v) => std::env::set_var(key, v),
             None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn should_check_not_blocked_by_false_boolean_flags() {
+        let notifier_key = "SKILLFILE_NO_UPDATE_NOTIFIER";
+        let ci_key = "CI";
+        let original_notifier = std::env::var(notifier_key).ok();
+        let original_ci = std::env::var(ci_key).ok();
+
+        std::env::set_var(notifier_key, "0");
+        std::env::set_var(ci_key, "false");
+        assert_eq!(should_check(), std::io::stderr().is_terminal());
+
+        match original_notifier {
+            Some(v) => std::env::set_var(notifier_key, v),
+            None => std::env::remove_var(notifier_key),
+        }
+        match original_ci {
+            Some(v) => std::env::set_var(ci_key, v),
+            None => std::env::remove_var(ci_key),
         }
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -144,7 +144,22 @@ fn init_fails_without_tty() {
         .timeout(std::time::Duration::from_secs(5))
         .assert()
         .failure()
-        .stderr(predicate::str::contains("interactive terminal"));
+        .stderr(predicate::str::contains(
+            "skillfile init is unavailable when CI=true",
+        ));
+}
+
+#[test]
+fn ci_false_does_not_trigger_ci_guard() {
+    let dir = tempfile::tempdir().unwrap();
+    sf(dir.path())
+        .arg("init")
+        .env("CI", "false")
+        .timeout(std::time::Duration::from_secs(5))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("interactive terminal"))
+        .stderr(predicate::str::contains("CI=true").not());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- centralize boolean environment flag parsing so only `1` and `true` enable a flag
- keep `CI=false` interactive while reporting a distinct error when CI is actually enabled
- apply the same semantics to quiet mode and the update notifier, with regression coverage

Fixes #161

## Testing

- `cargo fmt --check`
- `cargo test -p skillfile` (406 library tests, 36 binary tests, 5 integration tests)
- `cargo build -p skillfile`
- `cargo test -p skillfile-functional-tests --test cli` (57 tests)
- `git diff --check`

## AI disclosure

This contribution was prepared with assistance from OpenAI Codex. The implementation follows the repository's tracked `AGENTS.md` guidance, including focused regression tests and the required changelog entry.