### PR TITLE
Harden explicit install path targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to skillfile are documented here.
 
 ## Unreleased
 
+### Added
+
+- **Explicit install path targets** - deploy skills and agents to custom local or global directories using `install-path`, with support for formatting, validation, status, diff, pin, and unpin by @mto-s
+
 ### Fixed
 
 - **Boolean environment flags now require explicit true values** - `CI=false` no longer blocks `skillfile init`, while `SKILLFILE_QUIET=0` and `SKILLFILE_NO_UPDATE_NOTIFIER=0` no longer enable their respective flags by @floze-the-genius

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use super::format::sorted_manifest_text;
 use skillfile_core::error::SkillfileError;
 use skillfile_core::lock::{read_lock, write_lock};
-use skillfile_core::models::{EntityType, Entry, Manifest, SourceFields, DEFAULT_REF};
+use skillfile_core::models::{
+    EntityType, Entry, InstallOptions, Manifest, SourceFields, DEFAULT_REF,
+};
 use skillfile_core::parser::{infer_name, parse_manifest, parse_owner_repo_ref, MANIFEST_NAME};
 use skillfile_deploy::install::{
     capture_install_snapshot, install_entry_with_outcome, InstallOutcome, InstallSkipReason,
@@ -68,13 +70,17 @@ fn sync_and_install(
         })?;
 
     let mut report = InstallReport::default();
