### PR TITLE
fix: preserve entries when Skillfile has no trailing newline

### DIFF
--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -983,14 +983,18 @@ mod tests {
 
         append_and_format_entry(&entry, &dir.path().join(MANIFEST_NAME)).unwrap();
 
-        let parsed = parse_manifest(&dir.path().join(MANIFEST_NAME)).unwrap();
-        let paths: Vec<&str> = parsed
-            .manifest
-            .entries
-            .iter()
-            .filter_map(|entry| entry.source.as_local())
+        let updated = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
+        let entries: Vec<&str> = updated
+            .lines()
+            .filter(|line| line.starts_with("local  skill  "))
             .collect();
-        assert_eq!(paths, ["skills/existing.md", "skills/new.md"]);
+        assert_eq!(
+            entries,
+            [
+                "local  skill  skills/existing.md",
+                "local  skill  skills/new.md"
+            ]
+        );
     }
 
     #[test]

--- a/crates/cli/src/commands/add.rs
+++ b/crates/cli/src/commands/add.rs
@@ -398,6 +398,9 @@ fn append_and_format_entry(entry: &Entry, manifest_path: &Path) -> Result<String
     let line = format_line(entry);
     let original = std::fs::read_to_string(manifest_path)?;
     let mut content = original.clone();
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
     content.push_str(&line);
     content.push('\n');
     std::fs::write(manifest_path, &content)?;
@@ -969,6 +972,25 @@ mod tests {
         let updated = std::fs::read_to_string(dir.path().join(MANIFEST_NAME)).unwrap();
         assert!(updated.contains("skills/new.md"));
         assert!(updated.contains("skills/existing.md"));
+    }
+
+    #[test]
+    fn append_and_format_entry_preserves_entry_without_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let initial = "local  skill  skills/existing.md";
+        write_manifest(dir.path(), initial);
+        let entry = entry_from_local("skill", "skills/new.md", None);
+
+        append_and_format_entry(&entry, &dir.path().join(MANIFEST_NAME)).unwrap();
+
+        let parsed = parse_manifest(&dir.path().join(MANIFEST_NAME)).unwrap();
+        let paths: Vec<&str> = parsed
+            .manifest
+            .entries
+            .iter()
+            .filter_map(|entry| entry.source.as_local())
+            .collect();
+        assert_eq!(paths, ["skills/existing.md", "skills/new.md"]);
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -526,6 +526,41 @@ fn add_keeps_spaced_local_path_valid() {
 }
 
 #[test]
+fn add_preserves_manifest_entry_without_trailing_newline() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("skills")).unwrap();
+    std::fs::write(dir.path().join("skills/existing.md"), "# Existing\n").unwrap();
+    std::fs::write(dir.path().join("skills/new.md"), "# New\n").unwrap();
+    std::fs::write(
+        dir.path().join("Skillfile"),
+        "local  skill  skills/existing.md",
+    )
+    .unwrap();
+
+    sf(dir.path())
+        .env(
+            "SKILLFILE_CONFIG_PATH",
+            dir.path().join("missing-config.toml"),
+        )
+        .args(["add", "local", "skill", "skills/new.md"])
+        .assert()
+        .success();
+    sf(dir.path()).arg("validate").assert().success();
+
+    let text = std::fs::read_to_string(dir.path().join("Skillfile")).unwrap();
+    assert!(
+        text.lines()
+            .any(|line| line == "local  skill  skills/existing.md"),
+        "existing entry was not preserved:\n{text}"
+    );
+    assert!(
+        text.lines()
+            .any(|line| line == "local  skill  skills/new.md"),
+        "new entry was not added:\n{text}"
+    );
+}
+
+#[test]
 fn add_then_remove() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(dir.path().join("skills")).unwrap();


### PR DESCRIPTION
## Summary

- insert a newline separator before appending to a non-empty Skillfile that has no trailing newline
- preserve the existing last entry and the newly added entry through parsing and formatting
- cover the no-trailing-newline case at both the helper and CLI levels

## Root cause

The add command appended the new entry directly to the existing bytes. When the file did not end in a newline, the old last entry and the new entry became one malformed line before the formatter reparsed the manifest.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build -p skillfile
- git diff --check

Fixes #206