### PR TITLE
fix: fail search when all registries fail

### DIFF
--- a/crates/sources/src/registry/agentskill.rs
+++ b/crates/sources/src/registry/agentskill.rs
@@ -100,9 +100,7 @@ impl Registry for AgentskillSh {
         let (client, query) = (q.client, q.query);
         let url = format!("{AGENTSKILL_API}?q={}&limit=100", urlencoded(query));
 
-        let bytes = client
-            .get_bytes(&url)
-            .map_err(|e| SkillfileError::Network(format!("agentskill.sh search failed: {e}")))?;
+        let bytes = client.get_bytes(&url)?;
 
         let body = String::from_utf8(bytes).map_err(|e| {
             SkillfileError::Network(format!("invalid UTF-8 in agentskill.sh response: {e}"))
@@ -376,7 +374,7 @@ mod tests {
         let result = super::super::search_with_client(&client, "test", &SearchOptions::default());
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("search failed"), "got: {err}");
+        assert_eq!(err, "connection refused");
     }
 
     #[test]

--- a/crates/sources/src/registry/mod.rs
+++ b/crates/sources/src/registry/mod.rs
@@ -176,9 +176,9 @@ pub const REGISTRY_NAMES: &[&str] = &["agentskill.sh", "skills.sh", "skillhub.cl
 // Public search functions
 // ===========================================================================
 
-/// Iterates over all registries, collecting results (skipping registries that
-/// fail with a warning), applies `min_score` filter, and returns combined
-/// results.
+/// Iterates over all registries, collecting results, applies `min_score`
+/// filtering, and returns the combined results. Individual registry failures
+/// are skipped with a warning, but the search fails if no registry responds.
 pub fn search_all(query: &str, opts: &SearchOptions) -> Result<SearchResponse, SkillfileError> {
     let client = UreqClient::new();
     search_all_with_client(&client, query, opts)
@@ -193,6 +193,7 @@ pub fn search_all_with_client(
     let registries = all_registries();
     let mut all_items = Vec::new();
     let mut total = 0;
+    let mut failures = 0;
 
     for reg in &registries {
         match reg.search(&SearchQuery {
@@ -205,9 +206,16 @@ pub fn search_all_with_client(
                 all_items.extend(resp.items);
             }
             Err(e) => {
+                failures += 1;
                 eprintln!("warning: {} search failed: {e}", reg.name());
             }
         }
+    }
+
+    if failures == registries.len() {
+        return Err(SkillfileError::Network(
+            "all registry searches failed".to_string(),
+        ));
     }
 
     let mut resp = SearchResponse {
@@ -428,6 +436,23 @@ mod tests {
         let resp = search_all_with_client(&client, "test", &SearchOptions::default()).unwrap();
         assert_eq!(resp.items.len(), 2);
         assert_eq!(resp.items[0].registry, RegistryId::SkillsSh);
+    }
+
+    #[test]
+    fn search_all_fails_when_every_registry_fails() {
+        let _guard = SKILLHUB_ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("SKILLHUB_API_KEY") };
+        let client = MockClient::new(vec![
+            Err("agentskill unavailable".to_string()),
+            Err("skills unavailable".to_string()),
+        ]);
+
+        let result = search_all_with_client(&client, "test", &SearchOptions::default());
+
+        assert!(matches!(
+            result,
+            Err(SkillfileError::Network(message)) if message == "all registry searches failed"
+        ));
     }
 
     #[test]

--- a/crates/sources/src/registry/skillhub.rs
+++ b/crates/sources/src/registry/skillhub.rs
@@ -51,13 +51,11 @@ impl Registry for SkillhubClub {
         })
         .to_string();
 
-        let bytes = client
-            .post_json_with_bearer(&crate::http::BearerPost {
-                url: SKILLHUB_API,
-                body: &body,
-                token: &api_key,
-            })
-            .map_err(|e| SkillfileError::Network(format!("skillhub.club search failed: {e}")))?;
+        let bytes = client.post_json_with_bearer(&crate::http::BearerPost {
+            url: SKILLHUB_API,
+            body: &body,
+            token: &api_key,
+        })?;
 
         let resp_body = String::from_utf8(bytes).map_err(|e| {
             SkillfileError::Network(format!("invalid UTF-8 in skillhub.club response: {e}"))

--- a/crates/sources/src/registry/skillssh.rs
+++ b/crates/sources/src/registry/skillssh.rs
@@ -159,9 +159,7 @@ impl Registry for SkillsSh {
         let (client, query) = (q.client, q.query);
         let url = format!("{SKILLSSH_API}?q={}", urlencoded(query));
 
-        let bytes = client
-            .get_bytes(&url)
-            .map_err(|e| SkillfileError::Network(format!("skills.sh search failed: {e}")))?;
+        let bytes = client.get_bytes(&url)?;
 
         let body = String::from_utf8(bytes).map_err(|e| {
             SkillfileError::Network(format!("invalid UTF-8 in skills.sh response: {e}"))
@@ -274,6 +272,20 @@ mod tests {
             .unwrap();
         assert_eq!(resp.items.len(), 0);
         assert_eq!(resp.total, 0);
+    }
+
+    #[test]
+    fn search_returns_unprefixed_network_error() {
+        let client = MockClient::new(vec![Err("connection refused".to_string())]);
+        let reg = SkillsSh;
+
+        let result = reg.search(&SearchQuery {
+            client: &client,
+            query: "docker",
+            opts: &SearchOptions::default(),
+        });
+
+        assert_eq!(result.unwrap_err().to_string(), "connection refused");
     }
 
     // -- fetch_skill_content tests (GitHub raw fetch with fallback) -------------


### PR DESCRIPTION
## Summary

- Return a network error when every queried registry fails.
- Preserve partial results when at least one registry responds.
- Remove the duplicate registry-level error prefix from warnings.
- Add regression coverage for aggregate and adapter errors.

Closes #201

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p skillfile-sources` (340 tests and 1 doc test passed)
- `cargo clippy -p skillfile-sources --all-targets -- -D warnings`