+    let install_opts = InstallOptions {
+        dry_run: false,
+        overwrite: false,
+    };
     for target in &ctx.manifest.install_targets {
         let outcome = install_entry_with_outcome(
             entry,
             target,
             &skillfile_deploy::install::InstallCtx {
                 repo_root: ctx.repo_root,
-                opts: None,
+                opts: Some(&install_opts),
             },
         )?;
         let label = format!("{target}");

--- a/crates/cli/src/commands/installed_variants.rs
+++ b/crates/cli/src/commands/installed_variants.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use skillfile_core::error::SkillfileError;
 use skillfile_core::models::{Entry, Manifest};
+use skillfile_deploy::paths::is_safe_installed_path;
 use skillfile_deploy::target::ResolvedInstallTarget;
 
 pub(crate) struct SingleFileVariant {
@@ -31,7 +32,7 @@ pub(crate) fn installed_single_file_variants(
         }
 
         let path = resolved.installed_path(entry, repo_root);
-        if !path.exists() {
+        if !is_safe_installed_path(&path) || !path.exists() {
             continue;
         }
 

--- a/crates/core/src/parser.rs
+++ b/crates/core/src/parser.rs
@@ -379,9 +379,9 @@ fn parse_install_line(parts: &[String], lineno: usize, acc: &mut ParseAccumulato
 }
 
 fn parse_install_path_line(parts: &[String], lineno: usize, acc: &mut ParseAccumulator) {
-    if parts.len() < 4 {
+    if parts.len() != 4 {
         acc.warnings.push(format!(
-            "warning: line {lineno}: install-path line needs: tool-name entity-type path"
+            "warning: line {lineno}: install-path line needs exactly: tool-name entity-type path"
         ));
         return;
     }

--- a/crates/core/src/patch.rs
+++ b/crates/core/src/patch.rs
@@ -457,14 +457,26 @@ pub fn walkdir(dir: &Path) -> Vec<PathBuf> {
 }
 
 fn walkdir_inner(dir: &Path, result: &mut Vec<PathBuf>) {
+    let Ok(metadata) = std::fs::symlink_metadata(dir) else {
+        return;
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return;
+    }
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.is_dir() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
             walkdir_inner(&path, result);
-        } else {
+        } else if file_type.is_file() {
             result.push(path);
         }
     }
@@ -937,6 +949,24 @@ mod tests {
             .collect();
         assert!(names.contains(&"top.txt".to_string()));
         assert!(names.contains(&"nested.txt".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walkdir_skips_symlinked_files_and_directories() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(source.join("real.md"), "real").unwrap();
+        std::fs::write(outside.join("secret.md"), "secret").unwrap();
+        symlink(outside.join("secret.md"), source.join("linked-file.md")).unwrap();
+        symlink(&outside, source.join("linked-dir")).unwrap();
+
+        assert_eq!(walkdir(&source), vec![source.join("real.md")]);
     }
 
     #[test]

--- a/crates/deploy/src/adapter.rs
+++ b/crates/deploy/src/adapter.rs
@@ -148,6 +148,15 @@ pub(crate) fn ensure_no_symlink_components(path: &Path) -> std::io::Result<()> {
         if component_path.as_os_str().is_empty() {
             continue;
         }
+        // Top-level absolute components are controlled by the OS or an administrator. macOS
+        // exposes `/var` as a symlink, and Windows may use equivalent root-level aliases.
+        if component_path.is_absolute()
+            && component_path
+                .parent()
+                .is_some_and(|parent| parent.parent().is_none())
+        {
+            continue;
+        }
         match std::fs::symlink_metadata(component_path) {
             Ok(metadata) if metadata.file_type().is_symlink() => {
                 return Err(symlink_error(component_path));
@@ -932,6 +941,23 @@ mod tests {
     #[test]
     fn registry_get_unknown_returns_none() {
         assert!(adapters().get("unknown-tool").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_guard_allows_root_managed_top_level_symlink() {
+        let root_link = ["/var", "/bin", "/sbin", "/lib"]
+            .into_iter()
+            .map(Path::new)
+            .find(|path| {
+                std::fs::symlink_metadata(path)
+                    .is_ok_and(|metadata| metadata.file_type().is_symlink())
+            });
+        let Some(root_link) = root_link else {
+            return;
+        };
+
+        assert!(ensure_no_symlink_components(&root_link.join("skillfile-path-check")).is_ok());
     }
 
     // -- supports() --

--- a/crates/deploy/src/adapter.rs
+++ b/crates/deploy/src/adapter.rs
@@ -95,6 +95,7 @@ pub struct EntityConfig {
 pub struct FileSystemAdapter {
     name: String,
     entities: HashMap<EntityType, EntityConfig>,
+    cleanup_legacy_flat_files: bool,
 }
 
 impl FileSystemAdapter {
@@ -102,7 +103,13 @@ impl FileSystemAdapter {
         Self {
             name: name.to_string(),
             entities,
+            cleanup_legacy_flat_files: true,
         }
+    }
+
+    pub(crate) fn preserve_legacy_flat_files(mut self) -> Self {
+        self.cleanup_legacy_flat_files = false;
+        self
     }
 
     /// Returns true if the entity type uses flat file layout (e.g., agents).
@@ -136,6 +143,23 @@ fn preferred_home_dir() -> PathBuf {
     preferred_home_dir_from(std::env::var_os("HOME"), dirs::home_dir())
 }
 
+pub(crate) fn ensure_no_symlink_components(path: &Path) -> std::io::Result<()> {
+    for component_path in path.ancestors() {
+        if component_path.as_os_str().is_empty() {
+            continue;
+        }
+        match std::fs::symlink_metadata(component_path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(symlink_error(component_path));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
 impl PlatformAdapter for FileSystemAdapter {
     fn name(&self) -> &str {
         &self.name
@@ -157,9 +181,11 @@ impl PlatformAdapter for FileSystemAdapter {
             Scope::Global => &config.global_path,
             Scope::Local => &config.local_path,
         };
-        if raw.starts_with('~') {
+        if raw == "~" {
+            preferred_home_dir()
+        } else if raw.starts_with("~/") {
             let home = preferred_home_dir();
-            home.join(raw.strip_prefix("~/").unwrap_or(raw))
+            home.join(raw.strip_prefix("~/").unwrap_or_default())
         } else {
             ctx.repo_root.join(raw)
         }
@@ -175,6 +201,11 @@ impl PlatformAdapter for FileSystemAdapter {
             repo_root: req.repo_root,
         };
         let target_dir = self.target_dir(req.entry.entity_type, &ctx);
+        if ensure_no_symlink_components(&target_dir).is_err()
+            || ensure_no_symlink_components(req.source).is_err()
+        {
+            return HashMap::new();
+        }
         // Use filesystem truth as a backstop for ambiguous manifest paths.
         let is_dir = is_dir_entry(req.entry) || req.source.is_dir();
 
@@ -213,7 +244,7 @@ impl PlatformAdapter for FileSystemAdapter {
 
         // Migration: nested-mode installs may leave behind a legacy flat {name}.md from an older
         // layout. Remove it after a successful install to avoid duplicate skill loading.
-        if !self.is_flat_mode(req.entry.entity_type) {
+        if self.cleanup_legacy_flat_files && !self.is_flat_mode(req.entry.entity_type) {
             remove_orphan_flat_file(&req.entry.name, &target_dir);
         }
 
@@ -284,7 +315,7 @@ fn collect_dir_deploy_result(source: &Path, dest: &Path) -> DeployResult {
 /// Returns empty map when the installed directory does not exist.
 fn collect_nested_installed(entry: &Entry, target_dir: &Path) -> HashMap<String, PathBuf> {
     let installed_dir = target_dir.join(&entry.name);
-    if !installed_dir.is_dir() {
+    if ensure_no_symlink_components(&installed_dir).is_err() || !installed_dir.is_dir() {
         return HashMap::new();
     }
     collect_walkdir_relative(&installed_dir)
@@ -292,7 +323,7 @@ fn collect_nested_installed(entry: &Entry, target_dir: &Path) -> HashMap<String,
 
 /// Returns empty map when the vendor cache directory does not exist.
 fn collect_flat_installed_checked(vdir: &Path, target_dir: &Path) -> HashMap<String, PathBuf> {
-    if !vdir.is_dir() {
+    if ensure_no_symlink_components(target_dir).is_err() || !vdir.is_dir() {
         return HashMap::new();
     }
     collect_flat_installed(vdir, target_dir)
@@ -319,7 +350,7 @@ fn collect_flat_installed(vdir: &Path, target_dir: &Path) -> HashMap<String, Pat
             continue;
         }
         let dest = target_dir.join(file.file_name().unwrap_or_default());
-        if !dest.exists() {
+        if ensure_no_symlink_components(&dest).is_err() || !dest.exists() {
             continue;
         }
         let Some(key) = relative_file_key(vdir, &file) else {
@@ -397,7 +428,9 @@ fn cleanup_failed_path(path: &Path) {
 }
 
 fn copy_to_destination(op: &PlaceOp<'_>) -> std::io::Result<()> {
+    ensure_no_symlink_components(op.source)?;
     if let Some(parent) = op.dest.parent() {
+        ensure_no_symlink_components(parent)?;
         std::fs::create_dir_all(parent)?;
     }
 
@@ -1524,6 +1557,24 @@ mod tests {
             assert!(result.is_empty());
             assert!(!dest.join("SKILL.md").exists());
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deploy_entry_does_not_follow_symlinked_source_root() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("SKILL.md"), "# Outside\n").unwrap();
+        let source = dir.path().join("linked-source");
+        symlink(&outside, &source).unwrap();
+
+        let result = deploy_dir(&source, dir.path(), true);
+
+        assert!(result.is_empty());
+        assert!(!dir.path().join(".claude/skills/my-skill").exists());
     }
 
     #[cfg(unix)]

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -20,7 +20,7 @@ use skillfile_core::progress;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, is_dir_entry};
 use skillfile_sources::sync::{cmd_sync, vendor_dir_for};
 
-use crate::adapter::{DeployRequest, DirInstallMode};
+use crate::adapter::{ensure_no_symlink_components, DeployRequest, DirInstallMode};
 use crate::paths::source_path;
 use crate::target::ResolvedInstallTarget;
 
@@ -189,7 +189,7 @@ fn installed_single_file_variants(
             continue;
         }
         let path = resolved.installed_path(entry, repo_root);
-        if !path.exists() {
+        if ensure_no_symlink_components(&path).is_err() || !path.exists() {
             continue;
         }
         variants.push(SingleInstalledVariant {
@@ -804,11 +804,22 @@ fn install_effect_paths(ctx: &InstallValidationCtx<'_>) -> Vec<PathBuf> {
         vec![target_dir.join(&ctx.entry.name)]
     };
 
-    if ctx.resolved_target.dir_mode(ctx.entry.entity_type) != Some(DirInstallMode::Flat) {
+    if matches!(ctx.target, InstallTarget::Platform { .. })
+        && ctx.resolved_target.dir_mode(ctx.entry.entity_type) != Some(DirInstallMode::Flat)
+    {
         paths.push(target_dir.join(format!("{}.md", ctx.entry.name)));
     }
     paths.push(patch_effect_path(ctx));
     paths
+}
+
+fn ensure_safe_install_effect_paths(ctx: &InstallValidationCtx<'_>) -> Result<(), SkillfileError> {
+    for path in install_effect_paths(ctx) {
+        if let Err(error) = ensure_no_symlink_components(&path) {
+            return Err(install_failure(ctx.entry, ctx.target, &error.to_string()));
+        }
+    }
+    Ok(())
 }
 
 pub fn capture_install_snapshot(
@@ -834,9 +845,12 @@ fn install_effect_paths_for_target(
     if !resolved_target.supports(entry.entity_type) {
         return Vec::new();
     }
-    let Some(source) = source_path(entry, repo_root).filter(|path| path.exists()) else {
+    let Some(source) = source_path(entry, repo_root) else {
         return Vec::new();
     };
+    if ensure_no_symlink_components(&source).is_err() || !source.exists() {
+        return Vec::new();
+    }
     let default_opts = InstallOptions::default();
     let validation_ctx = InstallValidationCtx {
         entry,
@@ -1010,13 +1024,16 @@ pub fn install_entry_with_outcome(
         ));
     }
 
-    let source = match source_path(entry, ctx.repo_root) {
-        Some(p) if p.exists() => p,
-        _ => {
-            eprintln!("  warning: source missing for {}, skipping", entry.name);
-            return Ok(InstallOutcome::Skipped(InstallSkipReason::MissingSource));
-        }
+    let Some(source) = source_path(entry, ctx.repo_root) else {
+        eprintln!("  warning: source missing for {}, skipping", entry.name);
+        return Ok(InstallOutcome::Skipped(InstallSkipReason::MissingSource));
     };
+    ensure_no_symlink_components(&source)
+        .map_err(|error| install_failure(entry, target, &error.to_string()))?;
+    if !source.exists() {
+        eprintln!("  warning: source missing for {}, skipping", entry.name);
+        return Ok(InstallOutcome::Skipped(InstallSkipReason::MissingSource));
+    }
 
     let is_dir = is_dir_entry(entry) || source.is_dir();
     let validation_ctx = InstallValidationCtx {
@@ -1028,6 +1045,7 @@ pub fn install_entry_with_outcome(
         is_dir,
         opts,
     };
+    ensure_safe_install_effect_paths(&validation_ctx)?;
     let plan = build_install_plan(&validation_ctx);
     let snapshot = if opts.dry_run {
         InstallSnapshot::default()

--- a/crates/deploy/src/paths.rs
+++ b/crates/deploy/src/paths.rs
@@ -7,7 +7,7 @@ use skillfile_core::patch::walkdir;
 use skillfile_sources::strategy::{content_file, is_cached_dir_entry, meta_sha};
 use skillfile_sources::sync::vendor_dir_for;
 
-use crate::adapter::{adapters, AdapterScope};
+use crate::adapter::{adapters, ensure_no_symlink_components, AdapterScope};
 use crate::target::ResolvedInstallTarget;
 
 pub fn resolve_target_dir(
@@ -28,7 +28,15 @@ pub fn installed_path(
     repo_root: &Path,
 ) -> Result<PathBuf, SkillfileError> {
     let target = first_supporting_target(entry, manifest)?;
-    Ok(target.installed_path(entry, repo_root))
+    let path = target.installed_path(entry, repo_root);
+    ensure_no_symlink_components(&path)
+        .map_err(|error| SkillfileError::Install(error.to_string()))?;
+    Ok(path)
+}
+
+#[must_use]
+pub fn is_safe_installed_path(path: &Path) -> bool {
+    ensure_no_symlink_components(path).is_ok()
 }
 
 /// Installed paths for a single-file entry across all install targets.
@@ -43,7 +51,10 @@ pub fn installed_paths(
         if !target.supports(entry.entity_type) {
             continue;
         }
-        paths.push(target.installed_path(entry, repo_root));
+        let path = target.installed_path(entry, repo_root);
+        if is_safe_installed_path(&path) {
+            paths.push(path);
+        }
     }
     Ok(paths)
 }

--- a/crates/deploy/src/target.rs
+++ b/crates/deploy/src/target.rs
@@ -96,7 +96,7 @@ fn explicit_adapter(tool_name: &str, entity_type: EntityType, path: &str) -> Fil
             dir_mode: default_dir_mode(entity_type),
         },
     );
-    FileSystemAdapter::new(tool_name, entities)
+    FileSystemAdapter::new(tool_name, entities).preserve_legacy_flat_files()
 }
 
 fn default_dir_mode(entity_type: EntityType) -> DirInstallMode {

--- a/tests/install_path.rs
+++ b/tests/install_path.rs
@@ -1,5 +1,105 @@
 use skillfile_functional_tests::sf;
 
+const LOCKED_SHA: &str = "abc123def456abc123def456abc123def456abc1";
+const UPSTREAM_SKILL: &str = "# Release Skill\n\nUpstream content.\n";
+
+fn write_cached_remote_skill(root: &std::path::Path, name: &str) {
+    std::fs::write(
+        root.join("Skillfile"),
+        format!(
+            "install-path  \"custom target\"  skill  \"./custom targets/skills\"\n\
+             github  skill  {name}  owner/repo  skills/{name}.md  main\n"
+        ),
+    )
+    .unwrap();
+
+    let lock = serde_json::json!({
+        format!("github/skill/{name}"): {
+            "sha": LOCKED_SHA,
+            "raw_url": format!(
+                "https://raw.githubusercontent.com/owner/repo/{LOCKED_SHA}/skills/{name}.md"
+            )
+        }
+    });
+    std::fs::write(
+        root.join("Skillfile.lock"),
+        serde_json::to_string_pretty(&lock).unwrap(),
+    )
+    .unwrap();
+
+    let cache_dir = root.join(format!(".skillfile/cache/skills/{name}"));
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(cache_dir.join(format!("{name}.md")), UPSTREAM_SKILL).unwrap();
+    std::fs::write(
+        cache_dir.join(".meta"),
+        format!(r#"{{"sha":"{LOCKED_SHA}"}}"#),
+    )
+    .unwrap();
+}
+
+fn command_stdout(root: &std::path::Path, args: &[&str]) -> String {
+    let output = sf(root).args(args).output().unwrap();
+    assert!(
+        output.status.success(),
+        "{} failed:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn format_validate_and_install(root: &std::path::Path, name: &str) -> std::path::PathBuf {
+    command_stdout(root, &["validate"]);
+    command_stdout(root, &["format"]);
+    command_stdout(root, &["validate"]);
+
+    let manifest = std::fs::read_to_string(root.join("Skillfile")).unwrap();
+    assert!(manifest.contains("install-path  'custom target'  skill  './custom targets/skills'"));
+
+    command_stdout(root, &["install"]);
+    let installed = root.join(format!("custom targets/skills/{name}/SKILL.md"));
+    assert_eq!(std::fs::read_to_string(&installed).unwrap(), UPSTREAM_SKILL);
+    installed
+}
+
+fn assert_install_is_observable(root: &std::path::Path, name: &str) {
+    let info = command_stdout(root, &["info", name]);
+    assert!(info.contains(&format!("custom targets/skills/{name}/SKILL.md")));
+
+    let status = command_stdout(root, &["status"]);
+    assert!(status.contains(name));
+    assert!(!status.contains("[modified]"));
+}
+
+fn assert_diff_and_pin_lifecycle(root: &std::path::Path, name: &str, installed: &std::path::Path) {
+    std::fs::write(
+        installed,
+        format!("{UPSTREAM_SKILL}\n## Custom edit\n\nRelease validation.\n"),
+    )
+    .unwrap();
+
+    assert!(command_stdout(root, &["status"]).contains("[modified]"));
+    let diff = command_stdout(root, &["diff", name]);
+    assert!(diff.contains("Custom edit"));
+    assert!(diff.contains("custom target"));
+
+    command_stdout(root, &["pin", name]);
+    let patch = root.join(format!(".skillfile/patches/skills/{name}.patch"));
+    assert!(std::fs::read_to_string(&patch)
+        .unwrap()
+        .contains("Release validation."));
+
+    std::fs::remove_file(installed).unwrap();
+    command_stdout(root, &["install"]);
+    assert!(std::fs::read_to_string(installed)
+        .unwrap()
+        .contains("Release validation."));
+
+    command_stdout(root, &["unpin", name]);
+    assert!(!patch.exists());
+    assert_eq!(std::fs::read_to_string(installed).unwrap(), UPSTREAM_SKILL);
+}
+
 #[test]
 fn install_path_deploys_skill_nested_and_agent_flat() {
     let dir = tempfile::tempdir().unwrap();
@@ -64,4 +164,300 @@ fn install_path_expands_home() {
         std::fs::read_to_string(&deployed_skill).unwrap(),
         "# Home Skill\n"
     );
+}
+
+#[test]
+fn install_path_expands_bare_home_marker() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let home = tempfile::tempdir().unwrap();
+
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    std::fs::write(root.join("skills/home-skill.md"), "# Home Skill\n").unwrap();
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path  home-target  skill  ~\n\
+         local  skill  home-skill  skills/home-skill.md\n",
+    )
+    .unwrap();
+
+    sf(root)
+        .env("HOME", home.path())
+        .arg("install")
+        .assert()
+        .success();
+
+    assert!(home.path().join("home-skill/SKILL.md").exists());
+    assert!(!home.path().join("~/home-skill/SKILL.md").exists());
+}
+
+#[test]
+fn install_path_supports_release_lifecycle_for_cached_remote_skill() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let name = "release-skill";
+    write_cached_remote_skill(root, name);
+
+    let installed = format_validate_and_install(root, name);
+    assert_install_is_observable(root, name);
+    assert_diff_and_pin_lifecycle(root, name, &installed);
+}
+
+#[test]
+fn install_path_rejects_unquoted_extra_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install-path custom skill ./my skills\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path()).arg("validate").output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "validate unexpectedly succeeded");
+    assert!(
+        stderr.contains("install-path line needs exactly: tool-name entity-type path"),
+        "unexpected validation error:\n{stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn install_path_refuses_symlinked_target_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let outside = tempfile::tempdir().unwrap();
+
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    std::fs::write(root.join("skills/escape.md"), "# Must not escape\n").unwrap();
+    std::os::unix::fs::symlink(outside.path(), root.join("linked-target")).unwrap();
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path custom skill ./linked-target\n\
+         local skill escape skills/escape.md\n",
+    )
+    .unwrap();
+
+    let output = sf(root).arg("install").output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "install unexpectedly succeeded");
+    assert!(
+        stderr.contains("refusing to traverse symlink"),
+        "unexpected install error:\n{stderr}"
+    );
+    assert!(!outside.path().join("escape/SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn install_path_refuses_symlinked_nested_skill_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let outside = tempfile::tempdir().unwrap();
+
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    std::fs::create_dir_all(root.join("out/skills")).unwrap();
+    std::fs::write(root.join("skills/escape.md"), "# Must not escape\n").unwrap();
+    std::os::unix::fs::symlink(outside.path(), root.join("out/skills/escape")).unwrap();
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path custom skill ./out/skills\n\
+         local skill escape skills/escape.md\n",
+    )
+    .unwrap();
+
+    let output = sf(root).arg("install").output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "install unexpectedly succeeded");
+    assert!(
+        stderr.contains("refusing to traverse symlink"),
+        "unexpected install error:\n{stderr}"
+    );
+    assert!(!outside.path().join("SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn install_path_refuses_symlinked_single_file_source_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let outside = tempfile::tempdir().unwrap();
+
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    let outside_file = outside.path().join("secret.md");
+    std::fs::write(&outside_file, "SECRET OUTSIDE SOURCE\n").unwrap();
+    std::os::unix::fs::symlink(&outside_file, root.join("skills/escape.md")).unwrap();
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path custom skill ./out/skills\n\
+         local skill escape skills/escape.md\n",
+    )
+    .unwrap();
+
+    let output = sf(root).arg("install").output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "install unexpectedly succeeded");
+    assert!(
+        stderr.contains("refusing to traverse symlink"),
+        "unexpected install error:\n{stderr}"
+    );
+    assert!(!root.join("out/skills/escape/SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn install_path_refuses_symlinked_directory_source_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let outside = tempfile::tempdir().unwrap();
+
+    let outside_skill = outside.path().join("escape");
+    std::fs::create_dir_all(&outside_skill).unwrap();
+    std::fs::write(outside_skill.join("SKILL.md"), "SECRET OUTSIDE SOURCE\n").unwrap();
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    std::os::unix::fs::symlink(&outside_skill, root.join("skills/escape")).unwrap();
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path custom skill ./out/skills\n\
+         local skill escape skills/escape\n",
+    )
+    .unwrap();
+
+    let output = sf(root).arg("install").output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "install unexpectedly succeeded");
+    assert!(
+        stderr.contains("refusing to traverse symlink"),
+        "unexpected install error:\n{stderr}"
+    );
+    assert!(!root.join("out/skills/escape/SKILL.md").exists());
+}
+
+#[test]
+fn install_path_preserves_user_managed_legacy_shaped_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    std::fs::create_dir_all(root.join("out/skills")).unwrap();
+    std::fs::write(root.join("skills/demo.md"), "# Managed skill\n").unwrap();
+    std::fs::write(
+        root.join("out/skills/demo.md"),
+        "# User-managed flat file\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path custom skill ./out/skills\n\
+         local skill demo skills/demo.md\n",
+    )
+    .unwrap();
+
+    sf(root).arg("install").assert().success();
+
+    assert_eq!(
+        std::fs::read_to_string(root.join("out/skills/demo.md")).unwrap(),
+        "# User-managed flat file\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(root.join("out/skills/demo/SKILL.md")).unwrap(),
+        "# Managed skill\n"
+    );
+}
+
+#[test]
+fn add_preserves_existing_explicit_target_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join("agents")).unwrap();
+    std::fs::create_dir_all(root.join("team-agents")).unwrap();
+    std::fs::write(root.join("agents/reviewer.md"), "# Managed agent\n").unwrap();
+    std::fs::write(
+        root.join("team-agents/reviewer.md"),
+        "# User-managed agent\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path custom agent ./team-agents\n",
+    )
+    .unwrap();
+
+    sf(root)
+        .args(["add", "local", "agent", "agents/reviewer.md"])
+        .assert()
+        .success();
+
+    assert_eq!(
+        std::fs::read_to_string(root.join("team-agents/reviewer.md")).unwrap(),
+        "# User-managed agent\n"
+    );
+    assert!(std::fs::read_to_string(root.join("Skillfile"))
+        .unwrap()
+        .contains("local  agent  agents/reviewer.md"));
+}
+
+#[cfg(unix)]
+#[test]
+fn read_commands_do_not_follow_explicit_target_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let name = "release-skill";
+    write_cached_remote_skill(root, name);
+    command_stdout(root, &["install"]);
+
+    let installed = root.join("custom targets/skills/release-skill/SKILL.md");
+    let secret = root.join("outside-secret.txt");
+    std::fs::write(&secret, "DO NOT DISCLOSE\n").unwrap();
+    std::fs::remove_file(&installed).unwrap();
+    std::os::unix::fs::symlink(&secret, &installed).unwrap();
+
+    let status = command_stdout(root, &["status"]);
+    assert!(status.contains("[not installed]"));
+
+    for args in [["diff", name], ["pin", name]] {
+        let output = sf(root).args(args).output().unwrap();
+        assert!(!output.status.success());
+        assert!(!String::from_utf8_lossy(&output.stdout).contains("DO NOT DISCLOSE"));
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("DO NOT DISCLOSE"));
+    }
+    assert!(!root
+        .join(".skillfile/patches/skills/release-skill.patch")
+        .exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn install_path_preserves_legacy_shaped_sibling_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let outside = tempfile::tempdir().unwrap();
+
+    std::fs::create_dir_all(root.join("skills")).unwrap();
+    std::fs::create_dir_all(root.join("out/skills")).unwrap();
+    std::fs::write(root.join("skills/demo.md"), "# Managed skill\n").unwrap();
+    let outside_file = outside.path().join("user-managed.md");
+    std::fs::write(&outside_file, "# User-managed flat file\n").unwrap();
+    std::os::unix::fs::symlink(&outside_file, root.join("out/skills/demo.md")).unwrap();
+    std::fs::write(
+        root.join("Skillfile"),
+        "install-path custom skill ./out/skills\n\
+         local skill demo skills/demo.md\n",
+    )
+    .unwrap();
+
+    sf(root).arg("install").assert().success();
+
+    assert_eq!(
+        std::fs::read_to_string(outside_file).unwrap(),
+        "# User-managed flat file\n"
+    );
+    assert!(root.join("out/skills/demo.md").is_symlink());
+    assert!(root.join("out/skills/demo/SKILL.md").exists());
 }

--- a/tests/install_path.rs
+++ b/tests/install_path.rs
@@ -64,12 +64,16 @@ fn format_validate_and_install(root: &std::path::Path, name: &str) -> std::path:
 
 fn assert_install_is_observable(root: &std::path::Path, name: &str) {
     let info = command_stdout(root, &["info", name]);
+    let installed = info
+        .lines()
+        .find_map(|line| line.split_once("Installed:").map(|(_, path)| path.trim()))
+        .expect("info output must contain an Installed path");
     let installed_suffix = std::path::Path::new("custom targets")
         .join("skills")
         .join(name)
         .join("SKILL.md");
     assert!(
-        info.contains(installed_suffix.to_string_lossy().as_ref()),
+        std::path::Path::new(installed).ends_with(installed_suffix),
         "unexpected info output:\n{info}"
     );
 

--- a/tests/install_path.rs
+++ b/tests/install_path.rs
@@ -64,7 +64,14 @@ fn format_validate_and_install(root: &std::path::Path, name: &str) -> std::path:
 
 fn assert_install_is_observable(root: &std::path::Path, name: &str) {
     let info = command_stdout(root, &["info", name]);
-    assert!(info.contains(&format!("custom targets/skills/{name}/SKILL.md")));
+    let installed_suffix = std::path::Path::new("custom targets")
+        .join("skills")
+        .join(name)
+        .join("SKILL.md");
+    assert!(
+        info.contains(installed_suffix.to_string_lossy().as_ref()),
+        "unexpected info output:\n{info}"
+    );
 
     let status = command_stdout(root, &["status"]);
     assert!(status.contains(name));


### PR DESCRIPTION
**SUMMARY**

Harden explicit `install-path` behavior and add release-level functional coverage. Preserve user-managed files and reject unsafe filesystem paths.

**RATIONALE**

Explicit targets extend deployment beyond known platform directories. Release validation found parsing, home expansion, overwrite, legacy cleanup, and symlink cases that could truncate configuration, replace user files, or access content outside the declared source and target. These paths need a focused functional gate before the feature ships.

**CHANGES**

- Require exactly four fields in `parse_install_path_line` and resolve bare `~` directly to the home directory.
- Install from `add` with `overwrite: false` so existing targets are preserved.
- Reject symlinked source, destination, installed, patch, and rollback paths before reading or writing them.
- Skip symlinked entries in `walkdir` and installed-content discovery.
- Disable legacy flat-file cleanup for explicit nested targets while retaining it for built-in platform adapters.
- Add command-level `install-path` coverage for layouts, formatting, validation, lifecycle commands, collisions, and path safety.