### PR TITLE
fix(install): stop printing manifest warnings twice

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -735,6 +735,7 @@ fn run_source_commands(repo_root: &Path, cmd: Command) -> Result<(), SkillfileEr
             dry_run,
             entry_filter: entry.as_deref(),
             update,
+            print_warnings: true,
         }),
         Command::Status { check_upstream } => {
             commands::status::cmd_status(repo_root, check_upstream)

--- a/crates/deploy/src/install.rs
+++ b/crates/deploy/src/install.rs
@@ -1290,6 +1290,8 @@ pub fn cmd_install(repo_root: &Path, opts: &CmdInstallOpts<'_>) -> Result<(), Sk
         dry_run: opts.dry_run,
         entry_filter: None,
         update: opts.update,
+        // load_manifest already printed these warnings above.
+        print_warnings: false,
     });
 
     // Read new locked state (written by sync).

--- a/crates/sources/src/sync.rs
+++ b/crates/sources/src/sync.rs
@@ -1269,6 +1269,10 @@ pub struct SyncCmdOpts<'a> {
     pub dry_run: bool,
     pub entry_filter: Option<&'a str>,
     pub update: bool,
+    /// Whether to print manifest parse warnings. `cmd_install` parses the
+    /// manifest itself and already prints these, so it passes `false` here
+    /// to avoid showing the same warning twice.
+    pub print_warnings: bool,
 }
 
 /// Run the `sync` command.
@@ -1286,8 +1290,10 @@ pub fn cmd_sync(opts: &SyncCmdOpts<'_>) -> Result<(), SkillfileError> {
     }
 
     let result = parse_manifest(&manifest_path)?;
-    for w in &result.warnings {
-        eprintln!("{w}");
+    if opts.print_warnings {
+        for w in &result.warnings {
+            eprintln!("{w}");
+        }
     }
 
     let mut entries: Vec<&Entry> = result.manifest.entries.iter().collect();
@@ -2625,6 +2631,7 @@ mod tests {
             dry_run: false,
             entry_filter: None,
             update: false,
+            print_warnings: true,
         });
         assert!(result.is_ok(), "cmd_sync failed: {result:?}");
     }
@@ -2643,6 +2650,7 @@ mod tests {
             dry_run: false,
             entry_filter: None,
             update: false,
+            print_warnings: true,
         });
         assert!(result.is_ok());
     }
@@ -2657,6 +2665,7 @@ mod tests {
             dry_run: false,
             entry_filter: None,
             update: false,
+            print_warnings: true,
         });
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -2683,6 +2692,7 @@ mod tests {
             dry_run: false,
             entry_filter: Some("alpha"),
             update: false,
+            print_warnings: true,
         });
         assert!(result.is_ok(), "cmd_sync with filter failed: {result:?}");
     }
@@ -2702,6 +2712,7 @@ mod tests {
             dry_run: false,
             entry_filter: Some("nonexistent"),
             update: false,
+            print_warnings: true,
         });
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -2726,6 +2737,7 @@ mod tests {
             dry_run: true,
             entry_filter: None,
             update: false,
+            print_warnings: true,
         });
         assert!(result.is_ok(), "cmd_sync dry-run failed: {result:?}");
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -386,6 +386,32 @@ fn validate_duplicate_name_reported_once() {
 }
 
 #[test]
+fn install_prints_manifest_warning_once() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/a.md"), "# A\n").unwrap();
+    std::fs::write(dir.path().join("skills/b.md"), "# B\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "install  claude-code  local\n\
+         local  skill  dup  skills/a.md\n\
+         local  skill  dup  skills/b.md\n",
+    )
+    .unwrap();
+
+    let output = sf(dir.path()).arg("install").output().unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
+    assert_eq!(
+        stderr
+            .matches("warning: line 3: duplicate entry name 'dup'")
+            .count(),
+        1,
+        "manifest parse warning should only be printed once by install, got:\n{stderr}"
+    );
+}
+
+#[test]
 fn status_output_is_plain_text_when_captured() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(


### PR DESCRIPTION
## Summary

Closes #162.

`cmd_install` parses the Skillfile and prints its parse warnings, then calls `cmd_sync`, which re-parses the same manifest and prints the same warnings again. Any duplicate entry name, invalid line, or unknown source type ends up printed twice back-to-back during `install`.

## Fix

Added a `print_warnings` flag to `SyncCmdOpts`. `cmd_install` passes `false` since it already printed the warnings from its own parse; the standalone `sync` command still passes `true` so it keeps behaving as before.

## Test plan

- Added a functional test (`install_prints_manifest_warning_once` in `tests/cli.rs`) that builds a manifest with a duplicate entry name and asserts the warning line appears exactly once in `install` stderr.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build -p skillfile`, and `cargo test --workspace` all pass locally.